### PR TITLE
chore: pin terok-sandbox to own-namespace branch

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2413,13 +2413,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.20"
+version = "0.0.21"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.20-py3-none-any.whl", hash = "sha256:04bb143e09a6b6312c760dbdde55006f1fe4e2d7015e69b4c5d19a0b29e24648"},
+    {file = "terok_sandbox-0.0.21-py3-none-any.whl", hash = "sha256:c23a63fe93db9e3483815b0f38ae9255dfd7ca8790d887ee182eb193c3ce0c4b"},
 ]
 
 [package.dependencies]
@@ -2430,7 +2430,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.20/terok_sandbox-0.0.20-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.21/terok_sandbox-0.0.21-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2815,4 +2815,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "7c7c8353ec7725f36ef1b747845408fecdc8ade790fe8b9e00a32c2ed693a1b3"
+content-hash = "99b390e8fa33971dd7ae9b309471a9e6ab2fec7e3e2b4d7a9f6e74d8d7e717f6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.22"
+version = "0.0.23"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.20/terok_sandbox-0.0.20-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.21/terok_sandbox-0.0.21-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -326,7 +326,7 @@ class TestCredentialProxyEnv:
 
         # SandboxConfig derives proxy_db_path from state_dir, so set state_dir
         # to tmp_path and create the DB at the expected location.
-        cfg = SandboxConfig(state_dir=tmp_path)
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
         cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
 
         db = CredentialDB(cfg.proxy_db_path)
@@ -355,7 +355,7 @@ class TestCredentialProxyEnv:
         """When credentials exist but none map to proxy routes, returns empty."""
         from terok_sandbox import CredentialDB, SandboxConfig
 
-        cfg = SandboxConfig(state_dir=tmp_path)
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
         cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
 
         db = CredentialDB(cfg.proxy_db_path)


### PR DESCRIPTION
## Summary

- Pins `terok-sandbox` to sliwowitz/terok-sandbox@`chore/own-namespace` commit SHA for end-to-end testing
- No source code changes — all `SandboxConfig` property names are unchanged; path values change transparently
- Will be replaced with a release wheel pin after terok-ai/terok-sandbox#53 merges

## Context

Part of terok-ai/terok#532 (directory ownership restructuring). Phase 2 of the 3-phase plan:
1. terok-ai/terok-sandbox#53 — sandbox gets own namespace
2. **This PR** — agent bumps sandbox dep
3. terok-ai/terok (next) — orchestrator renames + credentials_dir

## Test plan

- [ ] `poetry install` resolves cleanly
- [ ] All existing tests pass (no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Project version bumped to 0.0.23 and the sandbox dependency updated to a newer fixed build for more reproducible installs.
* **Tests**
  * Unit tests refined to explicitly set credential paths and more precisely validate proxy-related environment behavior, improving test clarity and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->