### PR TITLE
ci: scope dependabot Sonar exclusion to PR events only

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -146,7 +146,7 @@ jobs:
 
   sonar:
     name: SonarQube Cloud
-    if: github.repository == 'terok-ai/terok-agent' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.repository == 'terok-ai/terok-agent' && (github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
     needs: [unit-tests, ruff, bandit]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Fix the dependabot exclusion from the previous PR — scope it to `pull_request` events only
- The previous version (`github.actor != 'dependabot[bot]'` at top level) would also skip the Sonar scan on push-to-master when dependabot merges
- New logic: `event == 'push' || (actor != 'dependabot[bot]' && head_repo == repo)`

## Test plan
- [ ] Verify dependabot PR skips Sonar
- [ ] Verify push to master (including dependabot merge) still triggers Sonar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality analysis pipeline to run more consistently across all push events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->