### PR TITLE
chore: bump terok-sandbox dependency to v0.0.5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1630,32 +1630,32 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.3"
+version = "0.0.5"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.3-py3-none-any.whl", hash = "sha256:75331076c292857c858601c668148ce2fdffd2c341d0ebb07d787c4137558b04"},
+    {file = "terok_sandbox-0.0.5-py3-none-any.whl", hash = "sha256:1f70bf88938c107b868f401a8102e57ee9d72f413cfdb111a5d014dd59577ecc"},
 ]
 
 [package.dependencies]
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.0/terok_shield-0.4.0-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.3/terok_sandbox-0.0.3-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.5/terok_sandbox-0.0.5-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.4.0"
+version = "0.4.1"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.4.0-py3-none-any.whl", hash = "sha256:6e83acff2dd737428db639eaca2e85b252b719a382dd1a5453f33ea144abebee"},
+    {file = "terok_shield-0.4.1-py3-none-any.whl", hash = "sha256:6257cb0e619d3965998dac68e4413580c5c2de5f2136a1f319374c2589fec9c7"},
 ]
 
 [package.dependencies]
@@ -1663,7 +1663,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.0/terok_shield-0.4.0-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -1874,4 +1874,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "e95a995aa3b9a24261172946536d2115303e5ecf0eb6b4a9e50a9982f54498fe"
+content-hash = "e0e33d2d78a75d4984db2385cd2ef5ac364284dbcd8c037365ed9559dd7dfc0d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.3/terok_sandbox-0.0.3-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.5/terok_sandbox-0.0.5-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary

- Bump terok-sandbox from v0.0.3 to v0.0.5 to align with terok's pin
- Prevents version conflict when terok depends on both terok-agent and terok-sandbox

## Test plan

- [x] `make check` passes all targets (72 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `terok-sandbox` dependency to v0.0.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->