### PR TITLE
feat: credential proxy integration — per-provider tokens, all agents/tools

### DIFF
--- a/docs/credential-proxy.md
+++ b/docs/credential-proxy.md
@@ -2,175 +2,206 @@
 
 ## Problem
 
-terok currently bind-mounts vendor config directories (containing API keys,
-OAuth tokens, SSH private keys) into task containers.  A prompt-injected or
-supply-chain-compromised agent can read and exfiltrate these secrets to any
-allowed domain.
+terok bind-mounts vendor config directories into task containers. A
+prompt-injected or supply-chain-compromised agent can read and exfiltrate
+API keys, OAuth tokens, or SSH private keys from these shared mounts.
 
-## Solution: Socket-Based Credential Injection
+## Solution: TCP Credential Proxy
 
-No real secret ever enters a task container.  Instead:
+No real secret enters a task container. Instead:
 
-1. **Credential DB** (sqlite3, host-side) stores captured API keys and OAuth tokens
-2. **Credential proxy** (aiohttp, Unix socket) injects real auth headers before forwarding to upstream APIs
-3. **Phantom tokens** (per-task, worthless outside the proxy) are what containers see
-
-Both **API key** and **OAuth subscription** users are supported — including
-Claude Max, Pro, Team, and Enterprise plans.
+1. **Credential DB** (sqlite3, host-side) stores API keys and OAuth tokens
+2. **Credential proxy** (aiohttp, TCP+Unix socket) injects real auth headers
+3. **Per-provider phantom tokens** (per-task, per-provider) are what containers see
 
 ## Architecture
 
 ```text
-HOST                                    CONTAINER
-─────────────────────────              ─────────────────────────
-Credential DB (sqlite3)                 Phantom API keys (env vars)
-  ├── credentials table                 ANTHROPIC_API_KEY=<phantom>
-  └── proxy_tokens table                ANTHROPIC_BASE_URL=…/claude
+HOST                                      CONTAINER
+-------------------------------           -----------------------------------
+Credential DB (sqlite3)                   Per-provider phantom tokens (env vars)
+  credentials table                         ANTHROPIC_API_KEY=<claude-phantom>
+  proxy_tokens table                        MISTRAL_API_KEY=<vibe-phantom>
+    (token, project, task,                  GH_TOKEN=<gh-phantom>
+     credential_set, provider)              GITLAB_TOKEN=<glab-phantom>
 
-Credential Proxy (aiohttp)              Proxy socket (mounted)
-  /run/terok/credential-proxy.sock      /run/terok/credential-proxy.sock
-  ├── Validates phantom token           Agent → proxy → real auth → upstream
-  ├── Routes by path prefix
-  ├── Detects credential type
-  │   (OAuth → Bearer, API key → x-api-key)
-  └── Forwards to upstream (genuine TLS)
+Credential Proxy (aiohttp)                Agent / tool makes API request
+  TCP: 127.0.0.1:18731                      with phantom token in auth header
+  Unix: $XDG_RUNTIME_DIR/terok/sock
+  1. Extracts phantom token                 Routing is by token, not URL path.
+  2. Looks up provider from token           Token encodes which provider it's for.
+  3. Loads real credential from DB
+  4. Injects real auth header
+  5. Forwards to upstream (genuine TLS)
 ```
+
+### Why TCP, not Unix sockets?
+
+SELinux blocks `connect()` on Unix sockets mounted into rootless Podman
+containers. The `connectto` process label check denies `container_t ->
+unconfined_t` regardless of file relabeling. This is intentional per
+Red Hat's container security model.
+
+TCP via `host.containers.internal:<port>` is the same pattern the gate
+server uses. The phantom token provides authentication. Shield's
+`loopback_ports` allows the proxy port through the nftables firewall.
+
+See: [Podman #23972](https://github.com/containers/podman/discussions/23972),
+[Dan Walsh: SELinux and Containers](https://danwalsh.livejournal.com/78643.html).
+
+### Per-provider phantom token routing
+
+Each provider gets its own phantom token, created at container launch:
+
+```python
+tokens = {
+    name: db.create_proxy_token(project, task, credential_set, name)
+    for name in routed_providers
+}
+```
+
+The proxy resolves the route from the token's `provider` field, not from
+the URL path. This is essential because some SDKs (Vibe's Mistral SDK,
+gh CLI) strip or ignore URL path components.
+
+## Per-Agent Traffic Routing
+
+Different agents reach the proxy in different ways, depending on what
+their SDK supports:
+
+| Agent | How it reaches the proxy | Notes |
+|-------|-------------------------|-------|
+| **Claude** | `ANTHROPIC_BASE_URL=http://host.containers.internal:18731` | Anthropic SDK respects this env var |
+| **Codex** | `OPENAI_BASE_URL=http://host.containers.internal:18731` | OpenAI SDK respects this env var (deprecated in Codex v0.117, needs config.toml) |
+| **Vibe** | `config.toml` with `api_base` in shared `~/.vibe` mount | Mistral SDK ignores URL path in api_base, only uses host:port. Written by `shared_config_patch` in YAML |
+| **KISSKI** | `TEROK_OC_KISSKI_BASE_URL` env var override | OpenCode reads this; overridden from the real upstream to proxy |
+| **Blablador** | `TEROK_OC_BLABLADOR_BASE_URL` env var override | Same pattern as KISSKI |
+| **gh** | `http_unix_socket` in `~/.config/gh/config.yml` + socat bridge | gh routes ALL API traffic through a Unix socket. socat bridges it to TCP. See below. |
+| **glab** | `GITLAB_API_HOST` + `API_PROTOCOL=http` env vars | glab sends to `http://<api_host>/api/v4/...` |
+
+### gh: socat bridge pattern
+
+gh has no env var for base URL. It supports `http_unix_socket` in its
+config file, which routes all API traffic through a Unix socket.
+
+The init script (`init-ssh-and-repo.sh`) starts a socat bridge:
+
+```bash
+socat UNIX-LISTEN:/tmp/terok-gh-proxy.sock,fork \
+  TCP:host.containers.internal:${TEROK_PROXY_PORT} &
+```
+
+The socket is created **inside** the container by the container's own
+process. SELinux allows `container_t -> container_t` socket connections.
+The TCP hop to the host proxy crosses the container boundary safely.
+
+The `http_unix_socket` path is written to `~/.config/gh/config.yml`
+by the `shared_config_patch` mechanism during `terok-agent auth gh`.
+
+### YAML-driven shared_config_patch
+
+Providers that need config file changes (not just env vars) declare a
+`shared_config_patch` in their YAML:
+
+```yaml
+# Vibe: TOML patch
+shared_config_patch:
+  file: config.toml
+  toml_table: providers
+  toml_match: {name: mistral}
+  toml_set: {api_base: "{proxy_url}/v1"}
+
+# gh: YAML patch
+shared_config_patch:
+  file: config.yml
+  yaml_set: {http_unix_socket: "/tmp/terok-gh-proxy.sock"}
+```
+
+The patch is applied after auth (`_write_proxy_config` in `auth.py`).
+Only non-secret values (URLs, socket paths) are written to shared mounts.
+
+## Agent YAML Registry
+
+Each agent declares its proxy integration in `resources/agents/<name>.yaml`:
+
+```yaml
+credential_proxy:
+  route_prefix: claude           # kept for routes.json generation
+  upstream: https://api.anthropic.com
+  auth_header: dynamic           # OAuth -> Bearer, API key -> x-api-key
+  credential_type: oauth
+  credential_file: .credentials.json
+  phantom_env:
+    ANTHROPIC_API_KEY: true      # env var gets the phantom token
+  base_url_env: ANTHROPIC_BASE_URL  # optional: env var for proxy URL
+  shared_config_patch: ...       # optional: file patch for proxy URL
+```
+
+### Agent-specific settings not in YAML
+
+- **OpenCode base URL override**: For KISSKI and Blablador, the environment
+  builder overrides `TEROK_OC_<NAME>_BASE_URL` when the proxy is active.
+  This is computed at container launch, not declared in YAML.
+
+- **glab env vars**: `GITLAB_API_HOST` and `API_PROTOCOL=http` are injected
+  by the environment builder for glab specifically. glab has no YAML field
+  for this because it's a routing concern, not a credential concern.
+
+- **socat bridge**: Started by `init-ssh-and-repo.sh` when `TEROK_PROXY_PORT`
+  and `GH_TOKEN` are both set. The socket path is hardcoded to
+  `/tmp/terok-gh-proxy.sock` (matching the `shared_config_patch`).
+
+- **anthropic-beta header**: The proxy appends `oauth-2025-04-20` to the
+  `anthropic-beta` header for OAuth credentials. Claude Code sends its own
+  beta features in this header, so the proxy must append (not replace).
 
 ## Auth Flow
 
 ### Three auth paths
 
 **1. OAuth / interactive login** (Claude, Codex, gh):
+Launches a container with the vendor CLI and an empty config directory.
+After exit, the extractor captures the OAuth token to the DB.
 
-Launches a container with the vendor CLI (e.g. `claude`) and an empty config
-directory.  The CLI goes through its native auth flow (browser redirect, device
-code, etc.).  After exit, the extractor captures the OAuth token to the DB.
+**2. API key -- interactive prompt** (Vibe, Blablador, KISSKI, glab):
+Prompts for an API key on the terminal. No container needed.
 
-**2. API key — interactive prompt** (Vibe, Blablador, KISSKI, glab):
+**3. API key -- non-interactive** (all providers):
+`terok-agent auth <provider> --api-key <key>`
 
-Prompts the user for an API key directly on the terminal.  No container needed.
+### Post-auth config patching
 
-**3. API key — non-interactive** (all providers):
-
-```bash
-terok-agent auth <provider> --api-key <key>
-```
-
-Stores the key directly in the credential DB.  No container, no prompt.  Useful
-for automated workflows and CI.
-
-### Auth mode selection
-
-For providers supporting both OAuth and API key (Claude, Codex, gh):
-
-```text
-$ terok-agent auth claude
-Authenticate Claude:
-
-  1. OAuth / interactive login (launches container)
-  2. API key (paste key, no container needed)
-
-Choose [1/2]:
-```
-
-Auth modes are declared in each agent's YAML (`auth.modes: [oauth, api_key]`).
-
-### Auth container lifecycle
-
-1. `terok-agent auth <provider>` creates an **empty** temp directory
-2. The temp dir is mounted as the provider's config dir inside the container
-3. The auth tool starts with a clean slate — forced re-authentication
-4. After exit, per-provider **extractors** parse the credential files
-5. Extracted credentials stored in the sqlite **Credential DB**
-6. Temp directory deleted — shared config mount never touched
-
-## Dynamic Auth Header Injection
-
-The proxy detects the credential type and selects the correct auth header:
-
-| Credential type | Header | Format |
-|----------------|--------|--------|
-| OAuth (`type: oauth`) | `Authorization` | `Bearer <access_token>` |
-| API key (`type: api_key`) | `x-api-key` | `<key>` |
-| OAuth token (`type: oauth_token`) | Route-configured | Route-configured |
-| PAT (`type: pat`) | Route-configured | Route-configured |
-
-This is critical for Claude, where OAuth tokens and API keys use different
-headers.  The route config declares `auth_header: dynamic` and the proxy
-resolves it based on what's stored in the DB.
-
-### Claude OAuth requirements
-
-Claude's API requires two additional signals for OAuth authentication
-(discovered by analyzing Claude Code v2.1.83 source):
-
-1. **`anthropic-beta: oauth-2025-04-20`** header — gates OAuth support
-2. **`?beta=true`** query parameter on the URL
-
-Both are sent natively by Claude Code — the proxy forwards them transparently
-since it passes all non-auth request headers through.
-
-**Verified end-to-end**: OAuth subscription token → credential DB → phantom
-token → proxy → `Authorization: Bearer <real_token>` → Anthropic API → success.
+After storing credentials, `_write_proxy_config()` applies any
+`shared_config_patch` from the YAML registry. This writes proxy URLs
+(not secrets) to the provider's shared config mount.
 
 ## Per-Provider Credential Extractors
 
-Each extractor is a pure function: `Path → dict`.  They parse vendor-specific
-credential files and return a normalized dict.
+| Provider  | File               | Key fields                    |
+|-----------|--------------------|-------------------------------|
+| Claude    | `.credentials.json`| access_token, refresh_token   |
+| Codex     | `auth.json`        | access_token, refresh_token   |
+| Vibe      | `.env`             | key (MISTRAL_API_KEY)         |
+| Blablador | `config.json`      | key (api_key)                 |
+| KISSKI    | `config.json`      | key (api_key)                 |
+| gh        | `hosts.yml`        | token (oauth_token)           |
+| glab      | `config.yml`       | token (per-host)              |
 
-| Provider  | File                   | Extractor                | Key fields           |
-|-----------|------------------------|--------------------------|----------------------|
-| Claude    | `.credentials.json`    | `extract_claude_oauth`   | access_token, refresh_token |
-| Claude    | `config.json`          | (API key fallback)       | key                  |
-| Codex     | `auth.json`            | `extract_codex_oauth`    | access_token, refresh_token |
-| Vibe      | `.env`                 | `extract_api_key_env`    | key (MISTRAL_API_KEY) |
-| Blablador | `config.json`          | `extract_json_api_key`   | key (api_key)        |
-| KISSKI    | `config.json`          | `extract_json_api_key`   | key (api_key)        |
-| gh        | `hosts.yml`            | `extract_gh_token`       | token (oauth_token)  |
-| glab      | `config.yml`           | `extract_glab_token`     | token (per-host)     |
+## Known Limitations
 
-## YAML Registry Extension
+- **Codex**: Needs WebSocket support (proxy only handles HTTP), OAuth token
+  refresh (Codex refreshes via `auth.openai.com`), and config.toml base URL
+  (env var deprecated in v0.117). Filed as bug issues.
 
-Each agent YAML declares a `credential_proxy:` section:
+- **OAuth token refresh**: Claude and Codex OAuth tokens expire (~1h). The
+  proxy does not refresh them automatically. Re-auth required after expiry.
 
-```yaml
-credential_proxy:
-  route_prefix: claude             # path prefix in proxy (/claude/v1/…)
-  upstream: https://api.anthropic.com
-  auth_header: dynamic             # auto-detect: OAuth → Bearer, API key → x-api-key
-  auth_prefix: ""
-  credential_type: oauth
-  credential_file: .credentials.json
-  phantom_env:
-    ANTHROPIC_API_KEY: true        # env var injected with phantom token
-  base_url_env: ANTHROPIC_BASE_URL # env var overridden with proxy URL
-```
+- **Copilot**: Not proxied yet. No `credential_proxy` section in YAML.
 
-And an `auth:` section with mode declarations:
-
-```yaml
-auth:
-  host_dir: _claude-config
-  container_mount: /home/dev/.claude
-  modes: [oauth, api_key]          # what the user can choose
-  command: ["claude"]               # container command for OAuth mode
-  api_key_hint: "Get your API key at: https://console.anthropic.com/settings/keys"
-```
-
-## Bypass Configuration
-
-The credential proxy is enabled by default.  To disable it:
-
-```yaml
-credential_proxy:
-  bypass_no_secret_protection: true
-```
-
-The deliberately long name makes it clear what you're giving up.  When bypassed,
-terok falls back to the current shared-mount behavior (real secrets in containers).
+- **SSH keys**: Still bind-mounted as files. SSH agent proxy planned (#551).
 
 ## Package Boundaries
 
-- **terok-sandbox**: Credential DB, proxy server, lifecycle management (generic plumbing)
-- **terok-agent**: Extractors, YAML registry, auth interceptor (agent-specific knowledge)
-- **terok**: Environment integration, phantom token injection, base URL overrides
+- **terok-sandbox**: Credential DB, proxy server, TCP+Unix listener, lifecycle
+- **terok-agent**: YAML registry, extractors, auth interceptor, runner proxy env
+- **terok**: Environment builder, phantom token injection for full-stack tasks

--- a/docs/credential-proxy.md
+++ b/docs/credential-proxy.md
@@ -71,7 +71,7 @@ their SDK supports:
 
 | Agent | How it reaches the proxy | Notes |
 |-------|-------------------------|-------|
-| **Claude** | `ANTHROPIC_BASE_URL=http://host.containers.internal:18731` | Anthropic SDK respects this env var |
+| **Claude** | `ANTHROPIC_BASE_URL=http://host.containers.internal:<proxy_port> (default: 18731)` | Anthropic SDK respects this env var |
 | **Codex** | `OPENAI_BASE_URL=http://host.containers.internal:18731` | OpenAI SDK respects this env var (deprecated in Codex v0.117, needs config.toml) |
 | **Vibe** | `config.toml` with `api_base` in shared `~/.vibe` mount | Mistral SDK ignores URL path in api_base, only uses host:port. Written by `shared_config_patch` in YAML |
 | **KISSKI** | `TEROK_OC_KISSKI_BASE_URL` env var override | OpenCode reads this; overridden from the real upstream to proxy |
@@ -117,7 +117,7 @@ shared_config_patch:
   yaml_set: {http_unix_socket: "/tmp/terok-gh-proxy.sock"}
 ```
 
-The patch is applied after auth (`_write_proxy_config` in `auth.py`).
+The patch is applied after auth (`write_proxy_config() in proxy_config.py`).
 Only non-secret values (URLs, socket paths) are written to shared mounts.
 
 ## Agent YAML Registry
@@ -171,7 +171,7 @@ Prompts for an API key on the terminal. No container needed.
 
 ### Post-auth config patching
 
-After storing credentials, `_write_proxy_config()` applies any
+After storing credentials, `write_proxy_config()` applies any
 `shared_config_patch` from the YAML registry. This writes proxy URLs
 (not secrets) to the provider's shared config mount.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2229,24 +2229,23 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.13"
+version = "0.0.14"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.14-py3-none-any.whl", hash = "sha256:429964dea7fbe79525d5c13700d3cfa5b8bea448bb651dfba8e431637956b913"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 platformdirs = ">=4.0"
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "d2aa16c"
-resolved_reference = "d2aa16c1a0bad30499850e472fe5bc7811d048b1"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.14/terok_sandbox-0.0.14-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2631,4 +2630,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "c23e743e61de0f62cbe1442779ceb81da81b21e7df2d451ac3f17ceb2178ddaa"
+content-hash = "01a6fd6e69a44cb90afe02f9683c917a6820bab70a224a934d535a1dd447c5a5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2234,18 +2234,19 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.13-py3-none-any.whl", hash = "sha256:58b07aa6ec7964f60fa2644ac40d29baaaa1b951866a91e0f29d6f6d7f683f74"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.13/terok_sandbox-0.0.13-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "d2aa16c"
+resolved_reference = "d2aa16c1a0bad30499850e472fe5bc7811d048b1"
 
 [[package]]
 name = "terok-shield"
@@ -2328,7 +2329,7 @@ version = "1.2.0"
 description = "A lil' TOML writer"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"},
     {file = "tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"},
@@ -2630,4 +2631,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "1737c87fe5bfb83c666d7e7176ad8c6f53d3767509a2e7b09eec65486b6ef154"
+content-hash = "c23e743e61de0f62cbe1442779ceb81da81b21e7df2d451ac3f17ceb2178ddaa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.12"
+version = "0.0.13"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "d2aa16c"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.14/terok_sandbox-0.0.14-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,10 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.13/terok_sandbox-0.0.13-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "d2aa16c"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
+tomli-w = ">=1.0"
 
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.8"

--- a/src/terok_agent/auth.py
+++ b/src/terok_agent/auth.py
@@ -253,6 +253,7 @@ def _capture_credentials(provider_name: str, auth_dir: Path, credential_set: str
     except Exception as exc:
         print(f"\nWarning: failed to store credentials: {exc}")
         print("The auth flow completed but credentials were not saved to the proxy DB.")
+        return
 
 
 def store_api_key(

--- a/src/terok_agent/commands.py
+++ b/src/terok_agent/commands.py
@@ -159,16 +159,19 @@ def _handle_auth(*, agent: str, api_key: str | None = None) -> None:
             available = ", ".join(AUTH_PROVIDERS)
             raise SystemExit(f"Unknown provider: {agent}. Available: {available}")
         store_api_key(agent, api_key.strip())
-        return
+    else:
+        from .build import l1_image_tag
 
-    from .build import l1_image_tag
+        image = l1_image_tag("ubuntu:24.04")
+        from terok_sandbox import SandboxConfig
 
-    # Need an L1 image for the auth container
-    image = l1_image_tag("ubuntu:24.04")
-    from terok_sandbox import SandboxConfig
+        cfg = SandboxConfig()
+        authenticate("standalone", agent, envs_base_dir=cfg.effective_envs_dir, image=image)
 
-    cfg = SandboxConfig()
-    authenticate("standalone", agent, envs_base_dir=cfg.effective_envs_dir, image=image)
+    # Write proxy URLs to shared config files (e.g. Vibe config.toml, gh config.yml)
+    from .proxy_config import write_proxy_config
+
+    write_proxy_config(agent)
 
 
 def _handle_ls() -> None:

--- a/src/terok_agent/proxy_config.py
+++ b/src/terok_agent/proxy_config.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Post-auth shared config patching for the credential proxy.
+
+Applies ``shared_config_patch`` from the YAML registry after authentication.
+Writes proxy URLs (not secrets) to provider config files so that agents
+route API traffic through the credential proxy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_proxy_config(provider_name: str) -> None:
+    """Apply ``shared_config_patch`` from the YAML registry after auth.
+
+    Patches a TOML or YAML config file in the provider's shared config dir
+    to redirect API traffic through the credential proxy.  The patch spec
+    is declared in the agent YAML — no provider-specific code needed.
+    """
+    from .registry import get_registry
+
+    registry = get_registry()
+    route = registry.proxy_routes.get(provider_name)
+    if not route or not route.shared_config_patch:
+        return
+
+    auth_info = registry.auth_providers.get(provider_name)
+    if not auth_info:
+        return
+
+    from terok_sandbox import SandboxConfig, get_proxy_port
+
+    cfg = SandboxConfig()
+    port = get_proxy_port(cfg)
+    proxy_url = f"http://host.containers.internal:{port}"
+
+    patch = route.shared_config_patch
+    shared_dir = cfg.effective_envs_dir / auth_info.host_dir_name
+    config_path = shared_dir / patch["file"]
+    shared_dir.mkdir(parents=True, exist_ok=True)
+
+    if "yaml_set" in patch:
+        _apply_yaml_patch(config_path, patch, proxy_url)
+    elif "toml_table" in patch:
+        _apply_toml_patch(config_path, patch, proxy_url)
+
+    print(f"Proxy config written to {config_path}")
+
+
+def _apply_toml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
+    """Patch a TOML array-of-tables entry."""
+    try:
+        import tomllib
+
+        existing = tomllib.loads(config_path.read_text()) if config_path.is_file() else {}
+    except Exception:
+        existing = {}
+
+    table_key = patch["toml_table"]
+    match_criteria = patch["toml_match"]
+    values = {
+        k: v.replace("{proxy_url}", proxy_url) if isinstance(v, str) else v
+        for k, v in patch["toml_set"].items()
+    }
+
+    entries = existing.get(table_key, [])
+    target = next(
+        (e for e in entries if all(e.get(k) == v for k, v in match_criteria.items())),
+        None,
+    )
+    if target:
+        target.update(values)
+    else:
+        entries.append({**match_criteria, **values})
+        existing[table_key] = entries
+
+    import tomli_w
+
+    config_path.write_bytes(tomli_w.dumps(existing).encode())
+
+
+def _apply_yaml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
+    """Set top-level keys in a YAML config file."""
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    try:
+        existing = yaml.load(config_path) if config_path.is_file() else {}
+    except Exception:
+        existing = {}
+    if not isinstance(existing, dict):
+        existing = {}
+
+    for k, v in patch["yaml_set"].items():
+        existing[k] = v.replace("{proxy_url}", proxy_url) if isinstance(v, str) else v
+
+    yaml.dump(existing, config_path)

--- a/src/terok_agent/registry.py
+++ b/src/terok_agent/registry.py
@@ -264,6 +264,9 @@ class CredentialProxyRoute:
     base_url_env: str = ""
     """Env var to override with proxy URL (e.g. ``"ANTHROPIC_BASE_URL"``)."""
 
+    shared_config_patch: dict | None = None
+    """Optional shared config patch applied after auth (e.g. Vibe's config.toml)."""
+
 
 def _to_proxy_route(name: str, data: dict) -> CredentialProxyRoute | None:
     """Parse the ``credential_proxy:`` YAML section into a route config."""
@@ -287,6 +290,7 @@ def _to_proxy_route(name: str, data: dict) -> CredentialProxyRoute | None:
         credential_file=cp.get("credential_file", ""),
         phantom_env=cp.get("phantom_env", {}),
         base_url_env=cp.get("base_url_env", ""),
+        shared_config_patch=cp.get("shared_config_patch"),
     )
 
 
@@ -381,7 +385,7 @@ class AgentRegistry:
                     f"providers {existing!r} and {route.provider!r}"
                 )
             prefix_owners[route.route_prefix] = route.provider
-            routes[route.route_prefix] = {
+            routes[route.provider] = {
                 "upstream": route.upstream,
                 "auth_header": route.auth_header,
                 "auth_prefix": route.auth_prefix,

--- a/src/terok_agent/resources/agents/gh.yaml
+++ b/src/terok_agent/resources/agents/gh.yaml
@@ -12,6 +12,11 @@ credential_proxy:
   auth_prefix: "token "
   credential_type: oauth_token
   credential_file: hosts.yml
+  phantom_env:
+    GH_TOKEN: true
+  shared_config_patch:
+    file: config.yml
+    yaml_set: {http_unix_socket: "/tmp/terok-gh-proxy.sock"}
 
 auth:
   host_dir: _gh-config

--- a/src/terok_agent/resources/agents/glab.yaml
+++ b/src/terok_agent/resources/agents/glab.yaml
@@ -7,11 +7,13 @@ binary: glab
 
 credential_proxy:
   route_prefix: gl
-  upstream: https://gitlab.com/api/v4
+  upstream: https://gitlab.com
   auth_header: PRIVATE-TOKEN
   auth_prefix: ""
   credential_type: pat
   credential_file: config.yml
+  phantom_env:
+    GITLAB_TOKEN: true
 
 auth:
   host_dir: _glab-config

--- a/src/terok_agent/resources/agents/vibe.yaml
+++ b/src/terok_agent/resources/agents/vibe.yaml
@@ -36,6 +36,11 @@ credential_proxy:
   credential_file: .env
   phantom_env:
     MISTRAL_API_KEY: true
+  shared_config_patch:
+    file: config.toml
+    toml_table: providers
+    toml_match: {name: mistral}
+    toml_set: {api_base: "{proxy_url}/v1"}
 
 auth:
   host_dir: _vibe-config

--- a/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
@@ -320,6 +320,14 @@ if [[ "${TEROK_UNRESTRICTED:-}" == "1" ]]; then
   fi
 fi
 
+# Credential proxy: start socat bridges for tools that need Unix sockets.
+# gh routes all API traffic through http_unix_socket (set in config.yml).
+# The socat bridge pipes that socket to the TCP proxy on the host.
+if [[ -n "${TEROK_PROXY_PORT:-}" ]] && [[ -n "${GH_TOKEN:-}" ]] && command -v socat >/dev/null 2>&1; then
+  socat UNIX-LISTEN:/tmp/terok-gh-proxy.sock,fork TCP:host.containers.internal:"${TEROK_PROXY_PORT}" &
+  echo ">> gh proxy bridge started (socat PID: $!)"
+fi
+
 # Signal readiness for host tools that watch initial logs
 echo ">> init complete"
 exec bash

--- a/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
@@ -324,6 +324,7 @@ fi
 # gh routes all API traffic through http_unix_socket (set in config.yml).
 # The socat bridge pipes that socket to the TCP proxy on the host.
 if [[ -n "${TEROK_PROXY_PORT:-}" ]] && [[ -n "${GH_TOKEN:-}" ]] && command -v socat >/dev/null 2>&1; then
+  rm -f /tmp/terok-gh-proxy.sock
   socat UNIX-LISTEN:/tmp/terok-gh-proxy.sock,fork TCP:host.containers.internal:"${TEROK_PROXY_PORT}" &
   echo ">> gh proxy bridge started (socat PID: $!)"
 fi

--- a/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
@@ -25,7 +25,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
             curl ca-certificates gnupg \
             python-is-python3 python3 python3-pip python3-venv pipx \
-            nodejs fd-find jq wget; \
+            nodejs fd-find jq wget socat; \
     rm -rf /var/lib/apt/lists/*
 
 # Binary tools: yq (YAML processor), ast-grep (structural code search via AST),

--- a/src/terok_agent/runner.py
+++ b/src/terok_agent/runner.py
@@ -17,6 +17,7 @@ Gate is on by default (safe-by-default egress control).
 
 from __future__ import annotations
 
+import logging
 import shlex
 import tempfile
 import uuid
@@ -29,6 +30,8 @@ if TYPE_CHECKING:
     from terok_sandbox import LifecycleHooks, Sandbox
 
     from .registry import AgentRegistry
+
+_logger = logging.getLogger(__name__)
 
 
 def _generate_task_id() -> str:
@@ -104,16 +107,26 @@ class AgentRunner:
         return images.l1
 
     def _shared_mounts(self, envs_dir: Path) -> list[str]:
-        """Derive shared config volume mounts from the agent registry.
+        """Derive shared volume mounts from the agent registry.
 
-        Each registry entry with an ``auth.host_dir`` and ``auth.container_mount``
-        becomes a bind mount so that auth credentials persist across runs.
+        Includes both auth config mounts (per-provider) and general mounts
+        (e.g. OpenCode runtime dirs) from the ``mounts:`` YAML section.
         """
+        seen: set[str] = set()
         mounts = []
         for _name, ap in sorted(self.registry.auth_providers.items()):
             host_dir = envs_dir / ap.host_dir_name
             host_dir.mkdir(parents=True, exist_ok=True)
-            mounts.append(f"{host_dir}:{ap.container_mount}:z")
+            mount = f"{host_dir}:{ap.container_mount}:z"
+            if ap.host_dir_name not in seen:
+                mounts.append(mount)
+                seen.add(ap.host_dir_name)
+        for m in self.registry.mounts:
+            if m.host_dir not in seen:
+                host_dir = envs_dir / m.host_dir
+                host_dir.mkdir(parents=True, exist_ok=True)
+                mounts.append(f"{host_dir}:{m.container_path}:z")
+                seen.add(m.host_dir)
         return mounts
 
     def _setup_gate(self, repo_url: str, task_id: str) -> str:
@@ -154,6 +167,104 @@ class AgentRunner:
         self.sandbox.ensure_gate()
         token = self.sandbox.create_token(repo_key, task_id)
         return self.sandbox.gate_url(gate_path, token)
+
+    def _credential_proxy_env(self, task_id: str) -> dict[str, str]:
+        """Inject phantom tokens and base URL overrides if the proxy is running.
+
+        Unlike terok (which hard-fails when the proxy is down), the standalone
+        runner silently skips proxy integration — credentials may come from
+        shared config mounts instead.
+
+        The proxy listens on a TCP port on the host; containers reach it via
+        ``host.containers.internal:<port>`` (same pattern as the gate server).
+        """
+        from terok_sandbox import (
+            CredentialDB,
+            get_proxy_port,
+            is_proxy_running,
+            is_proxy_socket_active,
+        )
+
+        cfg = self.sandbox.config
+        if not (is_proxy_socket_active() or is_proxy_running(cfg)):
+            return {}
+
+        proxy_routes = self.registry.proxy_routes
+        db = CredentialDB(cfg.proxy_db_path)
+        try:
+            credential_set = "default"
+            stored_providers = set(db.list_credentials(credential_set))
+            routed = stored_providers & proxy_routes.keys()
+            if not routed:
+                return {}
+            # Per-provider phantom tokens — each token encodes the provider
+            tokens = {
+                name: db.create_proxy_token("standalone", task_id, credential_set, name)
+                for name in routed
+            }
+        finally:
+            db.close()
+
+        port = get_proxy_port(cfg)
+        proxy_base = f"http://host.containers.internal:{port}"
+        env: dict[str, str] = {}
+
+        for name, route in proxy_routes.items():
+            if name not in routed:
+                continue
+            for env_var in route.phantom_env:
+                env[env_var] = tokens[name]
+            if route.base_url_env:
+                env[route.base_url_env] = proxy_base
+            # Override OpenCode base URL for proxied providers
+            provider = self.registry.providers.get(name)
+            if provider and provider.opencode_config:
+                oc_base_key = f"TEROK_OC_{name.upper()}_BASE_URL"
+                env[oc_base_key] = f"{proxy_base}/v1"
+            # glab: redirect API to proxy via env vars
+            if name == "glab":
+                env["GITLAB_API_HOST"] = f"host.containers.internal:{port}"
+                env["API_PROTOCOL"] = "http"
+
+        # Signal for init script to start socat bridges
+        if routed:
+            env["TEROK_PROXY_PORT"] = str(port)
+
+        _logger.debug("Credential proxy: injected %d env vars for %s", len(env), stored_providers)
+        return env
+
+    @staticmethod
+    def _stream_headless(cname: str, timeout: float) -> None:
+        """Stream container logs to stdout and print exit code when done."""
+        import subprocess
+        import sys
+
+        try:
+            proc = subprocess.Popen(
+                ["podman", "logs", "-f", cname],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.terminate()
+            print("Agent timed out", file=sys.stderr)
+        except (FileNotFoundError, OSError):
+            pass
+
+        # Retrieve exit code from the container itself
+        try:
+            result = subprocess.run(["podman", "wait", cname], capture_output=True, timeout=10)
+            exit_code = int(result.stdout.decode().strip()) if result.stdout else 1
+        except (subprocess.TimeoutExpired, ValueError, FileNotFoundError):
+            exit_code = 1
+
+        if exit_code != 0:
+            print(f"Agent exited with code {exit_code}")
 
     def _base_env(self, task_id: str, provider_name: str) -> dict[str, str]:
         """Assemble the base environment variables for a container."""
@@ -436,6 +547,9 @@ class AgentRunner:
         # Shared auth mounts (derived from registry)
         volumes += self._shared_mounts(envs_dir)
 
+        # Credential proxy: inject phantom tokens and base URL overrides
+        env.update(self._credential_proxy_env(task_id))
+
         # Agent config mount
         volumes.append(f"{agent_config_dir}:/home/dev/.terok:Z")
 
@@ -452,7 +566,11 @@ class AgentRunner:
             )
             command = ["bash", "-lc", cmd_str]
         elif mode == "interactive":
-            command = ["bash", "-lc", "init-ssh-and-repo.sh && echo __CLI_READY__; exec bash -l"]
+            command = [
+                "bash",
+                "-lc",
+                "init-ssh-and-repo.sh && echo __CLI_READY__; tail -f /dev/null",
+            ]
         elif mode == "web":
             toad_cmd = "init-ssh-and-repo.sh && toad --serve -H 0.0.0.0 -p 8080"
             if public_url:
@@ -481,9 +599,7 @@ class AgentRunner:
 
         # Follow output if requested
         if follow and mode == "headless":
-            exit_code = self.sandbox.wait_for_exit(cname, timeout=float(timeout + 60))
-            if exit_code != 0:
-                print(f"Agent exited with code {exit_code}")
+            self._stream_headless(cname, timeout=float(timeout + 60))
         elif mode == "interactive":
             from terok_sandbox import READY_MARKER
 

--- a/tach.toml
+++ b/tach.toml
@@ -18,7 +18,7 @@ ignore_type_checking_imports = true
 #   _util (standalone) ← config_stack ← {agent_config, instructions, agents}
 #   headless_providers (standalone, pure dataclasses)
 #   agents → _util + headless_providers
-#   auth → _util + credential_extractors + registry
+#   auth → _util + credential_extractors
 #   instructions → agent_config
 #   resources (data files, no code deps)
 

--- a/tach.toml
+++ b/tach.toml
@@ -18,7 +18,7 @@ ignore_type_checking_imports = true
 #   _util (standalone) ← config_stack ← {agent_config, instructions, agents}
 #   headless_providers (standalone, pure dataclasses)
 #   agents → _util + headless_providers
-#   auth → _util + headless_providers
+#   auth → _util + credential_extractors + registry
 #   instructions → agent_config
 #   resources (data files, no code deps)
 
@@ -74,6 +74,13 @@ depends_on = [
     "terok_agent.credential_extractors",
 ]
 
+# Post-auth shared config patching (proxy URL writes)
+[[modules]]
+path = "terok_agent.proxy_config"
+depends_on = [
+    "terok_agent.registry",
+]
+
 # YAML agent registry — loads bundled + user agent definitions
 [[modules]]
 path = "terok_agent.registry"
@@ -111,6 +118,7 @@ path = "terok_agent.commands"
 depends_on = [
     "terok_agent.auth",
     "terok_agent.build",
+    "terok_agent.proxy_config",
     "terok_agent.registry",
     "terok_agent.runner",
 ]

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -76,11 +76,10 @@ class TestGenerateRoutesJson:
         for prefix, cfg in routes.items():
             assert "upstream" in cfg, f"Route '{prefix}' missing upstream"
 
-    def test_glab_uses_gl_prefix(self) -> None:
-        """GitLab route uses 'gl' as the path prefix (not 'glab')."""
+    def test_glab_keyed_by_provider_name(self) -> None:
+        """GitLab route is keyed by provider name 'glab'."""
         routes = json.loads(get_registry().generate_routes_json())
-        assert "gl" in routes
-        assert "glab" not in routes
+        assert "glab" in routes
 
 
 class TestEnsureProxyRoutes:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -304,6 +304,77 @@ class TestGateIntegration:
         assert spec.env.get("CODE_REPO") == "git@github.com:user/repo.git"
 
 
+class TestCredentialProxyEnv:
+    """Verify _credential_proxy_env integration."""
+
+    def test_proxy_not_running_returns_empty(self) -> None:
+        """When proxy is not running, returns empty dict."""
+        sandbox = _mock_sandbox()
+        runner = AgentRunner(sandbox=sandbox)
+
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=False),
+            patch("terok_sandbox.is_proxy_running", return_value=False),
+        ):
+            env = runner._credential_proxy_env("task-1")
+
+        assert env == {}
+
+    def test_proxy_running_injects_phantom_tokens(self, tmp_path: Path) -> None:
+        """When proxy runs and credentials exist, injects phantom env vars."""
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        # SandboxConfig derives proxy_db_path from state_dir, so set state_dir
+        # to tmp_path and create the DB at the expected location.
+        cfg = SandboxConfig(state_dir=tmp_path)
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
+        db.close()
+
+        sandbox = _mock_sandbox()
+        sandbox.config = cfg
+        runner = AgentRunner(sandbox=sandbox)
+
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=False),
+            patch("terok_sandbox.is_proxy_running", return_value=True),
+        ):
+            env = runner._credential_proxy_env("task-1")
+
+        assert "ANTHROPIC_API_KEY" in env
+        assert len(env["ANTHROPIC_API_KEY"]) == 32
+        assert "ANTHROPIC_BASE_URL" in env
+        assert (
+            f"host.containers.internal:{cfg.proxy_port}"
+            == env["ANTHROPIC_BASE_URL"].split("://")[1]
+        )
+
+    def test_no_routed_providers_returns_empty(self, tmp_path: Path) -> None:
+        """When credentials exist but none map to proxy routes, returns empty."""
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path)
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "nonexistent-provider", {"type": "api_key", "key": "k"})
+        db.close()
+
+        sandbox = _mock_sandbox()
+        sandbox.config = cfg
+        runner = AgentRunner(sandbox=sandbox)
+
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=False),
+            patch("terok_sandbox.is_proxy_running", return_value=True),
+        ):
+            env = runner._credential_proxy_env("task-1")
+
+        assert env == {}
+
+
 class TestCommandRegistry:
     """Verify the command registry is well-formed."""
 


### PR DESCRIPTION
## Summary

Wire the credential proxy into `AgentRunner` for all supported agents and tools. Per-provider phantom tokens route through the TCP proxy without any real secrets entering the container.

### Changes
- **Runner**: `_credential_proxy_env()` creates per-provider phantom tokens, injects env vars, overrides OpenCode base URLs, glab env redirect
- **Auth**: post-auth `shared_config_patch` writes proxy URLs to provider config files (Vibe `config.toml`, gh `config.yml`) — no secrets in shared mounts
- **YAML registry**: `phantom_env` + `shared_config_patch` declarations for all providers; `routes.json` keyed by provider name
- **Init script**: socat bridge for gh (`UNIX-LISTEN → TCP` to proxy)
- **L1 Dockerfile**: `socat` pre-installed
- **Headless output**: `_stream_headless()` pipes container logs to terminal
- **Interactive mode**: `tail -f /dev/null` keepalive
- **General mounts**: registry `mounts:` section included alongside auth mounts (fixes OpenCode dirs)
- **Docs**: complete rewrite of `credential-proxy.md`

### Supported providers

| Provider | Type | Proxy method |
|----------|------|-------------|
| Claude | OAuth | `ANTHROPIC_BASE_URL` env var |
| Vibe | API key | `config.toml` shared_config_patch |
| KISSKI | API key | `TEROK_OC_*_BASE_URL` env override |
| Blablador | API key | `TEROK_OC_*_BASE_URL` env override |
| gh | OAuth | `http_unix_socket` + socat bridge |
| glab | PAT | `GITLAB_API_HOST` + `API_PROTOCOL` env |

### Known bugs (separate issues)
- Codex: #552 (WebSocket, token refresh, config base URL)
- OAuth refresh: #553
- Copilot: #555

### Dependency
- Requires terok-ai/terok-sandbox#36 (temporary git pin, will revert to release wheel after merge+release)

## Test plan
- [x] Unit tests for `_credential_proxy_env` (proxy running, not running, no routed providers)
- [x] Manual: all 6 providers tested headless and interactive
- [x] Manual: gh via socat bridge, glab via env redirect, both from inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TCP-first credential proxy with per-provider phantom-token routing and per-agent base-URL overrides
  * Post-auth shared-config patching to update CLI YAML/TOML configs to use the proxy
  * GitHub CLI socket→TCP bridging for proxied GitHub access

* **Chores**
  * CLI images and init scripts add socat and auto-start socket bridge when applicable
  * Runner injects proxy-related environment into task containers and improves headless log streaming
  * Package version bump and added runtime dependency for TOML writes

* **Documentation**
  * Expanded credential-proxy docs, architecture diagram, routing semantics, and known limitations

* **Tests**
  * Added unit tests for proxy env injection and route keying
<!-- end of auto-generated comment: release notes by coderabbit.ai -->