### PR TITLE
feat: credential proxy CLI commands with route generation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2229,13 +2229,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.15"
+version = "0.0.16"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.15-py3-none-any.whl", hash = "sha256:c9f2af16a3138dacb805697ef6a09af026ed36322d34aae9dee5b64a9be83425"},
+    {file = "terok_sandbox-0.0.16-py3-none-any.whl", hash = "sha256:4d81c43603ba9986b43f6c49858f13b42859645c6565eb47fc82c02e6d2c4fc2"},
 ]
 
 [package.dependencies]
@@ -2245,7 +2245,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.15/terok_sandbox-0.0.15-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.16/terok_sandbox-0.0.16-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2630,4 +2630,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "3a47b08071fcc9fba64d42b287d72e04086f1979ecdbfe1118e44955eaeb4406"
+content-hash = "0bc6a46c2d1a16192d17faf568d1ce9265aed1d85d810c7d107b91e556c3dfc6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.15/terok_sandbox-0.0.15-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.16/terok_sandbox-0.0.16-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.14"
+version = "0.0.15"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -78,7 +78,6 @@ from .config_stack import ConfigScope, ConfigStack
 
 # -- Credential proxy ----------------------------------------------------------
 from .credential_extractors import extract_credential
-from .proxy_commands import PROXY_COMMANDS
 
 # -- Provider registry ---------------------------------------------------------
 from .headless_providers import (
@@ -95,6 +94,7 @@ from .headless_providers import (
 
 # -- Instructions --------------------------------------------------------------
 from .instructions import bundled_default_instructions, resolve_instructions
+from .proxy_commands import PROXY_COMMANDS
 from .registry import CredentialProxyRoute, ensure_proxy_routes, get_registry
 
 # -- Runner facade -------------------------------------------------------------

--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -78,6 +78,7 @@ from .config_stack import ConfigScope, ConfigStack
 
 # -- Credential proxy ----------------------------------------------------------
 from .credential_extractors import extract_credential
+from .proxy_commands import PROXY_COMMANDS
 
 # -- Provider registry ---------------------------------------------------------
 from .headless_providers import (
@@ -166,6 +167,7 @@ __all__ = [
     "get_registry",
     # Command registry
     "AGENT_COMMANDS",
+    "PROXY_COMMANDS",
     "CommandDef",
     # Runner facade
     "AgentRunner",

--- a/src/terok_agent/cli.py
+++ b/src/terok_agent/cli.py
@@ -14,6 +14,7 @@ import argparse
 from importlib.metadata import PackageNotFoundError, version as _meta_version
 
 from .commands import COMMANDS, ArgDef, CommandDef
+from .proxy_commands import PROXY_COMMANDS
 
 try:
     __version__ = _meta_version("terok-agent")
@@ -68,9 +69,18 @@ def main() -> None:
     for cmd in COMMANDS:
         _wire_command(sub, cmd)
 
+    # -- proxy --
+    proxy_p = sub.add_parser("proxy", help="Credential proxy management")
+    proxy_sub = proxy_p.add_subparsers()
+    for cmd in PROXY_COMMANDS:
+        _wire_command(proxy_sub, cmd)
+    proxy_p.set_defaults(_group_help=proxy_p)
+
     args = parser.parse_args()
     if hasattr(args, "_cmd"):
         _dispatch(args)
+    elif hasattr(args, "_group_help"):
+        args._group_help.print_help()
     else:
         parser.print_help()
         raise SystemExit(1)

--- a/src/terok_agent/proxy_commands.py
+++ b/src/terok_agent/proxy_commands.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Credential proxy CLI commands for terok-agent.
+
+Wraps terok-sandbox proxy lifecycle with agent-level concerns: route
+generation from the YAML registry is performed before ``start`` and
+``install`` so the proxy always has up-to-date provider config.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from terok_sandbox import CommandDef
+
+
+def _ensure_routes() -> None:
+    """Generate routes.json from the YAML agent registry."""
+    from .registry import ensure_proxy_routes
+
+    ensure_proxy_routes()
+
+
+def _handle_start() -> None:
+    """Generate routes and start the credential proxy daemon."""
+    from terok_sandbox import is_proxy_running, start_proxy
+
+    if is_proxy_running():
+        print("Credential proxy is already running.")
+        sys.exit(1)
+    _ensure_routes()
+    start_proxy()
+    print("Credential proxy started.")
+
+
+def _handle_stop() -> None:
+    """Stop the credential proxy daemon."""
+    from terok_sandbox import is_proxy_running, stop_proxy
+
+    if not is_proxy_running():
+        print("Credential proxy is not running.")
+        return
+    stop_proxy()
+    print("Credential proxy stopped.")
+
+
+def _handle_status() -> None:
+    """Show credential proxy status."""
+    from terok_sandbox import get_proxy_status, is_proxy_systemd_available
+
+    status = get_proxy_status()
+    state = "running" if status.running else "stopped"
+    print(f"Mode:        {status.mode}")
+    print(f"Status:      {state}")
+    print(f"Socket:      {status.socket_path}")
+    print(f"DB:          {status.db_path}")
+    print(f"Routes:      {status.routes_path} ({status.routes_configured} configured)")
+    if status.credentials_stored:
+        print(f"Credentials: {', '.join(status.credentials_stored)}")
+    else:
+        print("Credentials: none stored")
+    if not status.running and status.mode == "none" and is_proxy_systemd_available():
+        print("\nHint: run 'install' to set up systemd socket activation.")
+
+
+def _handle_install() -> None:
+    """Generate routes and install systemd socket activation."""
+    from terok_sandbox import install_proxy_systemd, is_proxy_systemd_available
+
+    if not is_proxy_systemd_available():
+        print(
+            "Error: systemd user services are not available on this host.\n"
+            "Use 'start' to run the proxy without systemd."
+        )
+        sys.exit(1)
+    _ensure_routes()
+    install_proxy_systemd()
+    print("Credential proxy systemd socket installed and started.")
+
+
+def _handle_uninstall() -> None:
+    """Remove credential proxy systemd units."""
+    from terok_sandbox import is_proxy_systemd_available, uninstall_proxy_systemd
+
+    if not is_proxy_systemd_available():
+        print("Error: systemd user services are not available. Nothing to uninstall.")
+        sys.exit(1)
+    uninstall_proxy_systemd()
+    print("Credential proxy systemd units removed.")
+
+
+def _handle_routes() -> None:
+    """Regenerate routes.json from the YAML agent registry."""
+    path = _ensure_routes()
+    if path:
+        print(f"Routes written to {path}")
+
+
+PROXY_COMMANDS: tuple[CommandDef, ...] = (
+    CommandDef(name="start", help="Start the credential proxy daemon", handler=_handle_start, group="proxy"),
+    CommandDef(name="stop", help="Stop the credential proxy daemon", handler=_handle_stop, group="proxy"),
+    CommandDef(name="status", help="Show credential proxy status", handler=_handle_status, group="proxy"),
+    CommandDef(name="install", help="Install systemd socket activation", handler=_handle_install, group="proxy"),
+    CommandDef(name="uninstall", help="Remove systemd units", handler=_handle_uninstall, group="proxy"),
+    CommandDef(name="routes", help="Regenerate routes.json from YAML registry", handler=_handle_routes, group="proxy"),
+)

--- a/src/terok_agent/proxy_commands.py
+++ b/src/terok_agent/proxy_commands.py
@@ -99,10 +99,28 @@ def _handle_routes() -> None:
 
 
 PROXY_COMMANDS: tuple[CommandDef, ...] = (
-    CommandDef(name="start", help="Start the credential proxy daemon", handler=_handle_start, group="proxy"),
-    CommandDef(name="stop", help="Stop the credential proxy daemon", handler=_handle_stop, group="proxy"),
-    CommandDef(name="status", help="Show credential proxy status", handler=_handle_status, group="proxy"),
-    CommandDef(name="install", help="Install systemd socket activation", handler=_handle_install, group="proxy"),
-    CommandDef(name="uninstall", help="Remove systemd units", handler=_handle_uninstall, group="proxy"),
-    CommandDef(name="routes", help="Regenerate routes.json from YAML registry", handler=_handle_routes, group="proxy"),
+    CommandDef(
+        name="start", help="Start the credential proxy daemon", handler=_handle_start, group="proxy"
+    ),
+    CommandDef(
+        name="stop", help="Stop the credential proxy daemon", handler=_handle_stop, group="proxy"
+    ),
+    CommandDef(
+        name="status", help="Show credential proxy status", handler=_handle_status, group="proxy"
+    ),
+    CommandDef(
+        name="install",
+        help="Install systemd socket activation",
+        handler=_handle_install,
+        group="proxy",
+    ),
+    CommandDef(
+        name="uninstall", help="Remove systemd units", handler=_handle_uninstall, group="proxy"
+    ),
+    CommandDef(
+        name="routes",
+        help="Regenerate routes.json from YAML registry",
+        handler=_handle_routes,
+        group="proxy",
+    ),
 )

--- a/src/terok_agent/proxy_commands.py
+++ b/src/terok_agent/proxy_commands.py
@@ -11,15 +11,16 @@ generation from the YAML registry is performed before ``start`` and
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 from terok_sandbox import CommandDef
 
 
-def _ensure_routes() -> None:
+def _ensure_routes() -> Path:
     """Generate routes.json from the YAML agent registry."""
     from .registry import ensure_proxy_routes
 
-    ensure_proxy_routes()
+    return ensure_proxy_routes()
 
 
 def _handle_start() -> None:

--- a/tach.toml
+++ b/tach.toml
@@ -112,6 +112,13 @@ depends_on = [
     "terok_agent.registry",
 ]
 
+# Credential proxy CLI commands — wraps sandbox lifecycle + route generation
+[[modules]]
+path = "terok_agent.proxy_commands"
+depends_on = [
+    "terok_agent.registry",
+]
+
 # Command registry — defines all CLI commands
 [[modules]]
 path = "terok_agent.commands"
@@ -128,6 +135,7 @@ depends_on = [
 path = "terok_agent.cli"
 depends_on = [
     "terok_agent.commands",
+    "terok_agent.proxy_commands",
 ]
 
 # Package root — public API re-exports + registry bootstrap
@@ -143,6 +151,7 @@ depends_on = [
     "terok_agent.credential_extractors",
     "terok_agent.headless_providers",
     "terok_agent.instructions",
+    "terok_agent.proxy_commands",
     "terok_agent.registry",
     "terok_agent.runner",
 ]


### PR DESCRIPTION
## Summary

- New `proxy_commands.py` module with handlers wrapping sandbox lifecycle + agent route generation
- `terok-agent proxy start` generates routes.json before starting daemon
- New `routes` command to regenerate routes.json from YAML registry
- Exported as `PROXY_COMMANDS` for terokctl to mount via wire_group

```
terok-agent proxy start|stop|status|install|uninstall|routes
```

Relates-to: terok-ai/terok#554

## Test plan

- [x] 294 unit tests pass (including existing runner/registry tests)
- [x] Lint + format clean
- [x] 100% docstring coverage on new module

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `proxy` command group to manage credential proxies (start, stop, status, install, uninstall, routes) for full proxy lifecycle management.
  * Made the proxy command set directly accessible from the package for easier discovery and use.

* **Bug Fixes / UX**
  * CLI now shows the selected proxy group's help when that group is requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->