### PR TITLE
chore: migrate claude-code-acp to renamed package

### DIFF
--- a/src/terok_agent/resources/scripts/terok-claude-acp
+++ b/src/terok_agent/resources/scripts/terok-claude-acp
@@ -5,13 +5,13 @@
 # ACP wrapper for Claude Code.
 #
 # Sets up per-agent git identity and injects terok system instructions
-# before exec-ing the real claude-code-acp adapter.
+# before exec-ing the real claude-agent-acp adapter.
 #
 # Instructions: --append-system-prompt flag injects the resolved terok
 # instructions from /home/dev/.terok/instructions.md (per-task, written by
 # prepare_agent_config_dir on the host).  Same mechanism as the headless wrapper.
 #
-# Unrestricted mode: claude-code-acp reads /etc/claude-code/managed-settings.json
+# Unrestricted mode: claude-agent-acp reads /etc/claude-code/managed-settings.json
 # (enterprise managed settings, highest precedence).  Written once by
 # init-ssh-and-repo.sh at container startup — no per-invocation action needed.
 
@@ -26,4 +26,4 @@ if [[ -f /home/dev/.terok/instructions.md ]]; then
     _args+=(--append-system-prompt "$(cat /home/dev/.terok/instructions.md)")
 fi
 
-exec claude-code-acp "${_args[@]}" "$@"
+exec claude-agent-acp "${_args[@]}" "$@"

--- a/src/terok_agent/resources/scripts/toad
+++ b/src/terok_agent/resources/scripts/toad
@@ -63,7 +63,7 @@ fi
 #
 # Toad launches ACP agents by exec-ing the command from run_command."*" in
 # the agent's TOML file.  By default these point to the bare upstream
-# adapters (claude-code-acp, opencode acp, etc.) which bypass terok's
+# adapters (claude-agent-acp, opencode acp, etc.) which bypass terok's
 # per-agent git identity setup.
 #
 # We replace those commands with terok wrappers that configure the

--- a/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
@@ -160,7 +160,7 @@ WORKDIR /home/dev
 RUN set -eux; \
     mkdir -p "$NPM_CONFIG_PREFIX"; \
     npm config set prefix "$NPM_CONFIG_PREFIX"; \
-    npm install -g @openai/codex @github/copilot @zed-industries/claude-code-acp; \
+    npm install -g @openai/codex @github/copilot @agentclientprotocol/claude-agent-acp; \
     npm cache clean --force
 RUN curl -fsSL https://claude.ai/install.sh | bash
 RUN curl -fsSL https://opencode.ai/install | bash


### PR DESCRIPTION
## Summary
- `@zed-industries/claude-code-acp` has been deprecated and renamed to `@agentclientprotocol/claude-agent-acp`
- Updates the L1 Dockerfile template to install the new package
- Updates the `terok-claude-acp` wrapper to exec the new `claude-agent-acp` binary
- Updates comments in `toad` script to reflect the new name

## Test plan
- [ ] Build an L1 image and verify `claude-agent-acp` binary is installed
- [ ] Verify `terok-claude-acp` wrapper successfully execs the renamed adapter
- [ ] Verify Toad launches Claude agent via the wrapper without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated wrapper scripts and Docker image configuration with new adapter references.
  * Modified launcher script documentation to reflect updated adapter naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->