### PR TITLE
chore: bump sandbox to v0.0.13, version to 0.0.12

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2229,13 +2229,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.12"
+version = "0.0.13"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.12-py3-none-any.whl", hash = "sha256:48898cb19d50ebdec5cb0e0f2ade91025a0cb45c08b2f46a3443c4380f848ded"},
+    {file = "terok_sandbox-0.0.13-py3-none-any.whl", hash = "sha256:58b07aa6ec7964f60fa2644ac40d29baaaa1b951866a91e0f29d6f6d7f683f74"},
 ]
 
 [package.dependencies]
@@ -2245,7 +2245,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.12/terok_sandbox-0.0.12-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.13/terok_sandbox-0.0.13-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2630,4 +2630,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "949ca0103ee675538bb0e03da92a87232539fa49d5897a9d861e9c797c810eaa"
+content-hash = "1737c87fe5bfb83c666d7e7176ad8c6f53d3767509a2e7b09eec65486b6ef154"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.11"
+version = "0.0.12"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.12/terok_sandbox-0.0.12-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.13/terok_sandbox-0.0.13-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 


### PR DESCRIPTION
## Summary
- Bump terok-sandbox dependency from v0.0.12 to v0.0.13 (sys.executable -m proxy launch)
- Bump terok-agent version from 0.0.11 to 0.0.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped project version to 0.0.12
  * Updated terok-sandbox dependency to version 0.0.13

<!-- end of auto-generated comment: release notes by coderabbit.ai -->