### PR TITLE
fix: restore socat proxy bridges after container restart

### DIFF
--- a/src/terok_agent/resources/scripts/ensure-bridges.sh
+++ b/src/terok_agent/resources/scripts/ensure-bridges.sh
@@ -1,0 +1,45 @@
+# shellcheck shell=bash
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Idempotent socat bridge launcher for container ↔ host-side credential proxy.
+#
+# Manages two bridges:
+#   1. SSH agent  — UNIX socket → ssh-agent-bridge.sh → TCP (phantom-token)
+#   2. gh proxy   — UNIX socket → TCP (plain relay to credential proxy)
+#
+# Uses PID files (not socket existence) to detect dead bridges — stale
+# socket files persist after process death and are unreliable sentinels.
+#
+# Designed to be *sourced* (not executed) so SSH_AUTH_SOCK propagates
+# to the caller.  Called from:
+#   - init-ssh-and-repo.sh  (first boot)
+#   - terok-env.sh          (every shell — self-heal after restart)
+
+_TEROK_PIDDIR=/tmp/.terok
+mkdir -p "$_TEROK_PIDDIR" 2>/dev/null
+
+_terok_bridge_alive() {
+  local pidfile="$1"
+  [[ -f "$pidfile" ]] && kill -0 "$(cat "$pidfile" 2>/dev/null)" 2>/dev/null
+}
+
+# ── SSH agent bridge ─────────────────────────────────────────────────────
+if [[ -n "${TEROK_SSH_AGENT_PORT:-}" ]] && [[ -n "${TEROK_SSH_AGENT_TOKEN:-}" ]] \
+   && command -v socat >/dev/null 2>&1 \
+   && ! _terok_bridge_alive "$_TEROK_PIDDIR/ssh-agent.pid"; then
+  rm -f /tmp/ssh-agent.sock
+  socat "UNIX-LISTEN:/tmp/ssh-agent.sock,fork" "SYSTEM:ssh-agent-bridge.sh" &
+  echo $! > "$_TEROK_PIDDIR/ssh-agent.pid"
+  export SSH_AUTH_SOCK=/tmp/ssh-agent.sock
+fi
+
+# ── gh credential proxy bridge ───────────────────────────────────────────
+if [[ -n "${TEROK_PROXY_PORT:-}" ]] && [[ -n "${GH_TOKEN:-}" ]] \
+   && command -v socat >/dev/null 2>&1 \
+   && ! _terok_bridge_alive "$_TEROK_PIDDIR/gh-proxy.pid"; then
+  rm -f /tmp/terok-gh-proxy.sock
+  socat UNIX-LISTEN:/tmp/terok-gh-proxy.sock,fork \
+    TCP:host.containers.internal:"${TEROK_PROXY_PORT}" &
+  echo $! > "$_TEROK_PIDDIR/gh-proxy.pid"
+fi

--- a/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
@@ -12,20 +12,20 @@ set -euo pipefail
 #   GIT_RESET_MODE          - "none" (default), "hard", or "soft"
 #   CLONE_FROM              - optional alternate source to seed the repo (e.g. file:///git-gate/gate.git)
 #   EXTERNAL_REMOTE_URL     - optional URL for upstream repo in gatekeeping mode (added as "external" remote)
-#   TEROK_SSH_AGENT_PORT    - optional, TCP port for SSH agent proxy on host
-#   TEROK_SSH_AGENT_TOKEN   - optional, phantom token for SSH agent authentication
+#   (bridge env vars — TEROK_SSH_AGENT_PORT, TEROK_SSH_AGENT_TOKEN, TEROK_PROXY_PORT, GH_TOKEN —
+#    are consumed by ensure-bridges.sh, sourced below)
 
 : "${GIT_RESET_MODE:=none}"
 
 : "${HOME:=/home/dev}"
 
-# SSH agent proxy: bridge SSH_AUTH_SOCK to the host-side SSH agent handler.
-# The proxy holds private keys on the host and signs on behalf of the container.
-if [[ -n "${TEROK_SSH_AGENT_PORT:-}" ]] && [[ -n "${TEROK_SSH_AGENT_TOKEN:-}" ]] && command -v socat >/dev/null 2>&1; then
-  rm -f /tmp/ssh-agent.sock
-  socat "UNIX-LISTEN:/tmp/ssh-agent.sock,fork" "SYSTEM:ssh-agent-bridge.sh" &
-  export SSH_AUTH_SOCK=/tmp/ssh-agent.sock
-  echo ">> SSH agent bridge started (socat PID: $!, SSH_AUTH_SOCK=${SSH_AUTH_SOCK})"
+# Socat bridges: SSH agent + gh credential proxy.
+# Delegates to ensure-bridges.sh (single source of truth for both bridges).
+# shellcheck source=ensure-bridges.sh
+source ensure-bridges.sh
+
+if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
+  echo ">> bridges established (SSH_AUTH_SOCK=${SSH_AUTH_SOCK})"
 
   # Generate minimal ~/.ssh/config — the agent proxy handles keys, so no
   # IdentityFile is needed.  StrictHostKeyChecking=accept-new prevents
@@ -42,7 +42,7 @@ SSHEOF
   if command -v ssh >/dev/null 2>&1; then
     if [[ -n "${CODE_REPO:-}" && "${CODE_REPO}" == *"github.com"* ]]; then
       echo '>> warm github known_hosts (best-effort)'
-      ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o LogLevel=ERROR git@github.com || true
+      timeout 5 ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o LogLevel=ERROR git@github.com || true
     fi
   fi
 fi
@@ -323,15 +323,6 @@ if [[ "${TEROK_UNRESTRICTED:-}" == "1" ]]; then
     printf '{"permissions":{"defaultMode":"bypassPermissions"}}\n' \
       > /etc/claude-code/managed-settings.json
   fi
-fi
-
-# Credential proxy: start socat bridges for tools that need Unix sockets.
-# gh routes all API traffic through http_unix_socket (set in config.yml).
-# The socat bridge pipes that socket to the TCP proxy on the host.
-if [[ -n "${TEROK_PROXY_PORT:-}" ]] && [[ -n "${GH_TOKEN:-}" ]] && command -v socat >/dev/null 2>&1; then
-  rm -f /tmp/terok-gh-proxy.sock
-  socat UNIX-LISTEN:/tmp/terok-gh-proxy.sock,fork TCP:host.containers.internal:"${TEROK_PROXY_PORT}" &
-  echo ">> gh proxy bridge started (socat PID: $!)"
 fi
 
 # Signal readiness for host tools that watch initial logs

--- a/src/terok_agent/resources/scripts/terok-env.sh
+++ b/src/terok_agent/resources/scripts/terok-env.sh
@@ -68,7 +68,11 @@ glab() {
   )
 }
 
-# ── SSH agent ─────────────────────────────────────────────────────────────────
+# ── Proxy bridges ────────────────────────────────────────────────────────────
+
+# Ensure socat bridges are alive (idempotent; self-heals after container restart).
+# shellcheck source=ensure-bridges.sh
+command -v socat >/dev/null 2>&1 && . ensure-bridges.sh 2>/dev/null
 
 # Export SSH_AUTH_SOCK when the bridge socket exists; unset if it's gone.
 if [[ -S /tmp/ssh-agent.sock ]]; then

--- a/src/terok_agent/resources/templates/l0.dev.Dockerfile.template
+++ b/src/terok_agent/resources/templates/l0.dev.Dockerfile.template
@@ -47,7 +47,8 @@ WORKDIR /workspace
 
 COPY scripts/init-ssh-and-repo.sh /usr/local/bin/init-ssh-and-repo.sh
 COPY scripts/ssh-agent-bridge.sh /usr/local/bin/ssh-agent-bridge.sh
-RUN chmod +x /usr/local/bin/init-ssh-and-repo.sh /usr/local/bin/ssh-agent-bridge.sh
+COPY scripts/ensure-bridges.sh /usr/local/bin/ensure-bridges.sh
+RUN chmod +x /usr/local/bin/init-ssh-and-repo.sh /usr/local/bin/ssh-agent-bridge.sh /usr/local/bin/ensure-bridges.sh
 
 # tmux config for persistent login sessions (prefix ^a, green status bar)
 COPY tmux/container-tmux.conf /etc/tmux.conf


### PR DESCRIPTION
## Summary
- Extract bridge logic from inline blocks in `init-ssh-and-repo.sh` into `ensure-bridges.sh` — single source of truth for both SSH agent and gh proxy socat bridges
- PID-file based liveness checks (stale socket files are unreliable sentinels)
- Source from `terok-env.sh` on every shell startup — self-heals dead bridges after container stop/start
- Add `timeout 5` to SSH warmup to prevent blocking the rest of init

Closes terok-ai/terok-sandbox#59

## Test plan
- [x] `make lint` — clean
- [x] `make test` — 305 passed
- [x] `make reuse` — compliant
- [x] Manual: sourced `ensure-bridges.sh` in a container with dead gh bridge — bridge restored, `gh auth status` works
- [x] Manual: re-sourced — idempotent (same PID, no duplicate socat)
- [ ] Integration: stop/start container, verify both bridges come back on shell open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Credential bridges now automatically recover after container restarts with persistent health monitoring, improving reliability of container-to-host connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->