### PR TITLE
refactor: trim public API, add agent internals tests

### DIFF
--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -7,30 +7,16 @@ Builds agent images, launches instrumented containers, and manages the
 lifecycle of one AI coding agent at a time.  Designed for standalone use
 (``terok-agent run claude .``) and as a library for terok orchestration.
 
-Public API re-exports from instrumentation modules::
+Public API::
 
-    # Provider registry & types
-    from terok_agent import (
-        HEADLESS_PROVIDERS,
-        PROVIDER_NAMES,
-        HeadlessProvider,
-        get_provider,
-        CLIOverrides,
-        ProviderConfig,
-        WrapperConfig,
-        OpenCodeProviderConfig,
-        apply_provider_config,
-        build_headless_command,
-        collect_opencode_provider_env,
-        collect_all_auto_approve_env,
-    )
+    # Provider registry
+    from terok_agent import HEADLESS_PROVIDERS, HeadlessProvider, get_provider
+    from terok_agent import PROVIDER_NAMES, CLIOverrides
+    from terok_agent import apply_provider_config, build_headless_command
+    from terok_agent import collect_opencode_provider_env, collect_all_auto_approve_env
 
     # Agent config preparation
-    from terok_agent import (
-        AgentConfigSpec,
-        prepare_agent_config_dir,
-        parse_md_agent,
-    )
+    from terok_agent import AgentConfigSpec, prepare_agent_config_dir, parse_md_agent
 
     # Auth
     from terok_agent import AUTH_PROVIDERS, AuthProvider, authenticate
@@ -38,18 +24,16 @@ Public API re-exports from instrumentation modules::
     # Instructions
     from terok_agent import resolve_instructions, bundled_default_instructions
 
-    # Config stack & resolution
-    from terok_agent import (
-        ConfigStack,
-        ConfigScope,
-        resolve_provider_value,
-        deep_merge,
-        load_yaml_scope,
-        load_json_scope,
-    )
+    # Config stack
+    from terok_agent import ConfigStack, ConfigScope, resolve_provider_value
 
-    # Podman utilities
-    from terok_agent import podman_userns_args
+Internal symbols (available via submodule import for white-box tests)::
+
+    from terok_agent.headless_providers import generate_agent_wrapper, generate_all_wrappers
+    from terok_agent.headless_providers import OpenCodeProviderConfig, ProviderConfig, WrapperConfig
+    from terok_agent.config_stack import deep_merge, load_yaml_scope, load_json_scope
+    from terok_agent.instructions import has_custom_instructions
+    from terok_agent._util import podman_userns_args
 """
 
 __version__: str = "0.0.0"  # placeholder; replaced at build time
@@ -61,9 +45,6 @@ try:
 except PackageNotFoundError:
     pass  # editable install or running from source without metadata
 
-# -- Podman utilities ----------------------------------------------------------
-from ._util import podman_userns_args
-
 # -- Config resolution ---------------------------------------------------------
 from .agent_config import resolve_provider_value
 
@@ -74,17 +55,14 @@ from .agents import AgentConfigSpec, parse_md_agent, prepare_agent_config_dir
 from .auth import AUTH_PROVIDERS, AuthProvider, authenticate
 
 # -- Config stack --------------------------------------------------------------
-from .config_stack import ConfigScope, ConfigStack, deep_merge, load_json_scope, load_yaml_scope
+from .config_stack import ConfigScope, ConfigStack
 
-# -- Provider registry & types ------------------------------------------------
+# -- Provider registry ---------------------------------------------------------
 from .headless_providers import (
     HEADLESS_PROVIDERS,
     PROVIDER_NAMES,
     CLIOverrides,
     HeadlessProvider,
-    OpenCodeProviderConfig,
-    ProviderConfig,
-    WrapperConfig,
     apply_provider_config,
     build_headless_command,
     collect_all_auto_approve_env,
@@ -97,15 +75,12 @@ from .instructions import bundled_default_instructions, resolve_instructions
 
 __all__ = [
     "__version__",
-    # Provider registry & types
+    # Provider registry
     "HEADLESS_PROVIDERS",
     "PROVIDER_NAMES",
     "HeadlessProvider",
-    "OpenCodeProviderConfig",
     "get_provider",
     "CLIOverrides",
-    "ProviderConfig",
-    "WrapperConfig",
     "apply_provider_config",
     "build_headless_command",
     "collect_opencode_provider_env",
@@ -121,13 +96,8 @@ __all__ = [
     # Instructions
     "bundled_default_instructions",
     "resolve_instructions",
-    # Config stack & resolution
+    # Config stack
     "ConfigScope",
     "ConfigStack",
     "resolve_provider_value",
-    "deep_merge",
-    "load_yaml_scope",
-    "load_json_scope",
-    # Podman utilities
-    "podman_userns_args",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -83,7 +83,6 @@ depends_on = []
 [[modules]]
 path = "terok_agent"
 depends_on = [
-    "terok_agent._util",
     "terok_agent.agent_config",
     "terok_agent.agents",
     "terok_agent.auth",

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -45,5 +45,11 @@ CONTAINER_TEROK_DIR = CONTAINER_HOME / ".terok"
 CONTAINER_INSTRUCTIONS_PATH = CONTAINER_TEROK_DIR / "instructions.md"
 """Container instructions file path injected into agent configs."""
 
+CONTAINER_CLAUDE_SESSION_PATH = CONTAINER_TEROK_DIR / "claude-session.txt"
+"""Container Claude session file path used by session-hook assertions."""
+
+CONTAINER_CLAUDE_MEMORY_OVERRIDE = "/home/dev/.claude/projects/${PROJECT_ID}-workspace/memory"
+"""Literal shell path used in generated Claude wrapper memory override assertions."""
+
 WORKSPACE_ROOT = Path("/workspace")
 """Canonical workspace root referenced in bundled instructions assertions."""

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for agent configuration: parsing, filtering, wrapper generation, and config dir."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest.mock
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from terok_agent.agents import (
+    AgentConfigSpec,
+    _generate_claude_wrapper,
+    _inject_opencode_instructions,
+    _subagents_to_json,
+    _write_session_hook,
+    parse_md_agent,
+    prepare_agent_config_dir,
+)
+from terok_agent.headless_providers import WrapperConfig
+from tests.constants import (
+    CONTAINER_CLAUDE_MEMORY_OVERRIDE,
+    CONTAINER_CLAUDE_SESSION_PATH,
+    CONTAINER_INSTRUCTIONS_PATH,
+    NONEXISTENT_AGENT_PATH,
+    NONEXISTENT_FILE_PATH,
+)
+
+
+class TestSubagentsToJson:
+    """Tests for _subagents_to_json (dict output keyed by agent name)."""
+
+    def test_inline_definition_default_true(self) -> None:
+        """Inline sub-agent with default=True is included, output is dict keyed by name."""
+        subagents = [
+            {
+                "name": "reviewer",
+                "description": "Code reviewer",
+                "tools": ["Read", "Grep"],
+                "model": "sonnet",
+                "default": True,
+                "system_prompt": "You are a code reviewer.",
+            }
+        ]
+        result = json.loads(_subagents_to_json(subagents))
+        assert isinstance(result, dict)
+        assert "reviewer" in result
+        assert result["reviewer"]["prompt"] == "You are a code reviewer."
+        assert result["reviewer"]["description"] == "Code reviewer"
+        assert "system_prompt" not in result["reviewer"]
+        assert "name" not in result["reviewer"]
+        assert "default" not in result["reviewer"]
+
+    def test_default_false_excluded_without_selection(self) -> None:
+        """Agents with default=False are excluded when not selected."""
+        subagents = [
+            {"name": "debugger", "default": False, "model": "sonnet", "system_prompt": "Debug."},
+        ]
+        assert json.loads(_subagents_to_json(subagents)) == {}
+
+    def test_selected_agents_included(self) -> None:
+        """Non-default agents are included when passed in selected_agents."""
+        subagents = [
+            {"name": "debugger", "default": False, "model": "sonnet", "system_prompt": "Debug."},
+        ]
+        result = json.loads(_subagents_to_json(subagents, selected_agents=["debugger"]))
+        assert "debugger" in result
+
+    def test_mixed_default_and_selected(self) -> None:
+        """Default agents + selected non-default agents are both included."""
+        subagents = [
+            {"name": "reviewer", "default": True, "model": "sonnet", "system_prompt": "Review."},
+            {"name": "debugger", "default": False, "model": "opus", "system_prompt": "Debug."},
+            {"name": "planner", "default": False, "model": "haiku", "system_prompt": "Plan."},
+        ]
+        result = json.loads(_subagents_to_json(subagents, selected_agents=["debugger"]))
+        assert "reviewer" in result
+        assert "debugger" in result
+        assert "planner" not in result
+
+    def test_file_reference_with_default(self) -> None:
+        """File references with default flag are handled correctly."""
+        with tempfile.TemporaryDirectory() as td:
+            md_file = Path(td) / "reviewer.md"
+            md_file.write_text(
+                "---\nname: reviewer\ndescription: Code reviewer\n"
+                "tools: [Read, Grep]\nmodel: sonnet\n---\n"
+                "You are a code reviewer.\n",
+                encoding="utf-8",
+            )
+            subagents = [{"file": str(md_file), "default": True}]
+            result = json.loads(_subagents_to_json(subagents))
+            assert "reviewer" in result
+
+    def test_missing_file_skipped(self) -> None:
+        """Missing file references are skipped."""
+        subagents = [{"file": str(NONEXISTENT_AGENT_PATH), "default": True}]
+        assert json.loads(_subagents_to_json(subagents)) == {}
+
+    def test_agent_without_name_skipped(self) -> None:
+        """Agents without a name are skipped."""
+        subagents = [{"default": True, "model": "sonnet", "system_prompt": "No name."}]
+        assert json.loads(_subagents_to_json(subagents)) == {}
+
+
+class TestParseMdAgent:
+    """Tests for parse_md_agent."""
+
+    def test_parse_with_frontmatter(self) -> None:
+        """Parses YAML frontmatter + body from .md file."""
+        with tempfile.TemporaryDirectory() as td:
+            md = Path(td) / "test.md"
+            md.write_text("---\nname: test\ntools: [Read]\n---\nPrompt body.", encoding="utf-8")
+            result = parse_md_agent(str(md))
+            assert result["name"] == "test"
+            assert result["prompt"] == "Prompt body."
+
+    def test_parse_without_frontmatter(self) -> None:
+        """File without frontmatter is treated as raw prompt."""
+        with tempfile.TemporaryDirectory() as td:
+            md = Path(td) / "test.md"
+            md.write_text("Just a prompt.", encoding="utf-8")
+            result = parse_md_agent(str(md))
+            assert result["prompt"] == "Just a prompt."
+
+    def test_nonexistent_file(self) -> None:
+        """Nonexistent file returns empty dict."""
+        assert parse_md_agent(str(NONEXISTENT_FILE_PATH)) == {}
+
+
+class TestGenerateClaudeWrapper:
+    """Tests for _generate_claude_wrapper."""
+
+    def test_basic_wrapper(self) -> None:
+        """Wrapper includes add-dir / and git env vars."""
+        wrapper = _generate_claude_wrapper(WrapperConfig(has_agents=False))
+        assert "claude()" in wrapper
+        assert '--add-dir "/"' in wrapper
+        assert "_terok_apply_git_identity Claude noreply@anthropic.com" in wrapper
+        assert "agents.json" not in wrapper
+
+    def test_wrapper_with_agents(self) -> None:
+        """Wrapper includes agents.json reference when has_agents=True."""
+        assert "agents.json" in _generate_claude_wrapper(WrapperConfig(has_agents=True))
+
+    def test_wrapper_includes_append_system_prompt(self) -> None:
+        """Wrapper includes --append-system-prompt when has_instructions=True."""
+        wrapper = _generate_claude_wrapper(WrapperConfig(has_agents=False, has_instructions=True))
+        assert "--append-system-prompt" in wrapper
+
+    def test_wrapper_timeout_support(self) -> None:
+        """Wrapper parses --terok-timeout and wraps claude with timeout."""
+        wrapper = _generate_claude_wrapper(WrapperConfig(has_agents=False))
+        assert "--terok-timeout" in wrapper
+        assert 'timeout "$_timeout" claude' in wrapper
+        assert 'command claude "${_args[@]}" "$@"' in wrapper
+
+    def test_wrapper_resume_from_session_file(self) -> None:
+        """Wrapper adds --resume from claude-session.txt when it exists."""
+        wrapper = _generate_claude_wrapper(WrapperConfig(has_agents=False))
+        assert "claude-session.txt" in wrapper
+        assert "--resume" in wrapper
+
+    def test_wrapper_sets_memory_override(self) -> None:
+        """Wrapper exports CLAUDE_COWORK_MEMORY_PATH_OVERRIDE."""
+        wrapper = _generate_claude_wrapper(WrapperConfig(has_agents=False))
+        assert f'"{CONTAINER_CLAUDE_MEMORY_OVERRIDE}"' in wrapper
+
+
+class TestWriteSessionHook:
+    """Tests for _write_session_hook."""
+
+    def test_creates_settings_with_hook(self) -> None:
+        """Creates settings.json with a SessionStart hook."""
+        with tempfile.TemporaryDirectory() as td:
+            settings_path = Path(td) / "settings.json"
+            _write_session_hook(settings_path)
+            data = json.loads(settings_path.read_text())
+            assert "SessionStart" in data["hooks"]
+            command = data["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+            assert "session_id" in command
+
+    def test_merges_with_existing_settings(self) -> None:
+        """Merges hook into existing settings.json without clobbering."""
+        with tempfile.TemporaryDirectory() as td:
+            settings_path = Path(td) / "settings.json"
+            settings_path.write_text('{"permissions": {"allow": ["Read"]}}', encoding="utf-8")
+            _write_session_hook(settings_path)
+            data = json.loads(settings_path.read_text())
+            assert data["permissions"] == {"allow": ["Read"]}
+            assert "SessionStart" in data["hooks"]
+
+    def test_idempotent_hook_write(self) -> None:
+        """Calling twice doesn't create duplicate hooks."""
+        with tempfile.TemporaryDirectory() as td:
+            settings_path = Path(td) / "settings.json"
+            _write_session_hook(settings_path)
+            _write_session_hook(settings_path)
+            data = json.loads(settings_path.read_text())
+            assert len(data["hooks"]["SessionStart"]) == 1
+
+    def test_does_not_rewrite_when_hook_present(self) -> None:
+        """If equivalent hook exists, file is left untouched."""
+        with tempfile.TemporaryDirectory() as td:
+            settings_path = Path(td) / "settings.json"
+            hook_command = (
+                "python3 -c \"import json,sys; print(json.load(sys.stdin)['session_id'])\""
+                f" > {CONTAINER_CLAUDE_SESSION_PATH}"
+            )
+            original = json.dumps(
+                {
+                    "hooks": {
+                        "SessionStart": [{"hooks": [{"type": "command", "command": hook_command}]}]
+                    }
+                },
+                separators=(",", ":"),
+            )
+            settings_path.write_text(original, encoding="utf-8")
+            _write_session_hook(settings_path)
+            assert settings_path.read_text(encoding="utf-8") == original
+
+    def test_concurrent_writes_keep_single_hook(self) -> None:
+        """Concurrent writes produce a single valid SessionStart entry."""
+        with tempfile.TemporaryDirectory() as td:
+            settings_path = Path(td) / "settings.json"
+            with ThreadPoolExecutor(max_workers=8) as pool:
+                futures = [pool.submit(_write_session_hook, settings_path) for _ in range(48)]
+                for f in futures:
+                    f.result()
+            data = json.loads(settings_path.read_text())
+            assert len(data["hooks"]["SessionStart"]) == 1
+
+
+class TestPrepareAgentConfigDir:
+    """Tests for prepare_agent_config_dir."""
+
+    @staticmethod
+    def _make_spec(tasks_root: Path, task_id: str, **kwargs: object) -> AgentConfigSpec:
+        """Build a minimal AgentConfigSpec for testing."""
+        return AgentConfigSpec(
+            tasks_root=tasks_root,
+            task_id=task_id,
+            subagents=[],
+            default_agent=None,
+            envs_base_dir=kwargs.pop("envs_base_dir", None),
+            instructions=kwargs.pop("instructions", None),
+            **kwargs,
+        )
+
+    @unittest.mock.patch("terok_agent.agents._write_session_hook")
+    def test_writes_instructions(self, _mock: object, tmp_path: Path) -> None:
+        """Instructions text is written to instructions.md."""
+        with tempfile.TemporaryDirectory() as envs:
+            spec = self._make_spec(
+                tmp_path / "tasks", "t1", instructions="Custom.", envs_base_dir=Path(envs)
+            )
+            (tmp_path / "tasks" / "t1").mkdir(parents=True)
+            d = prepare_agent_config_dir(spec)
+            assert (d / "instructions.md").read_text(encoding="utf-8") == "Custom."
+
+    @unittest.mock.patch("terok_agent.agents._write_session_hook")
+    def test_default_instructions_when_none(self, _mock: object, tmp_path: Path) -> None:
+        """Default instructions.md written when instructions is None."""
+        with tempfile.TemporaryDirectory() as envs:
+            spec = self._make_spec(tmp_path / "tasks", "t2", envs_base_dir=Path(envs))
+            (tmp_path / "tasks" / "t2").mkdir(parents=True)
+            d = prepare_agent_config_dir(spec)
+            assert "conventions" in (d / "instructions.md").read_text(encoding="utf-8")
+
+    @unittest.mock.patch("terok_agent.agents._write_session_hook")
+    def test_wrapper_has_append_system_prompt(self, _mock: object, tmp_path: Path) -> None:
+        """Claude wrapper includes --append-system-prompt when instructions given."""
+        with tempfile.TemporaryDirectory() as envs:
+            spec = self._make_spec(
+                tmp_path / "tasks", "t3", instructions="Test.", envs_base_dir=Path(envs)
+            )
+            (tmp_path / "tasks" / "t3").mkdir(parents=True)
+            d = prepare_agent_config_dir(spec)
+            wrapper = (d / "terok-agent.sh").read_text(encoding="utf-8")
+            assert "--append-system-prompt" in wrapper
+
+
+class TestInjectOpencodeInstructions:
+    """Tests for _inject_opencode_instructions()."""
+
+    def test_creates_file_if_missing(self) -> None:
+        """Creates opencode.json with instructions entry and $schema."""
+        with tempfile.TemporaryDirectory() as td:
+            config_path = Path(td) / "opencode.json"
+            _inject_opencode_instructions(config_path)
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            assert data["instructions"] == [str(CONTAINER_INSTRUCTIONS_PATH)]
+            assert data["$schema"] == "https://opencode.ai/config.json"
+
+    def test_idempotent_when_already_present(self) -> None:
+        """Does not duplicate the instructions entry on repeated calls."""
+        with tempfile.TemporaryDirectory() as td:
+            config_path = Path(td) / "opencode.json"
+            _inject_opencode_instructions(config_path)
+            _inject_opencode_instructions(config_path)
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            assert data["instructions"] == [str(CONTAINER_INSTRUCTIONS_PATH)]
+
+    def test_preserves_existing_instructions(self) -> None:
+        """Appends to existing instructions list."""
+        with tempfile.TemporaryDirectory() as td:
+            config_path = Path(td) / "opencode.json"
+            config_path.write_text(
+                json.dumps({"instructions": ["/some/other/file.md"]}), encoding="utf-8"
+            )
+            _inject_opencode_instructions(config_path)
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            assert len(data["instructions"]) == 2
+
+    def test_preserves_existing_config_keys(self) -> None:
+        """Preserves other keys in the opencode.json file."""
+        with tempfile.TemporaryDirectory() as td:
+            config_path = Path(td) / "opencode.json"
+            config_path.write_text(json.dumps({"model": "test/model"}), encoding="utf-8")
+            _inject_opencode_instructions(config_path)
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            assert data["model"] == "test/model"
+
+    def test_creates_parent_directories(self) -> None:
+        """Creates parent directories if they do not exist."""
+        with tempfile.TemporaryDirectory() as td:
+            config_path = Path(td) / "nested" / "dir" / "opencode.json"
+            _inject_opencode_instructions(config_path)
+            assert config_path.is_file()
+
+    def test_handles_invalid_json(self) -> None:
+        """Overwrites file with valid config if existing JSON is invalid."""
+        with tempfile.TemporaryDirectory() as td:
+            config_path = Path(td) / "opencode.json"
+            config_path.write_text("not valid json", encoding="utf-8")
+            _inject_opencode_instructions(config_path)
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            assert data["instructions"] == [str(CONTAINER_INSTRUCTIONS_PATH)]


### PR DESCRIPTION
## Summary

- Trim `__init__.py` from 28 to 21 exports — remove 7 internal-only symbols
- Add 30 tests moved from terok's test suite (these test terok-agent internals)

## Removed from public API

| Symbol | Reason |
|--------|--------|
| `OpenCodeProviderConfig` | Type used only internally |
| `ProviderConfig` | Type used only internally |
| `WrapperConfig` | Type used only internally |
| `deep_merge` | Config stack internal |
| `load_yaml_scope` | Config stack internal |
| `load_json_scope` | Config stack internal |
| `podman_userns_args` | Vendored utility |

All remain accessible via `from terok_agent.module import X` for white-box tests.

## New tests (from terok)

| Class | Tests | What |
|-------|-------|------|
| `TestSubagentsToJson` | 8 | JSON agent conversion, filtering, file refs |
| `TestParseMdAgent` | 3 | Markdown frontmatter parsing |
| `TestGenerateClaudeWrapper` | 6 | Claude shell wrapper generation |
| `TestWriteSessionHook` | 5 | Session hook idempotency, concurrency |
| `TestPrepareAgentConfigDir` | 3 | Agent config dir assembly |
| `TestInjectOpencodeInstructions` | 6 | OpenCode JSON injection |

## Verification

- [x] `make check` — 102 tests pass (up from 72), all targets green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured package public API; some previously exported utilities now require direct submodule imports.

* **Tests**
  * Added comprehensive test coverage for agent configuration management, Claude wrapper generation, session handling, and OpenCode instruction injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->