### PR TITLE
fix: surface silent failures in proxy, roster, runner, auth

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2413,34 +2413,34 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.24"
+version = "0.0.25"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.24-py3-none-any.whl", hash = "sha256:1910e07f6f2c19ae4761003e680dce840add47a459c1177f0d1a9c452f30236b"},
+    {file = "terok_sandbox-0.0.25-py3-none-any.whl", hash = "sha256:825967c4bc730c38ff83e6b4d7721b92f3ec1258e06835cbcf70fc0e4b4b1238"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.4/terok_shield-0.5.4-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.24/terok_sandbox-0.0.24-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.25/terok_sandbox-0.0.25-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.5.3"
+version = "0.5.4"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.5.3-py3-none-any.whl", hash = "sha256:37ee4a330044150cdb7a300afbc416ca8dda8aa5a89ea658f6e356931b7c154a"},
+    {file = "terok_shield-0.5.4-py3-none-any.whl", hash = "sha256:11d13cd9631a4308d0cfffb547e102258bf33916f3efb3d9440a5be705517ec7"},
 ]
 
 [package.dependencies]
@@ -2448,7 +2448,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.4/terok_shield-0.5.4-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -2815,4 +2815,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "cb6817c9e2db0158de54ed320c60a3cb0a75b8b9a9f017f6385fdb64c9b37cdd"
+content-hash = "44bb6d1b01b1aeeef15cb5c56c79388c7cb8083a3d255977da2c608f7bf66537"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.29"
+version = "0.0.30"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.24/terok_sandbox-0.0.24-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.25/terok_sandbox-0.0.25-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_agent/auth.py
+++ b/src/terok_agent/auth.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -265,9 +266,16 @@ def _capture_credentials(
     try:
         cred_data = extract_credential(provider_name, auth_dir)
     except Exception as exc:
-        print(f"\nWarning: could not extract credentials for {provider_name}: {exc}")
-        print("The auth flow completed but credentials were not captured.")
-        print("You may need to re-authenticate or check the credential file format.")
+        print(
+            f"\nWarning [auth]: could not extract credentials for {provider_name} "
+            f"from {auth_dir}: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        print("The auth flow completed but credentials were not captured.", file=sys.stderr)
+        print(
+            "You may need to re-authenticate or check the credential file format.",
+            file=sys.stderr,
+        )
         # List files in the auth dir to aid debugging
         files = sorted(p.relative_to(auth_dir) for p in auth_dir.rglob("*") if p.is_file())
         if files:
@@ -287,8 +295,15 @@ def _capture_credentials(
         finally:
             db.close()
     except Exception as exc:
-        print(f"\nWarning: failed to store credentials: {exc}")
-        print("The auth flow completed but credentials were not saved to the proxy DB.")
+        print(
+            f"\nWarning [auth]: failed to store credentials for {provider_name} "
+            f"in proxy DB: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        print(
+            "The auth flow completed but credentials were not saved to the proxy DB.",
+            file=sys.stderr,
+        )
         return
 
     # Write static .credentials.json for OAuth subscription mode detection

--- a/src/terok_agent/proxy_commands.py
+++ b/src/terok_agent/proxy_commands.py
@@ -125,6 +125,10 @@ def _format_credentials(status: object) -> str:
             db.close()
         return ", ".join(parts)
     except Exception:  # noqa: BLE001
+        print(
+            "Warning [proxy]: credential type lookup failed; showing names only",
+            file=sys.stderr,
+        )
         return ", ".join(st.credentials_stored)
 
 

--- a/src/terok_agent/proxy_config.py
+++ b/src/terok_agent/proxy_config.py
@@ -10,6 +10,7 @@ route API traffic through the credential proxy.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 
@@ -54,11 +55,19 @@ def write_proxy_config(provider_name: str) -> None:
 
 def _apply_toml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
     """Patch a TOML array-of-tables entry."""
-    try:
-        import tomllib
+    import tomllib
 
-        existing = tomllib.loads(config_path.read_text()) if config_path.is_file() else {}
-    except Exception:
+    if config_path.is_file():
+        try:
+            existing = tomllib.loads(config_path.read_text())
+        except Exception as exc:
+            print(
+                f"Warning [proxy-config]: failed to parse {config_path}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            existing = {}
+    else:
         existing = {}
 
     table_key = patch["toml_table"]
@@ -90,9 +99,17 @@ def _apply_yaml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
 
     yaml = YAML()
     yaml.preserve_quotes = True
-    try:
-        existing = yaml.load(config_path) if config_path.is_file() else {}
-    except Exception:
+    if config_path.is_file():
+        try:
+            existing = yaml.load(config_path)
+        except Exception as exc:
+            print(
+                f"Warning [proxy-config]: failed to parse {config_path}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            existing = {}
+    else:
         existing = {}
     if not isinstance(existing, dict):
         existing = {}

--- a/src/terok_agent/roster.py
+++ b/src/terok_agent/roster.py
@@ -19,6 +19,7 @@ Directory layout::
 from __future__ import annotations
 
 import importlib.resources
+import sys
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -69,7 +70,15 @@ def _load_bundled_agents() -> dict[str, dict]:
         if not hasattr(item, "name") or not item.name.endswith(".yaml"):
             continue
         name = item.name.removesuffix(".yaml")
-        data = _load_yaml(item.read_text(encoding="utf-8"))
+        try:
+            data = _load_yaml(item.read_text(encoding="utf-8"))
+        except Exception as exc:
+            print(
+                f"Warning [roster]: failed to parse bundled agent {name!r}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            continue
         if data:
             agents[name] = data
     return agents
@@ -83,7 +92,15 @@ def _load_user_agents() -> dict[str, dict]:
         return agents
     for path in sorted(user_dir.glob("*.yaml")):
         name = path.stem
-        data = _load_yaml(path.read_text(encoding="utf-8"))
+        try:
+            data = _load_yaml(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            print(
+                f"Warning [roster]: failed to parse user agent file {path}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            continue
         if data:
             agents[name] = data
     return agents

--- a/src/terok_agent/runner.py
+++ b/src/terok_agent/runner.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import shlex
+import sys
 import tempfile
 import uuid
 from pathlib import Path
@@ -189,7 +190,15 @@ class AgentRunner:
             return {}
 
         proxy_routes = self.roster.proxy_routes
-        db = CredentialDB(cfg.proxy_db_path)
+        try:
+            db = CredentialDB(cfg.proxy_db_path)
+        except Exception as exc:
+            print(
+                f"Warning [runner]: credential proxy is running but DB at "
+                f"{cfg.proxy_db_path} is unavailable: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            return {}
         try:
             credential_set = "default"
             stored_providers = set(db.list_credentials(credential_set))
@@ -252,14 +261,22 @@ class AgentRunner:
         except subprocess.TimeoutExpired:
             proc.terminate()
             print("Agent timed out", file=sys.stderr)
-        except (FileNotFoundError, OSError):
-            pass
+        except (FileNotFoundError, OSError) as exc:
+            print(
+                f"Warning [runner]: failed to stream logs for {cname}: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
 
         # Retrieve exit code from the container itself
         try:
             result = subprocess.run(["podman", "wait", cname], capture_output=True, timeout=10)
             exit_code = int(result.stdout.decode().strip()) if result.stdout else 1
-        except (subprocess.TimeoutExpired, ValueError, FileNotFoundError):
+        except (subprocess.TimeoutExpired, ValueError, FileNotFoundError) as exc:
+            print(
+                f"Warning [runner]: failed to retrieve exit code for {cname}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
             exit_code = 1
 
         if exit_code != 0:

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -61,18 +61,18 @@ class TestCaptureCredentials:
         # Empty dir — no credential file to extract
         _capture_credentials("claude", tmp_path, "default")
 
-        out = capsys.readouterr().out
-        assert "Warning" in out
-        assert "claude" in out
-        assert "not captured" in out
+        err = capsys.readouterr().err
+        assert "Warning" in err
+        assert "claude" in err
+        assert "not captured" in err
 
     def test_unknown_provider_prints_warning(self, tmp_path: Path, capsys) -> None:
         """Unknown provider prints a warning mentioning the provider name."""
         _capture_credentials("unknown-agent", tmp_path, "default")
 
-        out = capsys.readouterr().out
-        assert "Warning" in out
-        assert "unknown-agent" in out
+        err = capsys.readouterr().err
+        assert "Warning" in err
+        assert "unknown-agent" in err
 
     def test_db_failure_prints_warning(self, tmp_path: Path, capsys) -> None:
         """If DB storage fails, prints warning but doesn't raise."""
@@ -82,9 +82,9 @@ class TestCaptureCredentials:
         with patch("terok_sandbox.SandboxConfig", side_effect=RuntimeError("DB broken")):
             _capture_credentials("claude", tmp_path, "default")
 
-        out = capsys.readouterr().out
-        assert "Warning" in out
-        assert "not saved" in out
+        err = capsys.readouterr().err
+        assert "Warning" in err
+        assert "not saved" in err
 
     def test_custom_credential_set(self, tmp_path: Path) -> None:
         """Credentials can be stored under a custom credential set."""

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for warning paths in proxy_config and roster.
+
+Verifies that parse errors in TOML/YAML config files and agent definition
+files are surfaced as warnings on stderr rather than silently swallowed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# proxy_config: _apply_toml_patch warns on invalid TOML
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTomlPatchWarning:
+    """_apply_toml_patch warns on TOML parse errors and falls back to empty dict."""
+
+    def test_warns_on_invalid_toml(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Invalid TOML triggers a warning on stderr and is treated as empty."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("this is not valid toml {{{")
+
+        patch_spec = {
+            "file": "config.toml",
+            "toml_table": "servers",
+            "toml_match": {"name": "proxy"},
+            "toml_set": {"api_base": "{proxy_url}/v1"},
+        }
+
+        from terok_agent.proxy_config import _apply_toml_patch
+
+        _apply_toml_patch(config_path, patch_spec, "http://localhost:9999")
+
+        captured = capsys.readouterr()
+        assert "Warning [proxy-config]" in captured.err
+        assert str(config_path) in captured.err
+
+        # The file should still be written with the new entry (fallback to empty dict)
+        import tomllib
+
+        result = tomllib.loads(config_path.read_text())
+        assert "servers" in result
+        assert result["servers"][0]["name"] == "proxy"
+        assert result["servers"][0]["api_base"] == "http://localhost:9999/v1"
+
+    def test_no_warning_on_missing_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A missing file is not a parse error — no warning emitted."""
+        config_path = tmp_path / "nonexistent.toml"
+        patch_spec = {
+            "file": "nonexistent.toml",
+            "toml_table": "servers",
+            "toml_match": {"name": "proxy"},
+            "toml_set": {"api_base": "{proxy_url}/v1"},
+        }
+
+        from terok_agent.proxy_config import _apply_toml_patch
+
+        _apply_toml_patch(config_path, patch_spec, "http://localhost:9999")
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+
+    def test_no_warning_on_valid_toml(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Valid TOML is parsed without warning."""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[[servers]]\nname = "existing"\nport = 80\n')
+
+        patch_spec = {
+            "file": "config.toml",
+            "toml_table": "servers",
+            "toml_match": {"name": "proxy"},
+            "toml_set": {"api_base": "{proxy_url}/v1"},
+        }
+
+        from terok_agent.proxy_config import _apply_toml_patch
+
+        _apply_toml_patch(config_path, patch_spec, "http://localhost:9999")
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# proxy_config: _apply_yaml_patch warns on invalid YAML
+# ---------------------------------------------------------------------------
+
+
+class TestApplyYamlPatchWarning:
+    """_apply_yaml_patch warns on YAML parse errors and falls back to empty dict."""
+
+    def test_warns_on_invalid_yaml(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Invalid YAML triggers a warning on stderr and is treated as empty."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(":\n  - :\n  bad: [unterminated")
+
+        patch_spec = {
+            "file": "config.yaml",
+            "yaml_set": {"api_base": "{proxy_url}/v1"},
+        }
+
+        from terok_agent.proxy_config import _apply_yaml_patch
+
+        _apply_yaml_patch(config_path, patch_spec, "http://localhost:9999")
+
+        captured = capsys.readouterr()
+        assert "Warning [proxy-config]" in captured.err
+        assert str(config_path) in captured.err
+
+        # The file should be written with only the new key (fallback to empty)
+        from ruamel.yaml import YAML
+
+        yaml = YAML()
+        result = yaml.load(config_path)
+        assert result["api_base"] == "http://localhost:9999/v1"
+
+    def test_no_warning_on_missing_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A missing file is not a parse error — no warning emitted."""
+        config_path = tmp_path / "nonexistent.yaml"
+        patch_spec = {
+            "file": "nonexistent.yaml",
+            "yaml_set": {"api_base": "{proxy_url}/v1"},
+        }
+
+        from terok_agent.proxy_config import _apply_yaml_patch
+
+        _apply_yaml_patch(config_path, patch_spec, "http://localhost:9999")
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+
+    def test_no_warning_on_valid_yaml(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Valid YAML is parsed without warning."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("existing_key: hello\n")
+
+        patch_spec = {
+            "file": "config.yaml",
+            "yaml_set": {"api_base": "{proxy_url}/v1"},
+        }
+
+        from terok_agent.proxy_config import _apply_yaml_patch
+
+        _apply_yaml_patch(config_path, patch_spec, "http://localhost:9999")
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# roster: _load_bundled_agents warns on parse failure
+# ---------------------------------------------------------------------------
+
+
+class TestLoadBundledAgentsWarning:
+    """_load_bundled_agents warns when a bundled agent YAML fails to parse."""
+
+    def test_warns_on_bundled_parse_failure(self, capsys: pytest.CaptureFixture) -> None:
+        """A bundled agent that raises on read_text triggers a warning and is skipped."""
+        good_item = MagicMock()
+        good_item.name = "good.yaml"
+        good_item.read_text.return_value = "kind: agent\nlabel: Good\nbinary: good\n"
+
+        bad_item = MagicMock()
+        bad_item.name = "broken.yaml"
+        bad_item.read_text.side_effect = OSError("permission denied")
+
+        mock_pkg = MagicMock()
+        mock_pkg.iterdir.return_value = [good_item, bad_item]
+
+        with patch("importlib.resources.files", return_value=mock_pkg):
+            from terok_agent.roster import _load_bundled_agents
+
+            agents = _load_bundled_agents()
+
+        captured = capsys.readouterr()
+        assert "Warning [roster]" in captured.err
+        assert "broken" in captured.err
+        assert "OSError" in captured.err
+
+        # Good agent still loaded, broken one skipped
+        assert "good" in agents
+        assert "broken" not in agents
+
+    def test_warns_on_bundled_yaml_syntax_error(self, capsys: pytest.CaptureFixture) -> None:
+        """A bundled YAML file with syntax errors triggers a warning and is skipped."""
+        bad_yaml_item = MagicMock()
+        bad_yaml_item.name = "garbled.yaml"
+        bad_yaml_item.read_text.return_value = ":\n  - :\n  bad: [unterminated"
+
+        mock_pkg = MagicMock()
+        mock_pkg.iterdir.return_value = [bad_yaml_item]
+
+        with patch("importlib.resources.files", return_value=mock_pkg):
+            from terok_agent.roster import _load_bundled_agents
+
+            agents = _load_bundled_agents()
+
+        captured = capsys.readouterr()
+        assert "Warning [roster]" in captured.err
+        assert "garbled" in captured.err
+
+        assert "garbled" not in agents
+
+
+# ---------------------------------------------------------------------------
+# roster: _load_user_agents warns on parse failure
+# ---------------------------------------------------------------------------
+
+
+class TestLoadUserAgentsWarning:
+    """_load_user_agents warns when a user agent YAML file fails to parse."""
+
+    def test_warns_on_user_agent_parse_failure(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A user agent YAML with invalid content triggers a warning and is skipped."""
+        user_dir = tmp_path / "agents"
+        user_dir.mkdir()
+        (user_dir / "good.yaml").write_text("kind: agent\nlabel: Good\nbinary: good\n")
+        (user_dir / "broken.yaml").write_text(":\n  - :\n  bad: [unterminated")
+
+        with patch("terok_agent.roster._user_agents_dir", return_value=user_dir):
+            from terok_agent.roster import _load_user_agents
+
+            agents = _load_user_agents()
+
+        captured = capsys.readouterr()
+        assert "Warning [roster]" in captured.err
+        assert str(user_dir / "broken.yaml") in captured.err
+
+        # Good agent loaded, broken one skipped
+        assert "good" in agents
+        assert "broken" not in agents
+
+    def test_warns_on_user_agent_read_error(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A user agent file that raises on read triggers a warning and is skipped."""
+        user_dir = tmp_path / "agents"
+        user_dir.mkdir()
+        bad_file = user_dir / "unreadable.yaml"
+        bad_file.write_text("kind: agent\n")
+
+        with (
+            patch("terok_agent.roster._user_agents_dir", return_value=user_dir),
+            patch.object(Path, "read_text", side_effect=PermissionError("denied")),
+        ):
+            from terok_agent.roster import _load_user_agents
+
+            agents = _load_user_agents()
+
+        captured = capsys.readouterr()
+        assert "Warning [roster]" in captured.err
+        assert "PermissionError" in captured.err
+
+        assert "unreadable" not in agents
+
+    def test_no_warning_when_dir_missing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Missing user agents directory produces no warning (expected case)."""
+        with patch("terok_agent.roster._user_agents_dir", return_value=tmp_path / "nonexistent"):
+            from terok_agent.roster import _load_user_agents
+
+            agents = _load_user_agents()
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+        assert agents == {}


### PR DESCRIPTION
## Summary

Replace silent exception swallowing with structured stderr warnings across config patching, agent YAML loading, log streaming, exit code retrieval, credential proxy DB, and auth storage.

- TOML/YAML config parse errors warn instead of silently resetting to `{}`
- Malformed agent YAML definitions warn with filename
- Log stream failures print warning instead of silently exiting
- Exit code retrieval logs specific error type before defaulting to 1
- Credential proxy DB unavailability warns at startup
- Auth credential extraction/storage errors include specific details

Part of a cross-repo effort. See also: terok-ai/terok#592, terok-ai/terok-shield, terok-ai/terok-sandbox

## Test plan

- [ ] Place invalid TOML in proxy config path → verify stderr warning
- [ ] Place malformed YAML in user agents dir → verify stderr warning
- [ ] Run with broken proxy DB path → verify stderr warning
- [ ] `make check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warnings now emit to stderr with clearer context when credential, config, roster, or runtime operations encounter issues.
  * Malformed or unreadable config/roster files no longer fail silently; they warn and fall back to safe defaults.
  * Log/credential initialization and credential-formatting errors now emit warnings while preserving normal control flow.

* **Tests**
  * Unit tests updated and extended to assert stderr warning behavior for parsing, load, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->