### PR TITLE
refactor: expand public API to re-export all consumer-facing symbols

### DIFF
--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -9,11 +9,47 @@ lifecycle of one AI coding agent at a time.  Designed for standalone use
 
 Public API re-exports from instrumentation modules::
 
-    from terok_agent import HEADLESS_PROVIDERS, get_provider
-    from terok_agent import AgentConfigSpec, prepare_agent_config_dir
-    from terok_agent import authenticate, AUTH_PROVIDERS
+    # Provider registry & types
+    from terok_agent import (
+        HEADLESS_PROVIDERS,
+        PROVIDER_NAMES,
+        HeadlessProvider,
+        get_provider,
+        CLIOverrides,
+        ProviderConfig,
+        WrapperConfig,
+        OpenCodeProviderConfig,
+        apply_provider_config,
+        build_headless_command,
+        collect_opencode_provider_env,
+        collect_all_auto_approve_env,
+    )
+
+    # Agent config preparation
+    from terok_agent import (
+        AgentConfigSpec,
+        prepare_agent_config_dir,
+        parse_md_agent,
+    )
+
+    # Auth
+    from terok_agent import AUTH_PROVIDERS, AuthProvider, authenticate
+
+    # Instructions
     from terok_agent import resolve_instructions, bundled_default_instructions
-    from terok_agent import ConfigStack, ConfigScope, resolve_provider_value
+
+    # Config stack & resolution
+    from terok_agent import (
+        ConfigStack,
+        ConfigScope,
+        resolve_provider_value,
+        deep_merge,
+        load_yaml_scope,
+        load_json_scope,
+    )
+
+    # Podman utilities
+    from terok_agent import podman_userns_args
 """
 
 __version__: str = "0.0.0"  # placeholder; replaced at build time
@@ -25,30 +61,73 @@ try:
 except PackageNotFoundError:
     pass  # editable install or running from source without metadata
 
+# -- Podman utilities ----------------------------------------------------------
+from ._util import podman_userns_args
+
+# -- Config resolution ---------------------------------------------------------
 from .agent_config import resolve_provider_value
-from .agents import AgentConfigSpec, prepare_agent_config_dir
-from .auth import AUTH_PROVIDERS, authenticate
-from .config_stack import ConfigScope, ConfigStack
-from .headless_providers import HEADLESS_PROVIDERS, HeadlessProvider, get_provider
+
+# -- Agent config preparation --------------------------------------------------
+from .agents import AgentConfigSpec, parse_md_agent, prepare_agent_config_dir
+
+# -- Auth ----------------------------------------------------------------------
+from .auth import AUTH_PROVIDERS, AuthProvider, authenticate
+
+# -- Config stack --------------------------------------------------------------
+from .config_stack import ConfigScope, ConfigStack, deep_merge, load_json_scope, load_yaml_scope
+
+# -- Provider registry & types ------------------------------------------------
+from .headless_providers import (
+    HEADLESS_PROVIDERS,
+    PROVIDER_NAMES,
+    CLIOverrides,
+    HeadlessProvider,
+    OpenCodeProviderConfig,
+    ProviderConfig,
+    WrapperConfig,
+    apply_provider_config,
+    build_headless_command,
+    collect_all_auto_approve_env,
+    collect_opencode_provider_env,
+    get_provider,
+)
+
+# -- Instructions --------------------------------------------------------------
 from .instructions import bundled_default_instructions, resolve_instructions
 
 __all__ = [
     "__version__",
-    # Provider registry
+    # Provider registry & types
     "HEADLESS_PROVIDERS",
+    "PROVIDER_NAMES",
     "HeadlessProvider",
+    "OpenCodeProviderConfig",
     "get_provider",
+    "CLIOverrides",
+    "ProviderConfig",
+    "WrapperConfig",
+    "apply_provider_config",
+    "build_headless_command",
+    "collect_opencode_provider_env",
+    "collect_all_auto_approve_env",
     # Agent config preparation
     "AgentConfigSpec",
     "prepare_agent_config_dir",
+    "parse_md_agent",
     # Auth
     "AUTH_PROVIDERS",
+    "AuthProvider",
     "authenticate",
     # Instructions
     "bundled_default_instructions",
     "resolve_instructions",
-    # Config stack
+    # Config stack & resolution
     "ConfigScope",
     "ConfigStack",
     "resolve_provider_value",
+    "deep_merge",
+    "load_yaml_scope",
+    "load_json_scope",
+    # Podman utilities
+    "podman_userns_args",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -83,6 +83,7 @@ depends_on = []
 [[modules]]
 path = "terok_agent"
 depends_on = [
+    "terok_agent._util",
     "terok_agent.agent_config",
     "terok_agent.agents",
     "terok_agent.auth",


### PR DESCRIPTION
## Summary

- Expand `__init__.py` from 12 to ~30 re-exports, covering every symbol that terok imports from agent submodules
- Promotes `podman_userns_args` from private `_util` to public API
- Enables consumers to use `from terok_agent import X` instead of `from terok_agent.headless_providers import X`

## New exports (previously submodule-only)

| Source module | New exports |
|--------------|-------------|
| `headless_providers` | `CLIOverrides`, `OpenCodeProviderConfig`, `PROVIDER_NAMES`, `ProviderConfig`, `WrapperConfig`, `apply_provider_config`, `build_headless_command`, `collect_all_auto_approve_env`, `collect_opencode_provider_env` |
| `agents` | `parse_md_agent` |
| `auth` | `AuthProvider` |
| `config_stack` | `deep_merge`, `load_json_scope`, `load_yaml_scope` |
| `_util` | `podman_userns_args` |

## Test plan

- [x] `make check` — all targets pass (72 tests, tach validated, REUSE compliant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the library's public API to provide direct access to additional provider configuration types, configuration utilities, and helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->