### PR TITLE
chore: align directory namespace under shared terok/ umbrella

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2413,34 +2413,34 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.22"
+version = "0.0.23"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.22-py3-none-any.whl", hash = "sha256:7712ea22a0cea65a43d051073a5aee7d8cdcc1f765c5e2e72e9e18b69de4d62d"},
+    {file = "terok_sandbox-0.0.23-py3-none-any.whl", hash = "sha256:144aeb72518b476bf05b5c9b8abfce881351b4f85d64643d0483450307ce3e19"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.2/terok_shield-0.5.2-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.22/terok_sandbox-0.0.22-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.5.2"
+version = "0.5.3"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.5.2-py3-none-any.whl", hash = "sha256:efe934014e5c4844d3067324775cfb5dac2182f2c595b4eb7ce40c31993351e1"},
+    {file = "terok_shield-0.5.3-py3-none-any.whl", hash = "sha256:37ee4a330044150cdb7a300afbc416ca8dda8aa5a89ea658f6e356931b7c154a"},
 ]
 
 [package.dependencies]
@@ -2448,7 +2448,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.2/terok_shield-0.5.2-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -2815,4 +2815,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "b39dd2caa3d121566e3aa036faef5b6072a82a1d9becf9b9ff5934c407fdda42"
+content-hash = "4e5834737af3bd72794c51d1ce25cd5fe48998ce24d3c69d89795bc8639d7bc2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.22/terok_sandbox-0.0.22-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_agent/paths.py
+++ b/src/terok_agent/paths.py
@@ -19,6 +19,9 @@ except ImportError:  # optional dependency
 
 APP_NAME = "terok-agent"
 
+_UMBRELLA = "terok"
+_SUBDIR = "agent"
+
 
 def _is_root() -> bool:
     """Return True if the current process is running as root."""
@@ -31,21 +34,21 @@ def _is_root() -> bool:
 def state_root() -> Path:
     """Writable state root for agent-owned data.
 
-    Priority: ``TEROK_AGENT_STATE_DIR`` → ``/var/lib/terok-agent`` (root)
-    → ``platformdirs.user_data_dir()`` → ``$XDG_DATA_HOME/terok-agent``
-    → ``~/.local/share/terok-agent``.
+    Priority: ``TEROK_AGENT_STATE_DIR`` → ``/var/lib/terok/agent`` (root)
+    → ``platformdirs.user_data_dir()`` → ``$XDG_DATA_HOME/terok/agent``
+    → ``~/.local/share/terok/agent``.
     """
     env = os.getenv("TEROK_AGENT_STATE_DIR")
     if env:
         return Path(env).expanduser()
     if _is_root():
-        return Path("/var/lib") / APP_NAME
+        return Path("/var/lib") / _UMBRELLA / _SUBDIR
     if _user_data_dir is not None:
-        return Path(_user_data_dir(APP_NAME))
+        return Path(_user_data_dir(_UMBRELLA)) / _SUBDIR
     xdg = os.getenv("XDG_DATA_HOME")
     if xdg:
-        return Path(xdg) / APP_NAME
-    return Path.home() / ".local" / "share" / APP_NAME
+        return Path(xdg) / _UMBRELLA / _SUBDIR
+    return Path.home() / ".local" / "share" / _UMBRELLA / _SUBDIR
 
 
 def mounts_dir() -> Path:

--- a/src/terok_agent/roster.py
+++ b/src/terok_agent/roster.py
@@ -13,7 +13,7 @@ Directory layout::
     resources/agents/claude.yaml      (bundled, shipped in wheel)
     resources/agents/codex.yaml
     ...
-    ~/.config/terok-agent/agents/     (user overrides / additions)
+    ~/.config/terok/agent/agents/      (user overrides / additions)
 """
 
 from __future__ import annotations
@@ -38,12 +38,12 @@ _USER_AGENTS_DIR_NAME = "agents"
 
 
 def _user_agents_dir() -> Path:
-    """Return ``~/.config/terok-agent/agents/``."""
+    """Return ``~/.config/terok/agent/agents/``."""
     try:
         from platformdirs import user_config_dir
     except ImportError:  # pragma: no cover
-        return Path.home() / ".config" / "terok-agent" / _USER_AGENTS_DIR_NAME
-    return Path(user_config_dir("terok-agent")) / _USER_AGENTS_DIR_NAME
+        return Path.home() / ".config" / "terok" / "agent" / _USER_AGENTS_DIR_NAME
+    return Path(user_config_dir("terok")) / "agent" / _USER_AGENTS_DIR_NAME
 
 
 # ---------------------------------------------------------------------------
@@ -74,7 +74,7 @@ def _load_bundled_agents() -> dict[str, dict]:
 
 
 def _load_user_agents() -> dict[str, dict]:
-    """Load user override/addition YAML files from ``~/.config/terok-agent/agents/``."""
+    """Load user override/addition YAML files from ``~/.config/terok/agent/agents/``."""
     agents: dict[str, dict] = {}
     user_dir = _user_agents_dir()
     if not user_dir.is_dir():
@@ -435,7 +435,7 @@ def load_roster() -> AgentRoster:
     """Load the agent roster from bundled YAML + user overrides.
 
     Bundled agents in ``resources/agents/*.yaml`` are loaded first, then
-    user files in ``~/.config/terok-agent/agents/*.yaml`` are deep-merged
+    user files in ``~/.config/terok/agent/agents/*.yaml`` are deep-merged
     on top (allowing field-level overrides or entirely new agents).
     """
     raw = _load_bundled_agents()

--- a/src/terok_agent/roster.py
+++ b/src/terok_agent/roster.py
@@ -39,11 +39,13 @@ _USER_AGENTS_DIR_NAME = "agents"
 
 def _user_agents_dir() -> Path:
     """Return ``~/.config/terok/agent/agents/``."""
+    from .paths import _SUBDIR, _UMBRELLA
+
     try:
         from platformdirs import user_config_dir
     except ImportError:  # pragma: no cover
-        return Path.home() / ".config" / "terok" / "agent" / _USER_AGENTS_DIR_NAME
-    return Path(user_config_dir("terok")) / "agent" / _USER_AGENTS_DIR_NAME
+        return Path.home() / ".config" / _UMBRELLA / _SUBDIR / _USER_AGENTS_DIR_NAME
+    return Path(user_config_dir(_UMBRELLA)) / _SUBDIR / _USER_AGENTS_DIR_NAME
 
 
 # ---------------------------------------------------------------------------

--- a/tach.toml
+++ b/tach.toml
@@ -95,6 +95,7 @@ depends_on = [
     "terok_agent.auth",
     "terok_agent.config_stack",
     "terok_agent.headless_providers",
+    "terok_agent.paths",
 ]
 
 # Credential extractors — per-provider credential file parsers

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for terok_agent.paths — umbrella directory resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from terok_agent import paths
+
+from ..constants import MOCK_BASE
+
+
+class TestStateRoot:
+    """Verify ``state_root()`` resolution across all priority tiers."""
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """TEROK_AGENT_STATE_DIR takes first priority."""
+        monkeypatch.setenv("TEROK_AGENT_STATE_DIR", str(tmp_path))
+        assert paths.state_root() == tmp_path
+
+    def test_env_tilde_expansion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Tilde in TEROK_AGENT_STATE_DIR is expanded."""
+        monkeypatch.setenv("TEROK_AGENT_STATE_DIR", "~/agent-state")
+        result = paths.state_root()
+        assert "~" not in str(result)
+        assert result == Path.home() / "agent-state"
+
+    def test_root_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Root user gets /var/lib/terok/agent."""
+        monkeypatch.delenv("TEROK_AGENT_STATE_DIR", raising=False)
+        monkeypatch.setattr(paths, "_is_root", lambda: True)
+        assert paths.state_root() == Path("/var/lib/terok/agent")
+
+    def test_platformdirs_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-root with platformdirs uses umbrella/subdir."""
+        monkeypatch.delenv("TEROK_AGENT_STATE_DIR", raising=False)
+        monkeypatch.setattr(paths, "_is_root", lambda: False)
+        monkeypatch.setattr(paths, "_user_data_dir", lambda name: f"{MOCK_BASE}/data/{name}")
+        assert paths.state_root() == MOCK_BASE / "data" / "terok" / "agent"
+
+    def test_xdg_data_home_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without platformdirs, XDG_DATA_HOME is honored."""
+        monkeypatch.delenv("TEROK_AGENT_STATE_DIR", raising=False)
+        monkeypatch.setattr(paths, "_is_root", lambda: False)
+        monkeypatch.setattr(paths, "_user_data_dir", None)
+        monkeypatch.setenv("XDG_DATA_HOME", str(MOCK_BASE / "xdg-data"))
+        assert paths.state_root() == MOCK_BASE / "xdg-data" / "terok" / "agent"
+
+    def test_bare_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Last resort: ~/.local/share/terok/agent."""
+        monkeypatch.delenv("TEROK_AGENT_STATE_DIR", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(paths, "_is_root", lambda: False)
+        monkeypatch.setattr(paths, "_user_data_dir", None)
+        assert paths.state_root() == Path.home() / ".local" / "share" / "terok" / "agent"
+
+
+class TestMountsDir:
+    """Verify ``mounts_dir()`` is a child of ``state_root()``."""
+
+    def test_is_subdir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """mounts_dir() returns state_root() / 'mounts'."""
+        monkeypatch.setenv("TEROK_AGENT_STATE_DIR", str(tmp_path))
+        assert paths.mounts_dir() == tmp_path / "mounts"
+
+
+class TestUmbrellaConstants:
+    """Verify umbrella namespace constants."""
+
+    def test_umbrella_is_terok(self) -> None:
+        """_UMBRELLA is 'terok'."""
+        assert paths._UMBRELLA == "terok"
+
+    def test_subdir_is_agent(self) -> None:
+        """_SUBDIR is 'agent'."""
+        assert paths._SUBDIR == "agent"

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -22,7 +22,7 @@ from terok_agent.roster import (
 
 @pytest.fixture(autouse=True)
 def _isolate_user_agents_dir(tmp_path: Path) -> None:
-    """Prevent real ~/.config/terok-agent/agents/ from leaking into tests."""
+    """Prevent real ~/.config/terok/agent/agents/ from leaking into tests."""
     isolated = tmp_path / "empty-agents"
     with patch("terok_agent.roster._user_agents_dir", return_value=isolated):
         yield


### PR DESCRIPTION
## Summary

- Move all default filesystem paths from flat `terok-agent` to nested `terok/agent` under a shared `terok/` umbrella directory
- State dirs (`~/.local/share/terok/agent/`), config dirs (`~/.config/terok/agent/agents/`), and root paths (`/var/lib/terok/agent`) now share a common parent with other terok packages
- `TEROK_AGENT_STATE_DIR` env override remains unchanged

## Changes

- **`src/terok_agent/paths.py`**: Add `_UMBRELLA` / `_SUBDIR` constants, update `state_root()` fallback paths
- **`src/terok_agent/roster.py`**: Update `_user_agents_dir()` to use `terok/agent` namespace, update all docstrings
- **`tests/unit/test_roster.py`**: Update fixture docstring to match new path

## Test plan

- [x] All 305 unit tests pass (`pytest tests/unit/ -x`)
- [x] `ruff check` and `ruff format --check` pass
- [ ] Verify terok parent repo path expectations still align after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configuration and data directories reorganized into a new umbrella/subdirectory layout (updated locations for runtime state, user configs, and agent data).
  * Bumped the internal sandbox dependency to the next patch release.

* **Tests**
  * Added and updated unit tests and test documentation to validate the new directory resolution and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->