### PR TITLE
chore: bump to 0.0.5, pin terok-sandbox 0.0.7

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1631,23 +1631,22 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.6.post6.dev0+5d0b9b7"
+version = "0.0.7"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.7-py3-none-any.whl", hash = "sha256:e4362fdc39f4aea723a1d7768ec0f183a8982eb4864a677a0101ca3a1b5acd49"},
+]
 
 [package.dependencies]
 platformdirs = ">=4.0"
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/terok-ai/terok-sandbox.git"
-reference = "5d0b9b75787b63fdf2e0797032d0308fb8a8fe38"
-resolved_reference = "5d0b9b75787b63fdf2e0797032d0308fb8a8fe38"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.7/terok_sandbox-0.0.7-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -1876,4 +1875,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "4ac46fc101047a027a4ebac26e363dff13d16a8795ea65230dae2cda793c3c6e"
+content-hash = "15bb806618017592bd5d4024575b68b9ab4a443a7473c260563a3f499bcd5c6f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.4"
+version = "0.0.5"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {git = "https://github.com/terok-ai/terok-sandbox.git", rev = "5d0b9b75787b63fdf2e0797032d0308fb8a8fe38"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.7/terok_sandbox-0.0.7-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 


### PR DESCRIPTION
## Summary

- Bump version from 0.0.4 to 0.0.5
- Switch terok-sandbox dependency from git rev pin to v0.0.7 release wheel

Includes everything since v0.0.4:
- `_launch()` delegation to `Sandbox.run()` (#33)
- `LifecycleHooks` passthrough in all three run methods
- `GpuConfigError → BuildError` wrapping

Tag `v0.0.5` pushed to fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.0.5
  * Updated terok-sandbox dependency to version 0.0.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->