### PR TITLE
chore: remove misleading dynaconf/omegaconf comment from ConfigStack

### DIFF
--- a/src/terok_agent/config_stack.py
+++ b/src/terok_agent/config_stack.py
@@ -3,8 +3,7 @@
 
 """Generic layered config resolution.
 
-Domain-agnostic: no terok service dependencies.  Could be extracted to a
-standalone package or replaced by omegaconf / dynaconf later.
+Domain-agnostic: no terok service dependencies.
 
 Terminology
 -----------


### PR DESCRIPTION
## Summary
- Remove the docstring suggestion to replace ConfigStack with omegaconf/dynaconf
- Evaluation confirmed neither library fits: omegaconf targets ML config (Hydra), dynaconf targets 12-factor env profiles
- ConfigStack's layered scope merging with `_inherit` splicing has no equivalent in either library

## Context
After the terok-agent extraction, we evaluated Red Hat / Podman ecosystem libraries for potential adoption. ConfigStack's comment was the trigger, but the evaluation covered the full dependency chain. The only actionable code change is this comment removal — the rest are future decisions (Jinja2 for Phase 3 templates, dbus-fast for clearance daemon).

## Test plan
- [x] `make lint` passes
- [x] `make test` — all 102 tests pass
- [x] No functional change — docstring-only edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)