### PR TITLE
feat: credential-type-aware phantom environment injection

### DIFF
--- a/src/terok_agent/proxy_commands.py
+++ b/src/terok_agent/proxy_commands.py
@@ -73,6 +73,28 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     return leaked
 
 
+def _format_credentials(status: object) -> str:
+    """Format stored credentials as ``name (type), ...`` for status display."""
+    from terok_sandbox import CredentialDB, CredentialProxyStatus
+
+    st: CredentialProxyStatus = status  # type: ignore[assignment]
+    if not st.credentials_stored:
+        return "none stored"
+    try:
+        db = CredentialDB(st.db_path)
+        try:
+            parts = []
+            for name in st.credentials_stored:
+                cred = db.load_credential("default", name)
+                ctype = cred.get("type", "unknown") if cred else "unknown"
+                parts.append(f"{name} ({ctype})")
+        finally:
+            db.close()
+        return ", ".join(parts)
+    except Exception:  # noqa: BLE001
+        return ", ".join(st.credentials_stored)
+
+
 def _handle_status() -> None:
     """Show credential proxy status."""
     from terok_sandbox import get_proxy_status, is_proxy_systemd_available
@@ -87,7 +109,7 @@ def _handle_status() -> None:
     print(f"DB:          {status.db_path}")
     print(f"Routes:      {status.routes_path} ({status.routes_configured} configured)")
     if status.credentials_stored:
-        print(f"Credentials: {', '.join(status.credentials_stored)}")
+        print(f"Credentials: {_format_credentials(status)}")
     else:
         print("Credentials: none stored")
     if not status.running and status.mode == "none" and is_proxy_systemd_available():

--- a/src/terok_agent/resources/agents/claude.yaml
+++ b/src/terok_agent/resources/agents/claude.yaml
@@ -49,7 +49,11 @@ credential_proxy:
     scope: "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
   phantom_env:
     ANTHROPIC_API_KEY: true
+  oauth_phantom_env:
+    CLAUDE_CODE_OAUTH_TOKEN: true
   base_url_env: ANTHROPIC_BASE_URL
+  socket_path: /tmp/terok-claude-proxy.sock
+  socket_env: ANTHROPIC_UNIX_SOCKET
 
 auth:
   host_dir: _claude-config

--- a/src/terok_agent/resources/scripts/ensure-bridges.sh
+++ b/src/terok_agent/resources/scripts/ensure-bridges.sh
@@ -4,9 +4,10 @@
 
 # Idempotent socat bridge launcher for container ↔ host-side credential proxy.
 #
-# Manages two bridges:
-#   1. SSH agent  — UNIX socket → ssh-agent-bridge.sh → TCP (phantom-token)
-#   2. gh proxy   — UNIX socket → TCP (plain relay to credential proxy)
+# Manages three bridges:
+#   1. SSH agent   — UNIX socket → ssh-agent-bridge.sh → TCP (phantom-token)
+#   2. gh proxy    — UNIX socket → TCP (plain relay to credential proxy)
+#   3. Claude proxy — UNIX socket → TCP (enables OAuth subscription mode)
 #
 # Uses PID files (not socket existence) to detect dead bridges — stale
 # socket files persist after process death and are unreliable sentinels.
@@ -42,4 +43,16 @@ if [[ -n "${TEROK_PROXY_PORT:-}" ]] && [[ -n "${GH_TOKEN:-}" ]] \
   socat UNIX-LISTEN:/tmp/terok-gh-proxy.sock,fork \
     TCP:host.containers.internal:"${TEROK_PROXY_PORT}" &
   echo $! > "$_TEROK_PIDDIR/gh-proxy.pid"
+fi
+
+# ── Claude credential proxy bridge (ANTHROPIC_UNIX_SOCKET transport) ────
+# Routes Claude API traffic through the credential proxy via a Unix socket
+# instead of ANTHROPIC_BASE_URL (enables OAuth subscription mode in Claude Code).
+if [[ -n "${TEROK_PROXY_PORT:-}" ]] && [[ -n "${ANTHROPIC_UNIX_SOCKET:-}" ]] \
+   && command -v socat >/dev/null 2>&1 \
+   && ! _terok_bridge_alive "$_TEROK_PIDDIR/claude-proxy.pid"; then
+  rm -f "${ANTHROPIC_UNIX_SOCKET}"
+  socat UNIX-LISTEN:"${ANTHROPIC_UNIX_SOCKET}",fork \
+    TCP:host.containers.internal:"${TEROK_PROXY_PORT}" &
+  echo $! > "$_TEROK_PIDDIR/claude-proxy.pid"
 fi

--- a/src/terok_agent/roster.py
+++ b/src/terok_agent/roster.py
@@ -308,8 +308,9 @@ def _to_proxy_route(name: str, data: dict) -> CredentialProxyRoute | None:
     for required in ("route_prefix", "upstream"):
         if required not in cp:
             raise ValueError(f"Agent {name!r}: credential_proxy missing required key {required!r}")
-    socket_path = cp.get("socket_path", "")
-    socket_env = cp.get("socket_env", "")
+    oauth_phantom_env = cp.get("oauth_phantom_env") or {}
+    socket_path = cp.get("socket_path") or ""
+    socket_env = cp.get("socket_env") or ""
     if bool(socket_path) != bool(socket_env):
         raise ValueError(
             f"Agent {name!r}: credential_proxy requires both 'socket_path' and 'socket_env' together"
@@ -323,7 +324,7 @@ def _to_proxy_route(name: str, data: dict) -> CredentialProxyRoute | None:
         credential_type=cp.get("credential_type", "api_key"),
         credential_file=cp.get("credential_file", ""),
         phantom_env=cp.get("phantom_env", {}),
-        oauth_phantom_env=cp.get("oauth_phantom_env", {}),
+        oauth_phantom_env=oauth_phantom_env,
         base_url_env=cp.get("base_url_env", ""),
         socket_path=socket_path,
         socket_env=socket_env,

--- a/src/terok_agent/roster.py
+++ b/src/terok_agent/roster.py
@@ -261,10 +261,23 @@ class CredentialProxyRoute:
     """Credential file path relative to the auth mount."""
 
     phantom_env: dict[str, bool] = field(default_factory=dict)
-    """Phantom API key env vars to inject (e.g. ``{"ANTHROPIC_API_KEY": true}``)."""
+    """Phantom env vars for API-key credentials (e.g. ``{"ANTHROPIC_API_KEY": true}``)."""
+
+    oauth_phantom_env: dict[str, bool] = field(default_factory=dict)
+    """Phantom env vars for OAuth credentials (e.g. ``{"CLAUDE_CODE_OAUTH_TOKEN": true}``).
+
+    When the stored credential type is ``"oauth"`` and this is non-empty, these
+    env vars are injected *instead of* :attr:`phantom_env`.
+    """
 
     base_url_env: str = ""
     """Env var to override with proxy URL (e.g. ``"ANTHROPIC_BASE_URL"``)."""
+
+    socket_path: str = ""
+    """Unix socket path for socat bridge (e.g. ``"/tmp/terok-claude-proxy.sock"``)."""
+
+    socket_env: str = ""
+    """Env var that receives :attr:`socket_path` (e.g. ``"ANTHROPIC_UNIX_SOCKET"``)."""
 
     shared_config_patch: dict | None = None
     """Optional shared config patch applied after auth (e.g. Vibe's config.toml)."""
@@ -304,7 +317,10 @@ def _to_proxy_route(name: str, data: dict) -> CredentialProxyRoute | None:
         credential_type=cp.get("credential_type", "api_key"),
         credential_file=cp.get("credential_file", ""),
         phantom_env=cp.get("phantom_env", {}),
+        oauth_phantom_env=cp.get("oauth_phantom_env", {}),
         base_url_env=cp.get("base_url_env", ""),
+        socket_path=cp.get("socket_path", ""),
+        socket_env=cp.get("socket_env", ""),
         shared_config_patch=cp.get("shared_config_patch"),
         oauth_refresh=_validated_oauth_refresh(name, cp.get("oauth_refresh")),
     )

--- a/src/terok_agent/roster.py
+++ b/src/terok_agent/roster.py
@@ -308,6 +308,12 @@ def _to_proxy_route(name: str, data: dict) -> CredentialProxyRoute | None:
     for required in ("route_prefix", "upstream"):
         if required not in cp:
             raise ValueError(f"Agent {name!r}: credential_proxy missing required key {required!r}")
+    socket_path = cp.get("socket_path", "")
+    socket_env = cp.get("socket_env", "")
+    if bool(socket_path) != bool(socket_env):
+        raise ValueError(
+            f"Agent {name!r}: credential_proxy requires both 'socket_path' and 'socket_env' together"
+        )
     return CredentialProxyRoute(
         provider=name,
         route_prefix=cp["route_prefix"],
@@ -319,8 +325,8 @@ def _to_proxy_route(name: str, data: dict) -> CredentialProxyRoute | None:
         phantom_env=cp.get("phantom_env", {}),
         oauth_phantom_env=cp.get("oauth_phantom_env", {}),
         base_url_env=cp.get("base_url_env", ""),
-        socket_path=cp.get("socket_path", ""),
-        socket_env=cp.get("socket_env", ""),
+        socket_path=socket_path,
+        socket_env=socket_env,
         shared_config_patch=cp.get("shared_config_patch"),
         oauth_refresh=_validated_oauth_refresh(name, cp.get("oauth_refresh")),
     )

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -60,6 +60,7 @@ class TestProxyRoutesParsed:
             assert route is not None, f"{name} missing proxy route"
             assert route.oauth_phantom_env == {}, f"{name} should have no oauth_phantom_env"
             assert route.socket_path == "", f"{name} should have no socket_path"
+            assert route.socket_env == "", f"{name} should have no socket_env"
 
     def test_opencode_agents_have_routes(self) -> None:
         """Blablador and KISSKI have proxy routes."""

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -362,6 +362,133 @@ class TestProxyCommandHandlers:
         assert "clean" in out
 
 
+class TestFormatCredentials:
+    """Verify _format_credentials() type-annotated status display."""
+
+    def test_shows_credential_types(self, tmp_path: Path) -> None:
+        """Formats credentials as 'name (type)' from the DB."""
+        from terok_sandbox import CredentialDB
+
+        from terok_agent.proxy_commands import _format_credentials
+
+        db_path = tmp_path / "creds.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "claude", {"type": "oauth", "access_token": "t"})
+        db.store_credential("default", "vibe", {"type": "api_key", "key": "k"})
+        db.close()
+
+        status = MagicMock(
+            credentials_stored=("claude", "vibe"),
+            db_path=db_path,
+        )
+        result = _format_credentials(status)
+        assert result == "claude (oauth), vibe (api_key)"
+
+    def test_unknown_type_when_missing(self, tmp_path: Path) -> None:
+        """Credentials without a type field show 'unknown'."""
+        from terok_sandbox import CredentialDB
+
+        from terok_agent.proxy_commands import _format_credentials
+
+        db_path = tmp_path / "creds.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "legacy", {"key": "k"})
+        db.close()
+
+        status = MagicMock(credentials_stored=("legacy",), db_path=db_path)
+        assert "unknown" in _format_credentials(status)
+
+    def test_empty_credentials(self) -> None:
+        """Returns 'none stored' when no credentials exist."""
+        from terok_agent.proxy_commands import _format_credentials
+
+        status = MagicMock(credentials_stored=())
+        assert _format_credentials(status) == "none stored"
+
+    def test_db_failure_falls_back_to_plain_names(self) -> None:
+        """Falls back to plain provider names when DB is unreadable."""
+        from terok_agent.proxy_commands import _format_credentials
+
+        status = MagicMock(
+            credentials_stored=("claude", "gh"),
+            db_path=Path("/nonexistent/creds.db"),
+        )
+        assert _format_credentials(status) == "claude, gh"
+
+
+class TestToProxyRoute:
+    """Verify _to_proxy_route() parsing edge cases."""
+
+    def test_both_socket_fields_accepted(self) -> None:
+        """Both socket_path and socket_env together are valid."""
+        from terok_agent.roster import _to_proxy_route
+
+        route = _to_proxy_route(
+            "test",
+            {
+                "credential_proxy": {
+                    "route_prefix": "test",
+                    "upstream": "https://example.com",
+                    "socket_path": "/tmp/test.sock",
+                    "socket_env": "TEST_SOCKET",
+                }
+            },
+        )
+        assert route is not None
+        assert route.socket_path == "/tmp/test.sock"
+        assert route.socket_env == "TEST_SOCKET"
+
+    def test_neither_socket_field_accepted(self) -> None:
+        """Omitting both socket fields is valid (no socket transport)."""
+        from terok_agent.roster import _to_proxy_route
+
+        route = _to_proxy_route(
+            "test",
+            {
+                "credential_proxy": {
+                    "route_prefix": "test",
+                    "upstream": "https://example.com",
+                }
+            },
+        )
+        assert route is not None
+        assert route.socket_path == ""
+        assert route.socket_env == ""
+
+    def test_oauth_phantom_env_parsed(self) -> None:
+        """oauth_phantom_env is parsed from YAML data."""
+        from terok_agent.roster import _to_proxy_route
+
+        route = _to_proxy_route(
+            "test",
+            {
+                "credential_proxy": {
+                    "route_prefix": "test",
+                    "upstream": "https://example.com",
+                    "oauth_phantom_env": {"MY_OAUTH_TOKEN": True},
+                }
+            },
+        )
+        assert route is not None
+        assert route.oauth_phantom_env == {"MY_OAUTH_TOKEN": True}
+
+    def test_missing_required_field_raises(self) -> None:
+        """Missing route_prefix or upstream raises ValueError."""
+        from terok_agent.roster import _to_proxy_route
+
+        with pytest.raises(ValueError, match="route_prefix"):
+            _to_proxy_route("test", {"credential_proxy": {"upstream": "https://x.com"}})
+        with pytest.raises(ValueError, match="upstream"):
+            _to_proxy_route("test", {"credential_proxy": {"route_prefix": "t"}})
+
+    def test_no_credential_proxy_returns_none(self) -> None:
+        """Agent without credential_proxy section returns None."""
+        from terok_agent.roster import _to_proxy_route
+
+        assert _to_proxy_route("test", {}) is None
+        assert _to_proxy_route("test", {"credential_proxy": {}}) is None
+
+
 class TestEnsureProxyRoutes:
     """Verify ensure_proxy_routes writes routes.json to disk."""
 

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -62,6 +62,16 @@ class TestProxyRoutesParsed:
             assert route.socket_path == "", f"{name} should have no socket_path"
             assert route.socket_env == "", f"{name} should have no socket_env"
 
+    def test_partial_socket_config_rejected(self) -> None:
+        """Setting only socket_path or only socket_env raises ValueError."""
+        from terok_agent.roster import _to_proxy_route
+
+        base = {"route_prefix": "test", "upstream": "https://example.com"}
+        with pytest.raises(ValueError, match="both.*together"):
+            _to_proxy_route("test", {"credential_proxy": {**base, "socket_path": "/tmp/s.sock"}})
+        with pytest.raises(ValueError, match="both.*together"):
+            _to_proxy_route("test", {"credential_proxy": {**base, "socket_env": "MY_SOCK"}})
+
     def test_opencode_agents_have_routes(self) -> None:
         """Blablador and KISSKI have proxy routes."""
         reg = get_roster()

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -405,8 +405,8 @@ class TestFormatCredentials:
         status = MagicMock(credentials_stored=())
         assert _format_credentials(status) == "none stored"
 
-    def test_db_failure_falls_back_to_plain_names(self) -> None:
-        """Falls back to plain provider names when DB is unreadable."""
+    def test_status_display_degrades_gracefully_on_db_error(self) -> None:
+        """Status display shows plain names when its read-only DB connection fails."""
         from terok_agent.proxy_commands import _format_credentials
 
         status = MagicMock(

--- a/tests/unit/test_proxy_routes.py
+++ b/tests/unit/test_proxy_routes.py
@@ -18,7 +18,7 @@ class TestProxyRoutesParsed:
     """Verify credential_proxy YAML sections are parsed into the roster."""
 
     def test_claude_route_exists(self) -> None:
-        """Claude has a proxy route with Anthropic upstream."""
+        """Claude has a proxy route with Anthropic upstream and OAuth support."""
         reg = get_roster()
         route = reg.proxy_routes.get("claude")
         assert route is not None
@@ -26,7 +26,10 @@ class TestProxyRoutesParsed:
         assert route.upstream == "https://api.anthropic.com"
         assert route.auth_header == "dynamic"
         assert "ANTHROPIC_API_KEY" in route.phantom_env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in route.oauth_phantom_env
         assert route.base_url_env == "ANTHROPIC_BASE_URL"
+        assert route.socket_path == "/tmp/terok-claude-proxy.sock"
+        assert route.socket_env == "ANTHROPIC_UNIX_SOCKET"
 
     def test_codex_route_exists(self) -> None:
         """Codex has a proxy route with OpenAI upstream."""
@@ -49,6 +52,14 @@ class TestProxyRoutesParsed:
         assert route.auth_header == "PRIVATE-TOKEN"
         assert route.auth_prefix == ""
         assert route.route_prefix == "gl"
+
+    def test_api_key_only_providers_have_no_oauth_phantom_env(self) -> None:
+        """Providers without OAuth support have empty oauth_phantom_env."""
+        for name in ("vibe", "blablador", "kisski"):
+            route = get_roster().proxy_routes.get(name)
+            assert route is not None, f"{name} missing proxy route"
+            assert route.oauth_phantom_env == {}, f"{name} should have no oauth_phantom_env"
+            assert route.socket_path == "", f"{name} should have no socket_path"
 
     def test_opencode_agents_have_routes(self) -> None:
         """Blablador and KISSKI have proxy routes."""


### PR DESCRIPTION
## Summary
- Add `oauth_phantom_env`, `socket_path`, and `socket_env` fields to `CredentialProxyRoute` for credential-type-aware phantom token injection
- For Claude OAuth credentials, inject `CLAUDE_CODE_OAUTH_TOKEN` instead of `ANTHROPIC_API_KEY` — activating subscription mode in Claude Code
- Add Claude socat bridge in `ensure-bridges.sh` for Unix socket transport via `ANTHROPIC_UNIX_SOCKET`

## Context
Claude Code determines subscription vs API-key mode from the auth env var it sees. The credential proxy currently always injects `ANTHROPIC_API_KEY` (even for OAuth tokens), causing Claude Code to enter API-key mode and disable subscription features. This PR enables the orchestrator (terok) to select the correct phantom env vars based on stored credential type and configured transport mode.

## Test plan
- [ ] `make check` passes
- [ ] `test_claude_route_exists` verifies new fields parsed from YAML
- [ ] `test_api_key_only_providers_have_no_oauth_phantom_env` confirms API-key-only providers unaffected
- [ ] Manual: OAuth login → verify `CLAUDE_CODE_OAUTH_TOKEN` injected, Claude `/status` shows subscription

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added OAuth credential injection support for the Claude provider.
  * Added optional Unix-socket proxy communication with idempotent bridge startup to avoid duplicates.
  * Enforced paired socket configuration validation and improved status output to show formatted stored credentials.

* **Tests**
  * Added and updated unit tests validating Claude’s OAuth and socket configurations and that other providers remain API-key-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->