### PR TITLE
ci: skip SonarQube scan on dependabot PRs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -146,7 +146,7 @@ jobs:
 
   sonar:
     name: SonarQube Cloud
-    if: github.repository == 'terok-ai/terok-agent' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.repository == 'terok-ai/terok-agent' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     needs: [unit-tests, ruff, bandit]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Gate the `sonar` job on `github.actor != 'dependabot[bot]'` so it doesn't fire on dependabot PRs (which lack `SONAR_TOKEN` access)
- Pushes to master and human-authored PRs are unaffected

## Test plan
- [ ] Verify next dependabot PR no longer shows a failed SonarQube check
- [ ] Verify a human PR still triggers the SonarQube scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined code analysis workflow execution conditions to exclude automated dependency management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->