### PR TITLE
fix: convert Claude Code JS millisecond expiresAt to POSIX seconds

### DIFF
--- a/src/terok_agent/credential_extractors.py
+++ b/src/terok_agent/credential_extractors.py
@@ -58,11 +58,21 @@ def extract_claude_oauth(base_dir: Path) -> dict:
         if isinstance(oauth, dict):
             access_token = oauth.get("accessToken")
             if access_token:
+                # Claude Code is a JS app: expiresAt is milliseconds since
+                # epoch (Date.now() convention).  Values > 1e12 are
+                # unambiguously ms; convert to POSIX seconds so the proxy
+                # refresh check (time.time()) works correctly.
+                expires_at_raw = oauth.get("expiresAt")
+                expires_at: float | None = None
+                if isinstance(expires_at_raw, (int, float)) and not isinstance(
+                    expires_at_raw, bool
+                ):
+                    expires_at = expires_at_raw / 1000 if expires_at_raw > 1e12 else expires_at_raw
                 return {
                     "type": "oauth",
                     "access_token": access_token,
                     "refresh_token": oauth.get("refreshToken", ""),
-                    "expires_at": oauth.get("expiresAt"),
+                    "expires_at": expires_at,
                 }
 
     # Fall back to API key (config.json)

--- a/tests/unit/test_credential_extractors.py
+++ b/tests/unit/test_credential_extractors.py
@@ -38,6 +38,42 @@ class TestClaudeOAuth:
         assert result["access_token"] == "sk-ant-test-123"
         assert result["refresh_token"] == "rt-test-456"
         assert result["type"] == "oauth"
+        assert result["expires_at"] == 1700000000  # seconds value kept as-is
+
+    def test_converts_ms_expires_at_to_seconds(self, tmp_path: Path) -> None:
+        """expiresAt from Claude Code (JS ms timestamp) is converted to POSIX seconds."""
+        expires_at_ms = 1_700_000_000_000  # realistic Claude Code value (ms)
+        cred = {
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-ms-test",
+                "refreshToken": "rt-ms",
+                "expiresAt": expires_at_ms,
+            }
+        }
+        (tmp_path / ".credentials.json").write_text(json.dumps(cred))
+        result = extract_claude_oauth(tmp_path)
+        assert result["expires_at"] == pytest.approx(expires_at_ms / 1000)
+
+    def test_missing_expires_at_stored_as_none(self, tmp_path: Path) -> None:
+        """Missing expiresAt field results in expires_at=None (triggers proactive refresh)."""
+        cred = {"claudeAiOauth": {"accessToken": "sk-ant-no-exp", "refreshToken": "rt-no-exp"}}
+        (tmp_path / ".credentials.json").write_text(json.dumps(cred))
+        result = extract_claude_oauth(tmp_path)
+        assert result["expires_at"] is None
+
+    @pytest.mark.parametrize("bad_value", ["1700000000000", True, False, None])
+    def test_non_numeric_expires_at_stored_as_none(self, tmp_path: Path, bad_value: object) -> None:
+        """Non-numeric expiresAt (string, bool, null) is ignored; expires_at falls back to None."""
+        cred = {
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-bad-exp",
+                "refreshToken": "rt-bad",
+                "expiresAt": bad_value,
+            }
+        }
+        (tmp_path / ".credentials.json").write_text(json.dumps(cred))
+        result = extract_claude_oauth(tmp_path)
+        assert result["expires_at"] is None
 
     def test_extracts_api_key_fallback(self, tmp_path: Path) -> None:
         """Falls back to config.json API key when no OAuth credentials."""


### PR DESCRIPTION
## Summary

- **Root cause**: `extract_claude_oauth` stored the raw `expiresAt` value from `.credentials.json` without conversion. Claude Code (Node.js) uses `Date.now()` — milliseconds — so the DB contained e.g. `1_700_000_000_000`. The proxy refresh loop (`time.time()`, seconds) then treated every token as valid for ~55 000 years and never refreshed it.
- **Fix**: apply a `> 1e12` guard in `extract_claude_oauth`: ms-range values are divided by 1000 before storage. Missing `expiresAt` is stored as `None` (triggers proactive refresh). Seconds-range values are stored as-is.
- **Tests** (3 new in `TestClaudeOAuth`):
  - `test_converts_ms_expires_at_to_seconds` — `1_700_000_000_000 ms` → `1_700_000_000.0 s`
  - `test_missing_expires_at_stored_as_none` — absent field → `None`
  - `test_extracts_oauth_token` updated to assert `expires_at == 1700000000` (the existing seconds-range fixture)

## Test plan

- [x] `pytest tests/unit/test_credential_extractors.py::TestClaudeOAuth` — all pass
- [x] `pytest tests/unit/` — 301 passed, 0 failures
- [x] `ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize OAuth credential expiration timestamps so millisecond and second values are handled consistently, improving expiration accuracy.

* **Tests**
  * Added unit tests covering timestamp conversion, missing timestamps, and non-numeric values to ensure robust handling of edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->