### PR TITLE
deps: relay upgraded sandbox conduit — terok-sandbox 0.0.20

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2413,34 +2413,34 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.19"
+version = "0.0.20"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.19-py3-none-any.whl", hash = "sha256:304b7eddd4db73dd44bdea421299fe3ae7825aedd25db4dc723518cf2a82f324"},
+    {file = "terok_sandbox-0.0.20-py3-none-any.whl", hash = "sha256:04bb143e09a6b6312c760dbdde55006f1fe4e2d7015e69b4c5d19a0b29e24648"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.1/terok_shield-0.5.1-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.2/terok_shield-0.5.2-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.19/terok_sandbox-0.0.19-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.20/terok_sandbox-0.0.20-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.5.1"
+version = "0.5.2"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.5.1-py3-none-any.whl", hash = "sha256:9b41059a932cdd4fa4539a8345dd4bfb449ce0d116e5beaec4a2842dc1dc26b4"},
+    {file = "terok_shield-0.5.2-py3-none-any.whl", hash = "sha256:efe934014e5c4844d3067324775cfb5dac2182f2c595b4eb7ce40c31993351e1"},
 ]
 
 [package.dependencies]
@@ -2448,7 +2448,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.1/terok_shield-0.5.1-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.2/terok_shield-0.5.2-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -2815,4 +2815,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "c114e4935b112666c4a6ee4fd71249169707e9e7de96fd90e7aa6c68c4674e88"
+content-hash = "7c7c8353ec7725f36ef1b747845408fecdc8ade790fe8b9e00a32c2ed693a1b3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.21"
+version = "0.0.22"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.19/terok_sandbox-0.0.19-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.20/terok_sandbox-0.0.20-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"


### PR DESCRIPTION
## Summary

- Upgrade terok-sandbox wheel from 0.0.19 to 0.0.20
- Bump agent version to 0.0.22

Propagates terok-shield 0.5.2 (shield watch, nflog-ready nft rules, dnsmasq query logging) through the dependency chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.0.22.
  * Updated internal dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->