### PR TITLE
feat: add ensure_proxy_routes() for route manifest generation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2229,13 +2229,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.10"
+version = "0.0.11"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.10-py3-none-any.whl", hash = "sha256:6508b64411a7643c95a62d50ff553a223a1d6277d7134aa9c15d7ce5715b63b7"},
+    {file = "terok_sandbox-0.0.11-py3-none-any.whl", hash = "sha256:17806f4ae7ae5940104388fdebc90bb2767d42711386fc83a1744077610df102"},
 ]
 
 [package.dependencies]
@@ -2245,7 +2245,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.10/terok_sandbox-0.0.10-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.11/terok_sandbox-0.0.11-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2630,4 +2630,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "4bb374dc3420d70fadc5c4e382483b4b2ff51f1c4e4b8c2b54498dee3567f23d"
+content-hash = "d2e8ee4cb7a0ff1c94ad667491c756e120cec778766dd4ce1c884141d865fd9a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.9"
+version = "0.0.10"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.10/terok_sandbox-0.0.10-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.11/terok_sandbox-0.0.11-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 

--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -24,6 +24,9 @@ Public API::
     # Instructions
     from terok_agent import resolve_instructions, bundled_default_instructions
 
+    # Credential proxy
+    from terok_agent import ensure_proxy_routes
+
     # Config stack
     from terok_agent import ConfigStack, ConfigScope, resolve_provider_value
 
@@ -91,7 +94,7 @@ from .headless_providers import (
 
 # -- Instructions --------------------------------------------------------------
 from .instructions import bundled_default_instructions, resolve_instructions
-from .registry import CredentialProxyRoute, get_registry
+from .registry import CredentialProxyRoute, ensure_proxy_routes, get_registry
 
 # -- Runner facade -------------------------------------------------------------
 from .runner import AgentRunner
@@ -157,6 +160,7 @@ __all__ = [
     "stage_tmux_config",
     # Credential proxy
     "CredentialProxyRoute",
+    "ensure_proxy_routes",
     "extract_credential",
     # Registry
     "get_registry",

--- a/src/terok_agent/registry.py
+++ b/src/terok_agent/registry.py
@@ -512,9 +512,20 @@ def ensure_proxy_routes() -> Path:
 
     cfg = SandboxConfig()
     path = cfg.proxy_routes_path
+    import os
+    import tempfile
+
     path.parent.mkdir(parents=True, exist_ok=True)
     content = get_registry().generate_routes_json() + "\n"
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(content, encoding="utf-8")
-    tmp.replace(path)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        tmp.replace(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
     return path

--- a/src/terok_agent/registry.py
+++ b/src/terok_agent/registry.py
@@ -513,5 +513,8 @@ def ensure_proxy_routes() -> Path:
     cfg = SandboxConfig()
     path = cfg.proxy_routes_path
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(get_registry().generate_routes_json() + "\n")
+    content = get_registry().generate_routes_json() + "\n"
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.replace(path)
     return path

--- a/src/terok_agent/registry.py
+++ b/src/terok_agent/registry.py
@@ -497,3 +497,21 @@ def load_registry() -> AgentRegistry:
 def get_registry() -> AgentRegistry:
     """Return the singleton registry instance (loaded once, cached)."""
     return load_registry()
+
+
+def ensure_proxy_routes() -> Path:
+    """Generate ``routes.json`` from the YAML registry and write it to disk.
+
+    The routes file is written to the path configured in
+    :class:`~terok_sandbox.SandboxConfig` (typically
+    ``~/.local/share/terok/proxy/routes.json``).
+
+    Returns the path to the written file.
+    """
+    from terok_sandbox import SandboxConfig
+
+    cfg = SandboxConfig()
+    path = cfg.proxy_routes_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(get_registry().generate_routes_json() + "\n")
+    return path

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -100,6 +100,7 @@ class TestEnsureProxyRoutes:
 
         path = ensure_proxy_routes()
 
+        assert path == mock_cfg.proxy_routes_path
         assert path.is_file()
         routes = json.loads(path.read_text())
         # Should have at least claude route from the YAML registry

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -81,3 +81,27 @@ class TestGenerateRoutesJson:
         routes = json.loads(get_registry().generate_routes_json())
         assert "gl" in routes
         assert "glab" not in routes
+
+
+class TestEnsureProxyRoutes:
+    """Verify ensure_proxy_routes writes routes.json to disk."""
+
+    def test_writes_routes_json(self, tmp_path, monkeypatch):
+        """ensure_proxy_routes() creates a valid routes.json file."""
+        from unittest.mock import MagicMock
+
+        import terok_sandbox
+
+        mock_cfg = MagicMock()
+        mock_cfg.proxy_routes_path = tmp_path / "proxy" / "routes.json"
+        monkeypatch.setattr(terok_sandbox, "SandboxConfig", lambda: mock_cfg)
+
+        from terok_agent.registry import ensure_proxy_routes
+
+        path = ensure_proxy_routes()
+
+        assert path.is_file()
+        routes = json.loads(path.read_text())
+        # Should have at least claude route from the YAML registry
+        assert "claude" in routes
+        assert "upstream" in routes["claude"]


### PR DESCRIPTION
## Summary
- Add `ensure_proxy_routes()` function that generates `routes.json` from the YAML agent registry and writes it to the configured state directory
- Exported from `terok_agent.__init__` for use by higher-level callers (`terokctl proxy start`, TUI)

## Motivation
The credential proxy requires a `routes.json` file mapping provider prefixes to upstream URLs. This file is fully derivable from the YAML agent registry, so it should be auto-generated rather than requiring manual creation. Higher-level callers invoke this before daemon launch to keep route tables synchronized.

## Test plan
- [x] All 10 proxy route tests pass (including new `TestEnsureProxyRoutes`)
- [x] Full suite: 275 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API expanded to allow triggering generation and safe on-disk publishing of proxy routes configuration.

* **Tests**
  * Added tests validating proxy routes file creation, JSON content, and returned-path behavior.

* **Chores**
  * Release bumped to v0.0.10 and aligned dependency artifact version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->