### PR TITLE
feat: display credential leak warning in hilfe banner

### DIFF
--- a/src/terok_agent/resources/scripts/hilfe
+++ b/src/terok_agent/resources/scripts/hilfe
@@ -19,6 +19,15 @@ case "$_mode" in
         ;;
 esac
 
+_terok_credential_warning() {
+    if [[ -n "${TEROK_LEAKED_CREDENTIALS:-}" ]]; then
+        printf '\n\033[1;31m[!] Real credentials detected in shared mounts\033[0m\n'
+        printf '    Providers: \033[33m%s\033[0m\n' "$TEROK_LEAKED_CREDENTIALS"
+        printf '    These files bypass the credential proxy and expose secrets to this container.\n'
+        printf '    On the host: \033[36mterokctl credentials clean\033[0m — then restart the container.\n'
+    fi
+}
+
 _terok_permission_mode() {
     if [[ "${TEROK_UNRESTRICTED:-}" == "1" ]]; then
         printf '\n\033[1mPermission mode:\033[0m \033[32munrestricted\033[0m\n'
@@ -57,6 +66,7 @@ _terok_notes() {
     printf '  - the container is disposable; \033[36msudo\033[0m works without a password\n'
 }
 
+_terok_credential_warning
 _terok_permission_mode
 _terok_agents
 


### PR DESCRIPTION
## Summary

- Adds `_terok_credential_warning()` to `hilfe`, shown at the top of both the `--kurz` login greeting and the full `hilfe` output
- Reads `TEROK_LEAKED_CREDENTIALS` (comma-separated provider names, injected by terok at container launch when real credential files are found in shared mounts)
- Message names the affected providers in yellow and directs the operator to `terokctl credentials clean` on the host + restart the container

Companion PR in terok: injects the env var — terok-ai/terok#568 (to be opened separately).

No new dependencies. The warning is silently absent when the env var is unset (clean state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a security warning that detects and alerts when credentials are accidentally found in shared container mounts, with instructions to clean them and restart the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->