### PR TITLE
chore: rename agent registry to roster

### DIFF
--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -113,10 +113,10 @@ def _bootstrap_roster() -> None:
 
     from .roster import get_roster
 
-    reg = get_roster()
-    HEADLESS_PROVIDERS.update(reg.providers)
-    AUTH_PROVIDERS.update(reg.auth_providers)
-    PROVIDER_NAMES = _hp.PROVIDER_NAMES = reg.agent_names
+    roster = get_roster()
+    HEADLESS_PROVIDERS.update(roster.providers)
+    AUTH_PROVIDERS.update(roster.auth_providers)
+    PROVIDER_NAMES = _hp.PROVIDER_NAMES = roster.agent_names
 
 
 _bootstrap_roster()

--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -95,31 +95,31 @@ from .headless_providers import (
 # -- Instructions --------------------------------------------------------------
 from .instructions import bundled_default_instructions, resolve_instructions
 from .proxy_commands import PROXY_COMMANDS, scan_leaked_credentials
-from .registry import CredentialProxyRoute, ensure_proxy_routes, get_registry
+from .roster import CredentialProxyRoute, ensure_proxy_routes, get_roster
 
 # -- Runner facade -------------------------------------------------------------
 from .runner import AgentRunner
 
-# -- Bootstrap YAML registry into module-level dicts ---------------------------
+# -- Bootstrap YAML roster into module-level dicts ---------------------------
 # HEADLESS_PROVIDERS and AUTH_PROVIDERS are empty dicts populated here to avoid
-# circular imports (registry → auth/headless_providers → registry).
+# circular imports (roster → auth/headless_providers → roster).
 
 
-def _bootstrap_registry() -> None:
-    """Populate module-level provider dicts from the YAML registry."""
+def _bootstrap_roster() -> None:
+    """Populate module-level provider dicts from the YAML roster."""
     global PROVIDER_NAMES  # noqa: PLW0603 — tuple requires rebind
 
     import terok_agent.headless_providers as _hp
 
-    from .registry import get_registry
+    from .roster import get_roster
 
-    reg = get_registry()
+    reg = get_roster()
     HEADLESS_PROVIDERS.update(reg.providers)
     AUTH_PROVIDERS.update(reg.auth_providers)
     PROVIDER_NAMES = _hp.PROVIDER_NAMES = reg.agent_names
 
 
-_bootstrap_registry()
+_bootstrap_roster()
 
 __all__ = [
     "__version__",
@@ -163,8 +163,8 @@ __all__ = [
     "CredentialProxyRoute",
     "ensure_proxy_routes",
     "extract_credential",
-    # Registry
-    "get_registry",
+    # Roster
+    "get_roster",
     # Command registry
     "AGENT_COMMANDS",
     "PROXY_COMMANDS",

--- a/src/terok_agent/build.py
+++ b/src/terok_agent/build.py
@@ -196,7 +196,7 @@ def _render_template(template_name: str, variables: dict[str, str]) -> str:
     Templates live in ``resources/templates/``.  Currently they use
     Dockerfile ``ARG``/``${VAR}`` syntax (Jinja2 is a pass-through).
     Future L1 templatisation will use ``{% for agent %}`` loops driven
-    by the YAML agent registry.
+    by the YAML agent roster.
     """
     from jinja2 import BaseLoader, Environment
 

--- a/src/terok_agent/commands.py
+++ b/src/terok_agent/commands.py
@@ -52,8 +52,8 @@ def _handle_agents(*, show_all: bool = False) -> None:
 
     from .roster import _load_bundled_agents, _load_user_agents, get_roster
 
-    reg = get_roster()
-    names = reg.all_names if show_all else reg.agent_names
+    roster = get_roster()
+    names = roster.all_names if show_all else roster.agent_names
 
     if not names:
         print("No agents registered.", file=sys.stderr)
@@ -64,8 +64,8 @@ def _handle_agents(*, show_all: bool = False) -> None:
 
     rows: list[tuple[str, str, str]] = []
     for name in sorted(names):
-        p = reg.providers.get(name)
-        auth = reg.auth_providers.get(name)
+        p = roster.providers.get(name)
+        auth = roster.auth_providers.get(name)
         label = p.label if p else (auth.label if auth else name)
         kind = raw.get(name, {}).get("kind", "native")
         rows.append((name, label, kind))

--- a/src/terok_agent/commands.py
+++ b/src/terok_agent/commands.py
@@ -50,9 +50,9 @@ def _handle_agents(*, show_all: bool = False) -> None:
     """List registered agents."""
     import sys
 
-    from .registry import _load_bundled_agents, _load_user_agents, get_registry
+    from .roster import _load_bundled_agents, _load_user_agents, get_roster
 
-    reg = get_registry()
+    reg = get_roster()
     names = reg.all_names if show_all else reg.agent_names
 
     if not names:

--- a/src/terok_agent/proxy_commands.py
+++ b/src/terok_agent/proxy_commands.py
@@ -4,7 +4,7 @@
 """Credential proxy CLI commands for terok-agent.
 
 Wraps terok-sandbox proxy lifecycle with agent-level concerns: route
-generation from the YAML registry is performed before ``start`` and
+generation from the YAML roster is performed before ``start`` and
 ``install`` so the proxy always has up-to-date provider config.
 """
 
@@ -17,8 +17,8 @@ from terok_sandbox import CommandDef
 
 
 def _ensure_routes() -> Path:
-    """Generate routes.json from the YAML agent registry."""
-    from .registry import ensure_proxy_routes
+    """Generate routes.json from the YAML agent roster."""
+    from .roster import ensure_proxy_routes
 
     return ensure_proxy_routes()
 
@@ -54,14 +54,14 @@ def scan_leaked_credentials(envs_base: Path) -> list[tuple[str, Path]]:
     into containers.  This function checks each routed provider's mount for
     credential files that would leak real tokens alongside phantom ones.
     """
-    from .registry import get_registry
+    from .roster import get_roster
 
-    registry = get_registry()
+    roster = get_roster()
     leaked: list[tuple[str, Path]] = []
-    for name, route in registry.proxy_routes.items():
+    for name, route in roster.proxy_routes.items():
         if not route.credential_file:
             continue
-        auth = registry.auth_providers.get(name)
+        auth = roster.auth_providers.get(name)
         if not auth:
             continue
         try:
@@ -127,7 +127,7 @@ def _handle_uninstall() -> None:
 
 
 def _handle_routes() -> None:
-    """Regenerate routes.json from the YAML agent registry."""
+    """Regenerate routes.json from the YAML agent roster."""
     path = _ensure_routes()
     if path:
         print(f"Routes written to {path}")
@@ -167,7 +167,7 @@ PROXY_COMMANDS: tuple[CommandDef, ...] = (
     ),
     CommandDef(
         name="routes",
-        help="Regenerate routes.json from YAML registry",
+        help="Regenerate routes.json from YAML roster",
         handler=_handle_routes,
         group="proxy",
     ),

--- a/src/terok_agent/proxy_config.py
+++ b/src/terok_agent/proxy_config.py
@@ -3,7 +3,7 @@
 
 """Post-auth shared config patching for the credential proxy.
 
-Applies ``shared_config_patch`` from the YAML registry after authentication.
+Applies ``shared_config_patch`` from the YAML roster after authentication.
 Writes proxy URLs (not secrets) to provider config files so that agents
 route API traffic through the credential proxy.
 """
@@ -14,20 +14,20 @@ from pathlib import Path
 
 
 def write_proxy_config(provider_name: str) -> None:
-    """Apply ``shared_config_patch`` from the YAML registry after auth.
+    """Apply ``shared_config_patch`` from the YAML roster after auth.
 
     Patches a TOML or YAML config file in the provider's shared config dir
     to redirect API traffic through the credential proxy.  The patch spec
     is declared in the agent YAML — no provider-specific code needed.
     """
-    from .registry import get_registry
+    from .roster import get_roster
 
-    registry = get_registry()
-    route = registry.proxy_routes.get(provider_name)
+    roster = get_roster()
+    route = roster.proxy_routes.get(provider_name)
     if not route or not route.shared_config_patch:
         return
 
-    auth_info = registry.auth_providers.get(provider_name)
+    auth_info = roster.auth_providers.get(provider_name)
     if not auth_info:
         return
 

--- a/src/terok_agent/roster.py
+++ b/src/terok_agent/roster.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""YAML-driven agent and tool registry.
+"""YAML-driven agent and tool roster.
 
 Loads per-agent definition files from bundled package resources and optional
 user extensions, deserializes them into the existing dataclass types, and
@@ -218,7 +218,7 @@ def _derive_opencode_auth(name: str, data: dict) -> AuthProvider | None:
 
 @dataclass(frozen=True)
 class MountDef:
-    """A shared directory mount derived from the agent registry."""
+    """A shared directory mount derived from the agent roster."""
 
     host_dir: str
     """Directory name under ``envs_base_dir`` (e.g. ``"_codex-config"``)."""
@@ -309,8 +309,8 @@ def _to_proxy_route(name: str, data: dict) -> CredentialProxyRoute | None:
 
 
 @dataclass(frozen=True)
-class AgentRegistry:
-    """Loaded registry of agents and tools from YAML definitions.
+class AgentRoster:
+    """Loaded roster of agents and tools from YAML definitions.
 
     Provides the same query API as the legacy hardcoded dicts.
     """
@@ -431,8 +431,8 @@ class AgentRegistry:
         return env
 
 
-def load_registry() -> AgentRegistry:
-    """Load the agent registry from bundled YAML + user overrides.
+def load_roster() -> AgentRoster:
+    """Load the agent roster from bundled YAML + user overrides.
 
     Bundled agents in ``resources/agents/*.yaml`` are loaded first, then
     user files in ``~/.config/terok-agent/agents/*.yaml`` are deep-merged
@@ -504,7 +504,7 @@ def load_registry() -> AgentRegistry:
         if proxy_route is not None:
             proxy_routes[name] = proxy_route
 
-    return AgentRegistry(
+    return AgentRoster(
         _providers=providers,
         _auth_providers=auth_providers,
         _proxy_routes=proxy_routes,
@@ -515,13 +515,13 @@ def load_registry() -> AgentRegistry:
 
 
 @lru_cache(maxsize=1)
-def get_registry() -> AgentRegistry:
-    """Return the singleton registry instance (loaded once, cached)."""
-    return load_registry()
+def get_roster() -> AgentRoster:
+    """Return the singleton roster instance (loaded once, cached)."""
+    return load_roster()
 
 
 def ensure_proxy_routes() -> Path:
-    """Generate ``routes.json`` from the YAML registry and write it to disk.
+    """Generate ``routes.json`` from the YAML roster and write it to disk.
 
     The routes file is written to the path configured in
     :class:`~terok_sandbox.SandboxConfig` (typically
@@ -537,7 +537,7 @@ def ensure_proxy_routes() -> Path:
     import tempfile
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    content = get_registry().generate_routes_json() + "\n"
+    content = get_roster().generate_routes_json() + "\n"
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     tmp = Path(tmp_name)
     try:

--- a/src/terok_agent/runner.py
+++ b/src/terok_agent/runner.py
@@ -29,7 +29,7 @@ from .build import BuildError, build_base_images
 if TYPE_CHECKING:
     from terok_sandbox import LifecycleHooks, Sandbox
 
-    from .registry import AgentRegistry
+    from .roster import AgentRoster
 
 _logger = logging.getLogger(__name__)
 
@@ -76,12 +76,12 @@ class AgentRunner:
         self,
         *,
         sandbox: Sandbox | None = None,
-        registry: AgentRegistry | None = None,
+        roster: AgentRoster | None = None,
         base_image: str = "ubuntu:24.04",
     ) -> None:
         self._base_image = base_image
         self._sandbox: Sandbox | None = sandbox
-        self._registry: AgentRegistry | None = registry
+        self._roster: AgentRoster | None = roster
 
     @property
     def sandbox(self) -> Sandbox:
@@ -93,13 +93,13 @@ class AgentRunner:
         return self._sandbox
 
     @property
-    def registry(self) -> AgentRegistry:
-        """Lazy-init agent registry."""
-        if self._registry is None:
-            from .registry import get_registry
+    def roster(self) -> AgentRoster:
+        """Lazy-init agent roster."""
+        if self._roster is None:
+            from .roster import get_roster
 
-            self._registry = get_registry()
-        return self._registry
+            self._roster = get_roster()
+        return self._roster
 
     def _ensure_images(self) -> str:
         """Ensure L0+L1 images exist, return L1 tag."""
@@ -107,21 +107,21 @@ class AgentRunner:
         return images.l1
 
     def _shared_mounts(self, envs_dir: Path) -> list[str]:
-        """Derive shared volume mounts from the agent registry.
+        """Derive shared volume mounts from the agent roster.
 
         Includes both auth config mounts (per-provider) and general mounts
         (e.g. OpenCode runtime dirs) from the ``mounts:`` YAML section.
         """
         seen: set[str] = set()
         mounts = []
-        for _name, ap in sorted(self.registry.auth_providers.items()):
+        for _name, ap in sorted(self.roster.auth_providers.items()):
             host_dir = envs_dir / ap.host_dir_name
             host_dir.mkdir(parents=True, exist_ok=True)
             mount = f"{host_dir}:{ap.container_mount}:z"
             if ap.host_dir_name not in seen:
                 mounts.append(mount)
                 seen.add(ap.host_dir_name)
-        for m in self.registry.mounts:
+        for m in self.roster.mounts:
             if m.host_dir not in seen:
                 host_dir = envs_dir / m.host_dir
                 host_dir.mkdir(parents=True, exist_ok=True)
@@ -189,7 +189,7 @@ class AgentRunner:
         if not (is_proxy_socket_active() or is_proxy_running(cfg)):
             return {}
 
-        proxy_routes = self.registry.proxy_routes
+        proxy_routes = self.roster.proxy_routes
         db = CredentialDB(cfg.proxy_db_path)
         try:
             credential_set = "default"
@@ -217,7 +217,7 @@ class AgentRunner:
             if route.base_url_env:
                 env[route.base_url_env] = proxy_base
             # Override OpenCode base URL for proxied providers
-            provider = self.registry.providers.get(name)
+            provider = self.roster.providers.get(name)
             if provider and provider.opencode_config:
                 oc_base_key = f"TEROK_OC_{name.upper()}_BASE_URL"
                 env[oc_base_key] = f"{proxy_base}/v1"
@@ -275,10 +275,10 @@ class AgentRunner:
         }
 
         # OpenCode provider env vars (TEROK_OC_* for Blablador, KISSKI, etc.)
-        env.update(self.registry.collect_opencode_provider_env())
+        env.update(self.roster.collect_opencode_provider_env())
 
-        # Git identity — use the agent's configured identity from registry
-        provider = self.registry.providers.get(provider_name)
+        # Git identity — use the agent's configured identity from roster
+        provider = self.roster.providers.get(provider_name)
         if provider:
             env["GIT_AUTHOR_NAME"] = provider.git_author_name
             env["GIT_AUTHOR_EMAIL"] = provider.git_author_email
@@ -501,7 +501,7 @@ class AgentRunner:
         """Unified launch flow for all three modes."""
         from .headless_providers import build_headless_command
 
-        agent = self.registry.get_provider(provider)
+        agent = self.roster.get_provider(provider)
         task_id = _generate_task_id()
         code_repo, local_path = _resolve_repo(repo)
 
@@ -544,7 +544,7 @@ class AgentRunner:
             workspace.mkdir(parents=True, exist_ok=True)
             volumes.append(f"{workspace}:/workspace:Z")
 
-        # Shared auth mounts (derived from registry)
+        # Shared auth mounts (derived from roster)
         volumes += self._shared_mounts(envs_dir)
 
         # Credential proxy: inject phantom tokens and base URL overrides
@@ -556,7 +556,7 @@ class AgentRunner:
         # Permission mode — unrestricted enables auto-approve for all agents
         if unrestricted:
             env["TEROK_UNRESTRICTED"] = "1"
-            env.update(self.registry.collect_all_auto_approve_env())
+            env.update(self.roster.collect_all_auto_approve_env())
 
         # Build command based on mode
         extra_args: list[str] = []

--- a/tach.toml
+++ b/tach.toml
@@ -78,12 +78,12 @@ depends_on = [
 [[modules]]
 path = "terok_agent.proxy_config"
 depends_on = [
-    "terok_agent.registry",
+    "terok_agent.roster",
 ]
 
-# YAML agent registry — loads bundled + user agent definitions
+# YAML agent roster — loads bundled + user agent definitions
 [[modules]]
-path = "terok_agent.registry"
+path = "terok_agent.roster"
 depends_on = [
     "terok_agent._util",
     "terok_agent.auth",
@@ -109,14 +109,14 @@ depends_on = [
     "terok_agent.build",
     "terok_agent.headless_providers",
     "terok_agent.instructions",
-    "terok_agent.registry",
+    "terok_agent.roster",
 ]
 
 # Credential proxy CLI commands — wraps sandbox lifecycle + route generation
 [[modules]]
 path = "terok_agent.proxy_commands"
 depends_on = [
-    "terok_agent.registry",
+    "terok_agent.roster",
 ]
 
 # Command registry — defines all CLI commands
@@ -126,7 +126,7 @@ depends_on = [
     "terok_agent.auth",
     "terok_agent.build",
     "terok_agent.proxy_config",
-    "terok_agent.registry",
+    "terok_agent.roster",
     "terok_agent.runner",
 ]
 
@@ -138,7 +138,7 @@ depends_on = [
     "terok_agent.proxy_commands",
 ]
 
-# Package root — public API re-exports + registry bootstrap
+# Package root — public API re-exports + roster bootstrap
 [[modules]]
 path = "terok_agent"
 depends_on = [
@@ -152,6 +152,6 @@ depends_on = [
     "terok_agent.headless_providers",
     "terok_agent.instructions",
     "terok_agent.proxy_commands",
-    "terok_agent.registry",
+    "terok_agent.roster",
     "terok_agent.runner",
 ]

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -125,9 +125,9 @@ class TestScanLeakedCredentials:
         from terok_agent import get_roster
         from terok_agent.proxy_commands import scan_leaked_credentials
 
-        registry = get_roster()
-        auth = registry.auth_providers.get("claude")
-        route = registry.proxy_routes.get("claude")
+        roster = get_roster()
+        auth = roster.auth_providers.get("claude")
+        route = roster.proxy_routes.get("claude")
         assert auth is not None and route is not None
 
         cred_dir = tmp_path / auth.host_dir_name
@@ -144,9 +144,9 @@ class TestScanLeakedCredentials:
         from terok_agent import get_roster
         from terok_agent.proxy_commands import scan_leaked_credentials
 
-        registry = get_roster()
-        auth = registry.auth_providers["claude"]
-        route = registry.proxy_routes["claude"]
+        roster = get_roster()
+        auth = roster.auth_providers["claude"]
+        route = roster.proxy_routes["claude"]
 
         cred_dir = tmp_path / auth.host_dir_name
         cred_dir.mkdir()
@@ -160,13 +160,13 @@ class TestScanLeakedCredentials:
 
         from terok_agent.proxy_commands import scan_leaked_credentials
 
-        # Mock a registry with a provider that has a proxy route but no credential_file
-        mock_registry = MagicMock()
+        # Mock a roster with a provider that has a proxy route but no credential_file
+        mock_roster = MagicMock()
         mock_route = MagicMock()
         mock_route.credential_file = ""
-        mock_registry.proxy_routes = {"fake-provider": mock_route}
-        mock_registry.auth_providers = {"fake-provider": MagicMock(host_dir_name="_fake")}
-        monkeypatch.setattr("terok_agent.roster.get_roster", lambda: mock_registry)
+        mock_roster.proxy_routes = {"fake-provider": mock_route}
+        mock_roster.auth_providers = {"fake-provider": MagicMock(host_dir_name="_fake")}
+        monkeypatch.setattr("terok_agent.roster.get_roster", lambda: mock_roster)
 
         assert scan_leaked_credentials(tmp_path) == []
 
@@ -177,9 +177,9 @@ class TestScanLeakedCredentials:
         from terok_agent import get_roster
         from terok_agent.proxy_commands import _handle_clean
 
-        registry = get_roster()
-        auth = registry.auth_providers["claude"]
-        route = registry.proxy_routes["claude"]
+        roster = get_roster()
+        auth = roster.auth_providers["claude"]
+        route = roster.proxy_routes["claude"]
 
         cred_dir = tmp_path / auth.host_dir_name
         cred_dir.mkdir()

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -11,15 +11,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from terok_agent.registry import get_registry
+from terok_agent.roster import get_roster
 
 
 class TestProxyRoutesParsed:
-    """Verify credential_proxy YAML sections are parsed into the registry."""
+    """Verify credential_proxy YAML sections are parsed into the roster."""
 
     def test_claude_route_exists(self) -> None:
         """Claude has a proxy route with Anthropic upstream."""
-        reg = get_registry()
+        reg = get_roster()
         route = reg.proxy_routes.get("claude")
         assert route is not None
         assert route.route_prefix == "claude"
@@ -30,21 +30,21 @@ class TestProxyRoutesParsed:
 
     def test_codex_route_exists(self) -> None:
         """Codex has a proxy route with OpenAI upstream."""
-        route = get_registry().proxy_routes.get("codex")
+        route = get_roster().proxy_routes.get("codex")
         assert route is not None
         assert route.upstream == "https://api.openai.com"
         assert "OPENAI_API_KEY" in route.phantom_env
 
     def test_gh_route_exists(self) -> None:
         """GitHub CLI has a proxy route with token-style auth."""
-        route = get_registry().proxy_routes.get("gh")
+        route = get_roster().proxy_routes.get("gh")
         assert route is not None
         assert route.auth_prefix == "token "
         assert route.upstream == "https://api.github.com"
 
     def test_glab_route_exists(self) -> None:
         """GitLab CLI has a proxy route with PRIVATE-TOKEN header."""
-        route = get_registry().proxy_routes.get("glab")
+        route = get_roster().proxy_routes.get("glab")
         assert route is not None
         assert route.auth_header == "PRIVATE-TOKEN"
         assert route.auth_prefix == ""
@@ -52,7 +52,7 @@ class TestProxyRoutesParsed:
 
     def test_opencode_agents_have_routes(self) -> None:
         """Blablador and KISSKI have proxy routes."""
-        reg = get_registry()
+        reg = get_roster()
         for name in ("blablador", "kisski"):
             route = reg.proxy_routes.get(name)
             assert route is not None, f"{name} missing proxy route"
@@ -60,11 +60,11 @@ class TestProxyRoutesParsed:
 
     def test_copilot_has_no_route(self) -> None:
         """Copilot has no credential_proxy section (tier-3, no base URL support)."""
-        assert get_registry().proxy_routes.get("copilot") is None
+        assert get_roster().proxy_routes.get("copilot") is None
 
     def test_claude_has_oauth_refresh(self) -> None:
         """Claude has oauth_refresh config for proactive token refresh."""
-        route = get_registry().proxy_routes.get("claude")
+        route = get_roster().proxy_routes.get("claude")
         assert route is not None
         assert route.oauth_refresh is not None
         assert "token_url" in route.oauth_refresh
@@ -72,7 +72,7 @@ class TestProxyRoutesParsed:
 
     def test_codex_has_no_oauth_refresh(self) -> None:
         """Codex does not yet have oauth_refresh configured."""
-        route = get_registry().proxy_routes.get("codex")
+        route = get_roster().proxy_routes.get("codex")
         assert route is not None
         assert route.oauth_refresh is None
 
@@ -82,7 +82,7 @@ class TestGenerateRoutesJson:
 
     def test_generates_valid_json(self) -> None:
         """generate_routes_json() produces parseable JSON with expected keys."""
-        routes_json = get_registry().generate_routes_json()
+        routes_json = get_roster().generate_routes_json()
         routes = json.loads(routes_json)
         assert "claude" in routes
         assert routes["claude"]["upstream"] == "https://api.anthropic.com"
@@ -90,24 +90,24 @@ class TestGenerateRoutesJson:
 
     def test_all_routes_have_upstream(self) -> None:
         """Every route in the JSON has an upstream field."""
-        routes = json.loads(get_registry().generate_routes_json())
+        routes = json.loads(get_roster().generate_routes_json())
         for prefix, cfg in routes.items():
             assert "upstream" in cfg, f"Route '{prefix}' missing upstream"
 
     def test_glab_keyed_by_provider_name(self) -> None:
         """GitLab route is keyed by provider name 'glab'."""
-        routes = json.loads(get_registry().generate_routes_json())
+        routes = json.loads(get_roster().generate_routes_json())
         assert "glab" in routes
 
     def test_claude_routes_json_includes_oauth_refresh(self) -> None:
         """Claude's routes.json entry includes oauth_refresh config."""
-        routes = json.loads(get_registry().generate_routes_json())
+        routes = json.loads(get_roster().generate_routes_json())
         assert "oauth_refresh" in routes["claude"]
         assert routes["claude"]["oauth_refresh"]["client_id"]
 
     def test_gh_routes_json_omits_oauth_refresh(self) -> None:
         """Providers without oauth_refresh omit it from routes.json."""
-        routes = json.loads(get_registry().generate_routes_json())
+        routes = json.loads(get_roster().generate_routes_json())
         assert "oauth_refresh" not in routes["gh"]
 
 
@@ -122,10 +122,10 @@ class TestScanLeakedCredentials:
 
     def test_detects_nonempty_credential_file(self, tmp_path) -> None:
         """Returns (provider, path) when a credential file is present and non-empty."""
-        from terok_agent import get_registry
+        from terok_agent import get_roster
         from terok_agent.proxy_commands import scan_leaked_credentials
 
-        registry = get_registry()
+        registry = get_roster()
         auth = registry.auth_providers.get("claude")
         route = registry.proxy_routes.get("claude")
         assert auth is not None and route is not None
@@ -141,10 +141,10 @@ class TestScanLeakedCredentials:
 
     def test_skips_empty_files(self, tmp_path) -> None:
         """Empty credential files are not flagged."""
-        from terok_agent import get_registry
+        from terok_agent import get_roster
         from terok_agent.proxy_commands import scan_leaked_credentials
 
-        registry = get_registry()
+        registry = get_roster()
         auth = registry.auth_providers["claude"]
         route = registry.proxy_routes["claude"]
 
@@ -166,7 +166,7 @@ class TestScanLeakedCredentials:
         mock_route.credential_file = ""
         mock_registry.proxy_routes = {"fake-provider": mock_route}
         mock_registry.auth_providers = {"fake-provider": MagicMock(host_dir_name="_fake")}
-        monkeypatch.setattr("terok_agent.registry.get_registry", lambda: mock_registry)
+        monkeypatch.setattr("terok_agent.roster.get_roster", lambda: mock_registry)
 
         assert scan_leaked_credentials(tmp_path) == []
 
@@ -174,10 +174,10 @@ class TestScanLeakedCredentials:
         """The clean handler removes detected credential files."""
         from unittest.mock import patch
 
-        from terok_agent import get_registry
+        from terok_agent import get_roster
         from terok_agent.proxy_commands import _handle_clean
 
-        registry = get_registry()
+        registry = get_roster()
         auth = registry.auth_providers["claude"]
         route = registry.proxy_routes["claude"]
 
@@ -355,13 +355,13 @@ class TestEnsureProxyRoutes:
         mock_cfg.proxy_routes_path = tmp_path / "proxy" / "routes.json"
         monkeypatch.setattr(terok_sandbox, "SandboxConfig", lambda: mock_cfg)
 
-        from terok_agent.registry import ensure_proxy_routes
+        from terok_agent.roster import ensure_proxy_routes
 
         path = ensure_proxy_routes()
 
         assert path == mock_cfg.proxy_routes_path
         assert path.is_file()
         routes = json.loads(path.read_text())
-        # Should have at least claude route from the YAML registry
+        # Should have at least claude route from the YAML roster
         assert "claude" in routes
         assert "upstream" in routes["claude"]

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the YAML agent registry loader."""
+"""Tests for the YAML agent roster loader."""
 
 from __future__ import annotations
 
@@ -12,11 +12,11 @@ import pytest
 
 from terok_agent.auth import AuthProvider
 from terok_agent.headless_providers import HeadlessProvider
-from terok_agent.registry import (
+from terok_agent.roster import (
     _load_bundled_agents,
     _to_auth_provider,
     _to_headless_provider,
-    load_registry,
+    load_roster,
 )
 
 
@@ -24,7 +24,7 @@ from terok_agent.registry import (
 def _isolate_user_agents_dir(tmp_path: Path) -> None:
     """Prevent real ~/.config/terok-agent/agents/ from leaking into tests."""
     isolated = tmp_path / "empty-agents"
-    with patch("terok_agent.registry._user_agents_dir", return_value=isolated):
+    with patch("terok_agent.roster._user_agents_dir", return_value=isolated):
         yield
 
 
@@ -198,35 +198,35 @@ class TestLoadRegistry:
     """Integration tests for the complete registry load cycle."""
 
     def test_loads_all_agents(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         expected_agents = {"claude", "codex", "copilot", "vibe", "blablador", "kisski", "opencode"}
         assert set(reg.agent_names) == expected_agents
 
     def test_all_names_includes_tools(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         assert "gh" in reg.all_names
         assert "glab" in reg.all_names
         assert "claude" in reg.all_names
 
     def test_providers_only_agents(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         assert "gh" not in reg.providers
         assert "glab" not in reg.providers
         assert "claude" in reg.providers
 
     def test_auth_includes_tools(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         assert "gh" in reg.auth_providers
         assert "glab" in reg.auth_providers
 
     def test_auth_includes_opencode_derived(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         # blablador has no explicit auth section but has opencode config → auto-derived
         assert "blablador" in reg.auth_providers
         assert "kisski" in reg.auth_providers
 
     def test_mounts_include_auth_dirs(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         mount_dirs = {m.host_dir for m in reg.mounts}
         assert "_claude-config" in mount_dirs
         assert "_codex-config" in mount_dirs
@@ -234,7 +234,7 @@ class TestLoadRegistry:
         assert "_glab-config" in mount_dirs
 
     def test_mounts_include_extra_dirs(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         mount_dirs = {m.host_dir for m in reg.mounts}
         assert "_opencode-config" in mount_dirs
         assert "_opencode-data" in mount_dirs
@@ -242,39 +242,39 @@ class TestLoadRegistry:
         assert "_toad-config" in mount_dirs
 
     def test_mounts_deduplicated(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         host_dirs = [m.host_dir for m in reg.mounts]
         assert len(host_dirs) == len(set(host_dirs))
 
     def test_get_provider_resolves(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         p = reg.get_provider("codex")
         assert p.name == "codex"
 
     def test_get_provider_fallback(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         p = reg.get_provider(None)
         assert p.name == "claude"
 
     def test_get_provider_unknown_exits(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         with pytest.raises(SystemExit, match="Unknown headless provider"):
             reg.get_provider("nonexistent")
 
     def test_get_auth_provider_unknown_exits(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         with pytest.raises(SystemExit, match="Unknown auth provider"):
             reg.get_auth_provider("nonexistent")
 
     def test_collect_all_auto_approve_env(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         env = reg.collect_all_auto_approve_env()
         assert "COPILOT_ALLOW_ALL" in env
         assert "VIBE_AUTO_APPROVE" in env
         assert "OPENCODE_PERMISSION" in env
 
     def test_collect_opencode_provider_env(self) -> None:
-        reg = load_registry()
+        reg = load_roster()
         env = reg.collect_opencode_provider_env()
         assert any(k.startswith("TEROK_OC_BLABLADOR_") for k in env)
         assert any(k.startswith("TEROK_OC_KISSKI_") for k in env)
@@ -294,8 +294,8 @@ class TestUserOverrides:
         user_dir.mkdir()
         (user_dir / "claude.yaml").write_text("tier: 99\n")
 
-        with patch("terok_agent.registry._user_agents_dir", return_value=user_dir):
-            reg = load_registry()
+        with patch("terok_agent.roster._user_agents_dir", return_value=user_dir):
+            reg = load_roster()
 
         # Provider still loads correctly, tier is just metadata
         p = reg.get_provider("claude")
@@ -314,8 +314,8 @@ class TestUserOverrides:
             "capabilities:\n  log_format: plain\n"
         )
 
-        with patch("terok_agent.registry._user_agents_dir", return_value=user_dir):
-            reg = load_registry()
+        with patch("terok_agent.roster._user_agents_dir", return_value=user_dir):
+            reg = load_roster()
 
         assert "custom" in reg.agent_names
         p = reg.get_provider("custom")
@@ -333,8 +333,8 @@ class TestUserOverrides:
             "  banner_hint: Authenticate.\n"
         )
 
-        with patch("terok_agent.registry._user_agents_dir", return_value=user_dir):
-            reg = load_registry()
+        with patch("terok_agent.roster._user_agents_dir", return_value=user_dir):
+            reg = load_roster()
 
         assert "mytool" in reg.all_names
         assert "mytool" not in reg.agent_names  # it's a tool, not an agent
@@ -343,8 +343,8 @@ class TestUserOverrides:
 
     def test_no_user_dir_ok(self, tmp_path: Path) -> None:
         """Missing user dir is fine — only bundled agents are loaded."""
-        with patch("terok_agent.registry._user_agents_dir", return_value=tmp_path / "nonexistent"):
-            reg = load_registry()
+        with patch("terok_agent.roster._user_agents_dir", return_value=tmp_path / "nonexistent"):
+            reg = load_roster()
 
         assert "claude" in reg.agent_names
 
@@ -359,7 +359,7 @@ class TestRegistryBehavior:
 
     def test_every_agent_has_valid_headless_provider(self) -> None:
         """Each agent deserializes into a HeadlessProvider with required fields."""
-        reg = load_registry()
+        reg = load_roster()
         for name in reg.agent_names:
             p = reg.get_provider(name)
             assert isinstance(p, HeadlessProvider)
@@ -372,7 +372,7 @@ class TestRegistryBehavior:
 
     def test_every_auth_provider_has_valid_config(self) -> None:
         """Each auth provider has mount paths and at least one auth mode."""
-        reg = load_registry()
+        reg = load_roster()
         for name, ap in reg.auth_providers.items():
             assert isinstance(ap, AuthProvider)
             assert ap.host_dir_name, f"{name}: empty host_dir"
@@ -384,7 +384,7 @@ class TestRegistryBehavior:
 
     def test_opencode_providers_have_complete_config(self) -> None:
         """Providers with opencode config have all required fields populated."""
-        reg = load_registry()
+        reg = load_roster()
         for name, p in reg.providers.items():
             if p.opencode_config is None:
                 continue
@@ -398,7 +398,7 @@ class TestRegistryBehavior:
 
     def test_auto_approve_env_values_are_strings(self) -> None:
         """Auto-approve env values must be strings (injected into container env)."""
-        reg = load_registry()
+        reg = load_roster()
         for name, p in reg.providers.items():
             for k, v in p.auto_approve_env.items():
                 assert isinstance(k, str), f"{name}: env key {k!r} not str"
@@ -406,7 +406,7 @@ class TestRegistryBehavior:
 
     def test_session_resume_consistency(self) -> None:
         """Providers with session resume must have a resume_flag."""
-        reg = load_registry()
+        reg = load_roster()
         for name, p in reg.providers.items():
             if p.supports_session_resume:
                 assert p.resume_flag, f"{name}: supports_resume but no resume_flag"

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -58,12 +58,12 @@ class TestAgentRunner:
         runner = AgentRunner(base_image="nvidia/cuda:12.4")
         assert runner._base_image == "nvidia/cuda:12.4"
 
-    def test_lazy_registry(self) -> None:
+    def test_lazy_roster(self) -> None:
         runner = AgentRunner()
-        reg = runner.registry
+        reg = runner.roster
         assert "claude" in reg.agent_names
 
-    def test_shared_mounts_from_registry(self, tmp_path: Path) -> None:
+    def test_shared_mounts_from_roster(self, tmp_path: Path) -> None:
         runner = AgentRunner()
         mounts = runner._shared_mounts(tmp_path)
         # Should have mounts for agents with auth (claude, codex, vibe, gh, glab, etc.)


### PR DESCRIPTION
## Summary

Rename the YAML agent definitions module from "registry" to "roster" to
eliminate naming confusion with CLI command registries (AGENT_COMMANDS, etc.).

- `registry.py` → `roster.py`
- `AgentRegistry` → `AgentRoster`
- `get_registry()` → `get_roster()` / `load_registry()` → `load_roster()`
- All imports, tach.toml boundaries, docstrings, test file names updated
- CLI command registries (AGENT_COMMANDS, PROXY_COMMANDS, CommandDef) unchanged

Pure rename — zero behavior changes.

Closes #51

## Test plan

- [x] 299 unit tests pass
- [x] Lint + format + tach clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced "registry" terminology with "roster" across the app for clearer agent data handling.
  * Breaking change: AgentRunner now exposes roster-oriented API (previous registry-based property renamed).

* **Documentation**
  * Updated user-facing help and docstrings to reference the YAML "roster" terminology.

* **Tests**
  * Test suite updated to exercise the roster-based behavior and ensure parity with prior functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->