### PR TITLE
feat: own agent namespace with mounts_dir(), decouple from sandbox envs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2413,13 +2413,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.21"
+version = "0.0.22"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.21-py3-none-any.whl", hash = "sha256:c23a63fe93db9e3483815b0f38ae9255dfd7ca8790d887ee182eb193c3ce0c4b"},
+    {file = "terok_sandbox-0.0.22-py3-none-any.whl", hash = "sha256:7712ea22a0cea65a43d051073a5aee7d8cdcc1f765c5e2e72e9e18b69de4d62d"},
 ]
 
 [package.dependencies]
@@ -2429,8 +2429,8 @@ platformdirs = ">=4.0"
 terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.2/terok_shield-0.5.2-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.21/terok_sandbox-0.0.21-py3-none-any.whl"
+type = "file"
+url = "../../..https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.22/terok_sandbox-0.0.22-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2815,4 +2815,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "99b390e8fa33971dd7ae9b309471a9e6ab2fec7e3e2b4d7a9f6e74d8d7e717f6"
+content-hash = "106f4bdd070ea7ed435ed55093d070747e0d4c80bfb50a58990c122e74867b29"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2429,8 +2429,8 @@ platformdirs = ">=4.0"
 terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.2/terok_shield-0.5.2-py3-none-any.whl"}
 
 [package.source]
-type = "file"
-url = "../../..https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.22/terok_sandbox-0.0.22-py3-none-any.whl"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.22/terok_sandbox-0.0.22-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2815,4 +2815,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "106f4bdd070ea7ed435ed55093d070747e0d4c80bfb50a58990c122e74867b29"
+content-hash = "b39dd2caa3d121566e3aa036faef5b6072a82a1d9becf9b9ff5934c407fdda42"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.23"
+version = "0.0.24"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.21/terok_sandbox-0.0.21-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.22/terok_sandbox-0.0.22-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -94,6 +94,7 @@ from .headless_providers import (
 
 # -- Instructions --------------------------------------------------------------
 from .instructions import bundled_default_instructions, resolve_instructions
+from .paths import mounts_dir
 from .proxy_commands import PROXY_COMMANDS, scan_leaked_credentials
 from .roster import CredentialProxyRoute, ensure_proxy_routes, get_roster
 
@@ -169,6 +170,7 @@ __all__ = [
     "AGENT_COMMANDS",
     "PROXY_COMMANDS",
     "CommandDef",
+    "mounts_dir",
     "scan_leaked_credentials",
     # Runner facade
     "AgentRunner",

--- a/src/terok_agent/agents.py
+++ b/src/terok_agent/agents.py
@@ -405,7 +405,7 @@ class AgentConfigSpec:
     provider: str = "claude"
     instructions: str | None = None
     default_agent: str | None = None
-    envs_base_dir: Path | None = None
+    mounts_base: Path | None = None
 
     def __post_init__(self) -> None:
         """Coerce mutable sequences to tuples for true immutability."""
@@ -471,14 +471,14 @@ def prepare_agent_config_dir(spec: AgentConfigSpec) -> Path:
     # interactive and headless modes).
     from .headless_providers import HEADLESS_PROVIDERS
 
-    envs_base = spec.envs_base_dir
-    if envs_base is None:
-        raise ValueError("envs_base_dir is required in AgentConfigSpec")
-    _inject_opencode_instructions(envs_base / "_opencode-config" / "opencode.json")
+    mounts_base = spec.mounts_base
+    if mounts_base is None:
+        raise ValueError("mounts_base is required in AgentConfigSpec")
+    _inject_opencode_instructions(mounts_base / "_opencode-config" / "opencode.json")
     for _p in HEADLESS_PROVIDERS.values():
         if _p.opencode_config is not None:
             _inject_opencode_instructions(
-                envs_base / f"_{_p.name}-config" / "opencode" / "opencode.json"
+                mounts_base / f"_{_p.name}-config" / "opencode" / "opencode.json"
             )
 
     # Write shell wrapper functions for ALL providers so interactive CLI users
@@ -502,7 +502,7 @@ def prepare_agent_config_dir(spec: AgentConfigSpec) -> Path:
 
     # Write SessionStart hook — only for providers that support it (Claude)
     if resolved.supports_session_hook:
-        shared_claude_dir = envs_base / "_claude-config"
+        shared_claude_dir = mounts_base / "_claude-config"
         ensure_dir_writable(shared_claude_dir, "_claude-config")
         _write_session_hook(shared_claude_dir / "settings.json")
 

--- a/src/terok_agent/auth.py
+++ b/src/terok_agent/auth.py
@@ -37,7 +37,7 @@ class AuthProvider:
     """Human-readable display name (e.g. ``"Codex"``)."""
 
     host_dir_name: str
-    """Directory name under ``get_envs_base_dir()`` (e.g. ``"_codex-config"``)."""
+    """Directory name under ``mounts_dir()`` (e.g. ``"_codex-config"``)."""
 
     container_mount: str
     """Mount point inside the container (e.g. ``"/home/dev/.codex"``)."""
@@ -150,7 +150,7 @@ def _run_auth_container(
     project_id: str,
     provider: AuthProvider,
     *,
-    envs_base_dir: Path,
+    mounts_dir: Path,
     image: str,
     credential_set: str = "default",
 ) -> None:
@@ -293,7 +293,7 @@ def authenticate(
     project_id: str,
     provider: str,
     *,
-    envs_base_dir: Path,
+    mounts_dir: Path,
     image: str,
 ) -> None:
     """Run the auth flow for *provider* against *project_id*.
@@ -307,7 +307,7 @@ def authenticate(
     Args:
         project_id: Project identifier (for container naming).
         provider: Auth provider name (e.g. ``"claude"``).
-        envs_base_dir: Base directory for shared env mounts.
+        mounts_dir: Base directory for shared config bind-mounts.
         image: Container image to use for the auth container.
 
     Raises ``SystemExit`` if the provider name is unknown.
@@ -329,7 +329,7 @@ def authenticate(
             store_api_key(provider, key)
             return
         # choice == "1" or anything else → OAuth
-        _run_auth_container(project_id, info, envs_base_dir=envs_base_dir, image=image)
+        _run_auth_container(project_id, info, mounts_dir=mounts_dir, image=image)
 
     elif info.supports_api_key:
         # API key only — fast path, no container
@@ -338,4 +338,4 @@ def authenticate(
 
     else:
         # OAuth only
-        _run_auth_container(project_id, info, envs_base_dir=envs_base_dir, image=image)
+        _run_auth_container(project_id, info, mounts_dir=mounts_dir, image=image)

--- a/src/terok_agent/commands.py
+++ b/src/terok_agent/commands.py
@@ -163,10 +163,9 @@ def _handle_auth(*, agent: str, api_key: str | None = None) -> None:
         from .build import l1_image_tag
 
         image = l1_image_tag("ubuntu:24.04")
-        from terok_sandbox import SandboxConfig
+        from .paths import mounts_dir
 
-        cfg = SandboxConfig()
-        authenticate("standalone", agent, envs_base_dir=cfg.effective_envs_dir, image=image)
+        authenticate("standalone", agent, mounts_dir=mounts_dir(), image=image)
 
     # Write proxy URLs to shared config files (e.g. Vibe config.toml, gh config.yml)
     from .proxy_config import write_proxy_config

--- a/src/terok_agent/paths.py
+++ b/src/terok_agent/paths.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Platform-aware path resolution for terok-agent directories.
+
+Provides XDG / FHS resolution for the agent's own state directory,
+independent of terok-sandbox's namespace.
+"""
+
+import getpass
+import os
+from pathlib import Path
+
+try:
+    from platformdirs import user_data_dir as _user_data_dir
+except ImportError:  # optional dependency
+    _user_data_dir = None  # type: ignore[assignment]
+
+
+APP_NAME = "terok-agent"
+
+
+def _is_root() -> bool:
+    """Return True if the current process is running as root."""
+    try:
+        return os.geteuid() == 0  # type: ignore[attr-defined]
+    except AttributeError:
+        return getpass.getuser() == "root"
+
+
+def state_root() -> Path:
+    """Writable state root for agent-owned data.
+
+    Priority: ``TEROK_AGENT_STATE_DIR`` → ``/var/lib/terok-agent`` (root)
+    → ``platformdirs.user_data_dir()`` → ``$XDG_DATA_HOME/terok-agent``
+    → ``~/.local/share/terok-agent``.
+    """
+    env = os.getenv("TEROK_AGENT_STATE_DIR")
+    if env:
+        return Path(env).expanduser()
+    if _is_root():
+        return Path("/var/lib") / APP_NAME
+    if _user_data_dir is not None:
+        return Path(_user_data_dir(APP_NAME))
+    xdg = os.getenv("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / APP_NAME
+    return Path.home() / ".local" / "share" / APP_NAME
+
+
+def mounts_dir() -> Path:
+    """Base directory for agent config bind-mounts.
+
+    Each agent/tool gets a subdirectory (e.g. ``_claude-config/``) that is
+    bind-mounted read-write into task containers.  These directories are
+    intentionally separated from the credentials store since they are
+    container-exposed and subject to potential poisoning.
+    """
+    return state_root() / "mounts"

--- a/src/terok_agent/proxy_commands.py
+++ b/src/terok_agent/proxy_commands.py
@@ -46,7 +46,7 @@ def _handle_stop() -> None:
     print("Credential proxy stopped.")
 
 
-def scan_leaked_credentials(envs_base: Path) -> list[tuple[str, Path]]:
+def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     """Return ``(provider, host_path)`` for credential files found in shared mounts.
 
     When the credential proxy is active, real secrets should only live in the
@@ -65,7 +65,7 @@ def scan_leaked_credentials(envs_base: Path) -> list[tuple[str, Path]]:
         if not auth:
             continue
         try:
-            path = envs_base / auth.host_dir_name / route.credential_file
+            path = mounts_base / auth.host_dir_name / route.credential_file
             if path.is_file() and path.stat().st_size > 0:
                 leaked.append((name, path))
         except (OSError, TypeError):
@@ -75,7 +75,9 @@ def scan_leaked_credentials(envs_base: Path) -> list[tuple[str, Path]]:
 
 def _handle_status() -> None:
     """Show credential proxy status."""
-    from terok_sandbox import SandboxConfig, get_proxy_status, is_proxy_systemd_available
+    from terok_sandbox import get_proxy_status, is_proxy_systemd_available
+
+    from .paths import mounts_dir
 
     status = get_proxy_status()
     state = "running" if status.running else "stopped"
@@ -91,7 +93,7 @@ def _handle_status() -> None:
     if not status.running and status.mode == "none" and is_proxy_systemd_available():
         print("\nHint: run 'install' to set up systemd socket activation.")
 
-    leaked = scan_leaked_credentials(SandboxConfig().effective_envs_dir)
+    leaked = scan_leaked_credentials(mounts_dir())
     if leaked:
         print("\nWARNING: Real credentials found in shared config mounts:")
         for provider, path in leaked:
@@ -135,9 +137,9 @@ def _handle_routes() -> None:
 
 def _handle_clean() -> None:
     """Remove leaked credential files from shared config mounts."""
-    from terok_sandbox import SandboxConfig
+    from .paths import mounts_dir
 
-    leaked = scan_leaked_credentials(SandboxConfig().effective_envs_dir)
+    leaked = scan_leaked_credentials(mounts_dir())
     if not leaked:
         print("No leaked credential files found.")
         return

--- a/src/terok_agent/proxy_config.py
+++ b/src/terok_agent/proxy_config.py
@@ -33,12 +33,14 @@ def write_proxy_config(provider_name: str) -> None:
 
     from terok_sandbox import SandboxConfig, get_proxy_port
 
+    from .paths import mounts_dir
+
     cfg = SandboxConfig()
     port = get_proxy_port(cfg)
     proxy_url = f"http://host.containers.internal:{port}"
 
     patch = route.shared_config_patch
-    shared_dir = cfg.effective_envs_dir / auth_info.host_dir_name
+    shared_dir = mounts_dir() / auth_info.host_dir_name
     config_path = shared_dir / patch["file"]
     shared_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/terok_agent/roster.py
+++ b/src/terok_agent/roster.py
@@ -221,7 +221,7 @@ class MountDef:
     """A shared directory mount derived from the agent roster."""
 
     host_dir: str
-    """Directory name under ``envs_base_dir`` (e.g. ``"_codex-config"``)."""
+    """Directory name under ``mounts_dir()`` (e.g. ``"_codex-config"``)."""
 
     container_path: str
     """Mount point inside the container (e.g. ``"/home/dev/.codex"``)."""

--- a/src/terok_agent/runner.py
+++ b/src/terok_agent/runner.py
@@ -106,7 +106,7 @@ class AgentRunner:
         images = build_base_images(self._base_image)
         return images.l1
 
-    def _shared_mounts(self, envs_dir: Path) -> list[str]:
+    def _shared_mounts(self, mounts_base: Path) -> list[str]:
         """Derive shared volume mounts from the agent roster.
 
         Includes both auth config mounts (per-provider) and general mounts
@@ -115,7 +115,7 @@ class AgentRunner:
         seen: set[str] = set()
         mounts = []
         for _name, ap in sorted(self.roster.auth_providers.items()):
-            host_dir = envs_dir / ap.host_dir_name
+            host_dir = mounts_base / ap.host_dir_name
             host_dir.mkdir(parents=True, exist_ok=True)
             mount = f"{host_dir}:{ap.container_mount}:z"
             if ap.host_dir_name not in seen:
@@ -123,7 +123,7 @@ class AgentRunner:
                 seen.add(ap.host_dir_name)
         for m in self.roster.mounts:
             if m.host_dir not in seen:
-                host_dir = envs_dir / m.host_dir
+                host_dir = mounts_base / m.host_dir
                 host_dir.mkdir(parents=True, exist_ok=True)
                 mounts.append(f"{host_dir}:{m.container_path}:z")
                 seen.add(m.host_dir)
@@ -159,7 +159,6 @@ class AgentRunner:
             project_id=repo_key,
             gate_path=gate_path,
             upstream_url=repo_url,
-            envs_base_dir=cfg.effective_envs_dir,
         )
         gate.sync()
 
@@ -295,7 +294,7 @@ class AgentRunner:
         *,
         prompt: str | None = None,
         instructions: str | None = None,
-        envs_dir: Path,
+        mounts_base: Path,
         project_root: Path | None = None,
     ) -> Path:
         """Prepare the agent-config directory for a task.
@@ -317,7 +316,7 @@ class AgentRunner:
             prompt=prompt,
             provider=provider,
             instructions=resolved_instructions,
-            envs_base_dir=envs_dir,
+            mounts_base=mounts_base,
         )
         return prepare_agent_config_dir(spec)
 
@@ -512,7 +511,9 @@ class AgentRunner:
         task_dir = Path(tempfile.mkdtemp(prefix=f"terok-agent-{task_id}-"))
 
         # Env base for shared auth mounts
-        envs_dir = self.sandbox.config.effective_envs_dir
+        from .paths import mounts_dir
+
+        mounts_base = mounts_dir()
 
         # Prepare agent config (pass local_path so repo instructions.md is found)
         agent_config_dir = self._prepare_agent_config(
@@ -520,7 +521,7 @@ class AgentRunner:
             task_id,
             provider,
             prompt=prompt,
-            envs_dir=envs_dir,
+            mounts_base=mounts_base,
             project_root=local_path,
         )
 
@@ -545,7 +546,7 @@ class AgentRunner:
             volumes.append(f"{workspace}:/workspace:Z")
 
         # Shared auth mounts (derived from roster)
-        volumes += self._shared_mounts(envs_dir)
+        volumes += self._shared_mounts(mounts_base)
 
         # Credential proxy: inject phantom tokens and base URL overrides
         env.update(self._credential_proxy_env(task_id))

--- a/tach.toml
+++ b/tach.toml
@@ -22,6 +22,11 @@ ignore_type_checking_imports = true
 #   instructions → agent_config
 #   resources (data files, no code deps)
 
+# Path resolution — standalone XDG/FHS helpers
+[[modules]]
+path = "terok_agent.paths"
+depends_on = []
+
 # Vendored utilities — standalone, no internal deps
 [[modules]]
 path = "terok_agent._util"
@@ -78,6 +83,7 @@ depends_on = [
 [[modules]]
 path = "terok_agent.proxy_config"
 depends_on = [
+    "terok_agent.paths",
     "terok_agent.roster",
 ]
 
@@ -109,6 +115,7 @@ depends_on = [
     "terok_agent.build",
     "terok_agent.headless_providers",
     "terok_agent.instructions",
+    "terok_agent.paths",
     "terok_agent.roster",
 ]
 
@@ -116,6 +123,7 @@ depends_on = [
 [[modules]]
 path = "terok_agent.proxy_commands"
 depends_on = [
+    "terok_agent.paths",
     "terok_agent.roster",
 ]
 
@@ -125,6 +133,7 @@ path = "terok_agent.commands"
 depends_on = [
     "terok_agent.auth",
     "terok_agent.build",
+    "terok_agent.paths",
     "terok_agent.proxy_config",
     "terok_agent.roster",
     "terok_agent.runner",
@@ -151,6 +160,7 @@ depends_on = [
     "terok_agent.credential_extractors",
     "terok_agent.headless_providers",
     "terok_agent.instructions",
+    "terok_agent.paths",
     "terok_agent.proxy_commands",
     "terok_agent.roster",
     "terok_agent.runner",

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -245,7 +245,7 @@ class TestPrepareAgentConfigDir:
             task_id=task_id,
             subagents=[],
             default_agent=None,
-            envs_base_dir=kwargs.pop("envs_base_dir", None),
+            mounts_base=kwargs.pop("mounts_base", None),
             instructions=kwargs.pop("instructions", None),
             **kwargs,
         )
@@ -255,7 +255,7 @@ class TestPrepareAgentConfigDir:
         """Instructions text is written to instructions.md."""
         with tempfile.TemporaryDirectory() as envs:
             spec = self._make_spec(
-                tmp_path / "tasks", "t1", instructions="Custom.", envs_base_dir=Path(envs)
+                tmp_path / "tasks", "t1", instructions="Custom.", mounts_base=Path(envs)
             )
             (tmp_path / "tasks" / "t1").mkdir(parents=True)
             d = prepare_agent_config_dir(spec)
@@ -265,7 +265,7 @@ class TestPrepareAgentConfigDir:
     def test_default_instructions_when_none(self, _mock: object, tmp_path: Path) -> None:
         """Default instructions.md written when instructions is None."""
         with tempfile.TemporaryDirectory() as envs:
-            spec = self._make_spec(tmp_path / "tasks", "t2", envs_base_dir=Path(envs))
+            spec = self._make_spec(tmp_path / "tasks", "t2", mounts_base=Path(envs))
             (tmp_path / "tasks" / "t2").mkdir(parents=True)
             d = prepare_agent_config_dir(spec)
             assert "conventions" in (d / "instructions.md").read_text(encoding="utf-8")
@@ -275,7 +275,7 @@ class TestPrepareAgentConfigDir:
         """Claude wrapper includes --append-system-prompt when instructions given."""
         with tempfile.TemporaryDirectory() as envs:
             spec = self._make_spec(
-                tmp_path / "tasks", "t3", instructions="Test.", envs_base_dir=Path(envs)
+                tmp_path / "tasks", "t3", instructions="Test.", mounts_base=Path(envs)
             )
             (tmp_path / "tasks" / "t3").mkdir(parents=True)
             d = prepare_agent_config_dir(spec)

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -186,8 +186,7 @@ class TestScanLeakedCredentials:
         cred_file = cred_dir / route.credential_file
         cred_file.write_text('{"secret": true}')
 
-        with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
-            mock_cfg_cls.return_value.effective_envs_dir = tmp_path
+        with patch("terok_agent.paths.mounts_dir", return_value=tmp_path):
             _handle_clean()
 
         assert not cred_file.exists()
@@ -199,8 +198,7 @@ class TestScanLeakedCredentials:
 
         from terok_agent.proxy_commands import _handle_clean
 
-        with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
-            mock_cfg_cls.return_value.effective_envs_dir = Path("/nonexistent")
+        with patch("terok_agent.paths.mounts_dir", return_value=Path("/nonexistent")):
             _handle_clean()
 
         assert "No leaked" in capsys.readouterr().out


### PR DESCRIPTION
Introduce terok-agent's own XDG state directory (TEROK_AGENT_STATE_DIR) with mounts_dir() for agent config bind-mounts. This separates container-exposed directories from the host-only credentials store.

Replace all envs_base_dir/effective_envs_dir references with mounts_dir/mounts_base throughout agent source and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.0.24
  * Updated terok-sandbox dependency to 0.0.22

* **New Features**
  * Platform-aware mount directory resolution with improved system fallback behavior

* **Public API**
  * Exposed a central mounts directory symbol and renamed environment-mount related parameters/fields from envs_* to mounts_*

* **Tests**
  * Updated unit tests and mocks to use the new mounts-directory behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->