### PR TITLE
feat: agent-level container diagnostics — bridge, credential, and proxy checks

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2413,13 +2413,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.27"
+version = "0.0.28"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.27-py3-none-any.whl", hash = "sha256:b185bae1f03f3575293a96551e7a75ffe9a408f323c75e187e499dda231e5346"},
+    {file = "terok_sandbox-0.0.28-py3-none-any.whl", hash = "sha256:5f003b9f36434495d31f369172337ef11ceee1ab8b954114e354c1f87bcf78f3"},
 ]
 
 [package.dependencies]
@@ -2430,7 +2430,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.27/terok_sandbox-0.0.27-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.28/terok_sandbox-0.0.28-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2815,4 +2815,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "8a88d32e7487d4dd396949dec913af5035b0dc2feb94c2c58a0584e155e8c1ae"
+content-hash = "051132b88642403d9c8acd7383da781b0d74e3b47cdd7e2213e7ad98ad3dcaa9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.27/terok_sandbox-0.0.27-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.28/terok_sandbox-0.0.28-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -49,6 +49,9 @@ except PackageNotFoundError:
     pass  # editable install or running from source without metadata
 
 # -- Config resolution ---------------------------------------------------------
+# Re-export protocol types from terok-sandbox for convenience
+from terok_sandbox.doctor import CheckVerdict, DoctorCheck
+
 from .agent_config import resolve_provider_value
 
 # -- Agent config preparation --------------------------------------------------
@@ -87,6 +90,7 @@ from .config_stack import ConfigScope, ConfigStack
 
 # -- Credential proxy ----------------------------------------------------------
 from .credential_extractors import extract_credential
+from .doctor import agent_doctor_checks
 
 # -- Provider registry ---------------------------------------------------------
 from .headless_providers import (
@@ -186,6 +190,10 @@ __all__ = [
     "CommandDef",
     "mounts_dir",
     "scan_leaked_credentials",
+    # Doctor (container health checks)
+    "CheckVerdict",
+    "DoctorCheck",
+    "agent_doctor_checks",
     # Runner facade
     "AgentRunner",
 ]

--- a/src/terok_agent/doctor.py
+++ b/src/terok_agent/doctor.py
@@ -183,8 +183,9 @@ def _make_phantom_token_checks(roster: AgentRoster) -> list[DoctorCheck]:
                 def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
                     """Check if env var looks like a phantom token."""
                     val = stdout.strip()
-                    if not val:
-                        return CheckVerdict("warn", f"{env_var}: not set")
+                    if rc != 0 or not val:
+                        hint = "not set" if rc != 0 else "empty"
+                        return CheckVerdict("warn", f"{env_var}: {hint}")
                     if _PHANTOM_TOKEN_RE.match(val):
                         return CheckVerdict("ok", f"{env_var}: phantom token ({pname})")
                     for prefix in _REAL_KEY_PREFIXES:

--- a/src/terok_agent/doctor.py
+++ b/src/terok_agent/doctor.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent-level container health checks.
+
+Contributes domain-specific checks to the layered doctor protocol
+(``terok_sandbox.doctor``): socat bridge liveness, credential file
+integrity in shared mounts, and phantom token / base URL verification.
+
+The checks are returned as :class:`DoctorCheck` specs — probe commands
++ evaluate callables — that the top-level orchestrator (``terok sickbay``)
+executes inside containers via ``podman exec``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from terok_sandbox.doctor import CheckVerdict, DoctorCheck
+
+if TYPE_CHECKING:
+    from .roster import AgentRoster
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BRIDGE_PIDDIR = "/tmp/.terok"  # nosec B108 — matches ensure-bridges.sh in-container paths
+_SSH_AGENT_PIDFILE = f"{_BRIDGE_PIDDIR}/ssh-agent.pid"
+_SSH_AGENT_SOCKET = "/tmp/ssh-agent.sock"  # nosec B108
+_GH_PROXY_PIDFILE = f"{_BRIDGE_PIDDIR}/gh-proxy.pid"
+_GH_PROXY_SOCKET = "/tmp/terok-gh-proxy.sock"  # nosec B108
+
+# Matches 32-character hexadecimal phantom tokens
+_PHANTOM_TOKEN_RE = re.compile(r"^[0-9a-fA-F]{32}$")
+
+# Known real API key prefixes (obvious non-phantom patterns)
+_REAL_KEY_PREFIXES = ("sk-ant-", "sk-", "gho_", "ghp_", "ghs_", "glpat-")
+
+
+# ---------------------------------------------------------------------------
+# Bridge checks
+# ---------------------------------------------------------------------------
+
+
+def _make_ssh_bridge_check() -> DoctorCheck:
+    """Check that the SSH agent socat bridge is alive inside the container."""
+
+    def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
+        """Evaluate bridge liveness probe."""
+        if rc == 0:
+            return CheckVerdict("ok", "SSH agent bridge alive (PID + socket)")
+        return CheckVerdict(
+            "error",
+            "SSH agent bridge dead — socat process or socket missing",
+            fixable=True,
+        )
+
+    return DoctorCheck(
+        category="bridge",
+        label="SSH agent bridge (socat)",
+        probe_cmd=[
+            "bash",
+            "-c",
+            f"kill -0 $(cat {_SSH_AGENT_PIDFILE} 2>/dev/null) 2>/dev/null"
+            f" && test -S {_SSH_AGENT_SOCKET}",
+        ],
+        evaluate=_eval,
+        fix_cmd=["bash", "-lc", "source ensure-bridges.sh"],
+        fix_description="Re-source ensure-bridges.sh to restart the socat bridge.",
+    )
+
+
+def _make_gh_proxy_bridge_check() -> DoctorCheck:
+    """Check that the gh credential proxy socat bridge is alive."""
+
+    def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
+        """Evaluate bridge liveness probe."""
+        if rc == 0:
+            return CheckVerdict("ok", "gh proxy bridge alive (PID + socket)")
+        return CheckVerdict(
+            "error",
+            "gh proxy bridge dead — socat process or socket missing",
+            fixable=True,
+        )
+
+    return DoctorCheck(
+        category="bridge",
+        label="gh proxy bridge (socat)",
+        probe_cmd=[
+            "bash",
+            "-c",
+            f"kill -0 $(cat {_GH_PROXY_PIDFILE} 2>/dev/null) 2>/dev/null"
+            f" && test -S {_GH_PROXY_SOCKET}",
+        ],
+        evaluate=_eval,
+        fix_cmd=["bash", "-lc", "source ensure-bridges.sh"],
+        fix_description="Re-source ensure-bridges.sh to restart the socat bridge.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Credential file check (shared mount integrity)
+# ---------------------------------------------------------------------------
+
+
+def _make_credential_file_checks(roster: AgentRoster) -> list[DoctorCheck]:
+    """Check known credential files in shared mounts for leaked real secrets."""
+    checks: list[DoctorCheck] = []
+    for name, route in roster.proxy_routes.items():
+        if not route.credential_file:
+            continue
+        auth = roster.auth_providers.get(name)
+        if not auth:
+            continue
+
+        container_path = f"{auth.container_mount}/{route.credential_file}"
+        provider_name = name
+
+        def _make_eval(pname: str, cpath: str):  # noqa: ANN202 — closure factory
+            """Create an evaluate closure for a specific provider."""
+
+            def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
+                """Check if file contains phantom tokens or real secrets."""
+                if rc != 0:
+                    # File doesn't exist — that's fine
+                    return CheckVerdict("ok", f"{pname}: no credential file (clean)")
+                content = stdout.strip()
+                if not content:
+                    return CheckVerdict("ok", f"{pname}: credential file empty")
+                # Check for real API key patterns in content
+                for prefix in _REAL_KEY_PREFIXES:
+                    if prefix in content:
+                        return CheckVerdict(
+                            "error",
+                            f"{pname}: real API key detected in {cpath}",
+                            fixable=True,
+                        )
+                return CheckVerdict("ok", f"{pname}: credential file looks clean")
+
+            return _eval
+
+        checks.append(
+            DoctorCheck(
+                category="mount",
+                label=f"Credential file ({name})",
+                probe_cmd=["cat", container_path],
+                evaluate=_make_eval(provider_name, container_path),
+                fix_cmd=["rm", "-f", container_path],
+                fix_description=f"Remove leaked credential file {container_path}.",
+            )
+        )
+    return checks
+
+
+# ---------------------------------------------------------------------------
+# Phantom token integrity
+# ---------------------------------------------------------------------------
+
+
+def _make_phantom_token_checks(roster: AgentRoster) -> list[DoctorCheck]:
+    """Verify that API key env vars contain phantom tokens, not real keys."""
+    checks: list[DoctorCheck] = []
+    seen_vars: set[str] = set()
+
+    for name, route in roster.proxy_routes.items():
+        # Collect all phantom env vars (api_key + oauth types)
+        env_vars = list(route.phantom_env.keys()) + list(route.oauth_phantom_env.keys())
+        for var in env_vars:
+            if var in seen_vars:
+                continue
+            seen_vars.add(var)
+
+            def _make_eval(env_var: str, pname: str):  # noqa: ANN202
+                """Create evaluate closure for a specific env var."""
+
+                def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
+                    """Check if env var looks like a phantom token."""
+                    val = stdout.strip()
+                    if not val:
+                        return CheckVerdict("warn", f"{env_var}: not set")
+                    if _PHANTOM_TOKEN_RE.match(val):
+                        return CheckVerdict("ok", f"{env_var}: phantom token ({pname})")
+                    for prefix in _REAL_KEY_PREFIXES:
+                        if val.startswith(prefix):
+                            return CheckVerdict(
+                                "error",
+                                f"{env_var}: real API key detected — restart task",
+                            )
+                    # Unknown format — could be a new phantom token format or custom key
+                    return CheckVerdict("ok", f"{env_var}: non-standard format ({pname})")
+
+                return _eval
+
+            checks.append(
+                DoctorCheck(
+                    category="env",
+                    label=f"Phantom token ({var})",
+                    probe_cmd=["printenv", var],
+                    evaluate=_make_eval(var, name),
+                )
+            )
+    return checks
+
+
+# ---------------------------------------------------------------------------
+# Base URL override checks
+# ---------------------------------------------------------------------------
+
+
+def _make_base_url_checks(roster: AgentRoster, proxy_port: int) -> list[DoctorCheck]:
+    """Verify base URL env vars point to the credential proxy, not upstream."""
+    checks: list[DoctorCheck] = []
+    seen_vars: set[str] = set()
+    expected_host = f"host.containers.internal:{proxy_port}"
+
+    for name, route in roster.proxy_routes.items():
+        if not route.base_url_env:
+            continue
+        var = route.base_url_env
+        if var in seen_vars:
+            continue
+        seen_vars.add(var)
+
+        def _make_eval(env_var: str, pname: str, host: str):  # noqa: ANN202
+            """Create evaluate closure for a base URL check."""
+
+            def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
+                """Check if base URL points to proxy."""
+                val = stdout.strip()
+                if not val:
+                    return CheckVerdict("warn", f"{env_var}: not set — proxy bypass possible")
+                if host in val:
+                    return CheckVerdict("ok", f"{env_var}: routed through proxy ({pname})")
+                return CheckVerdict(
+                    "error",
+                    f"{env_var}: points to {val!r}, not proxy — restart task",
+                )
+
+            return _eval
+
+        checks.append(
+            DoctorCheck(
+                category="env",
+                label=f"Base URL ({var})",
+                probe_cmd=["printenv", var],
+                evaluate=_make_eval(var, name, expected_host),
+            )
+        )
+    return checks
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def agent_doctor_checks(
+    roster: AgentRoster,
+    *,
+    proxy_port: int | None = None,
+) -> list[DoctorCheck]:
+    """Return agent-level health checks for in-container diagnostics.
+
+    Args:
+        roster: The loaded agent roster.
+        proxy_port: Credential proxy TCP port. Required for base URL checks;
+            if ``None``, base URL checks are skipped.
+
+    Returns:
+        List of :class:`DoctorCheck` instances ready for orchestration.
+    """
+    checks: list[DoctorCheck] = [
+        _make_ssh_bridge_check(),
+        _make_gh_proxy_bridge_check(),
+    ]
+    checks.extend(_make_credential_file_checks(roster))
+    checks.extend(_make_phantom_token_checks(roster))
+    if proxy_port is not None:
+        checks.extend(_make_base_url_checks(roster, proxy_port))
+    return checks

--- a/src/terok_agent/doctor.py
+++ b/src/terok_agent/doctor.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import re
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
 
 from terok_sandbox.doctor import CheckVerdict, DoctorCheck
 
@@ -124,8 +125,12 @@ def _make_credential_file_checks(roster: AgentRoster) -> list[DoctorCheck]:
             def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
                 """Check if file contains phantom tokens or real secrets."""
                 if rc != 0:
-                    # File doesn't exist — that's fine
-                    return CheckVerdict("ok", f"{pname}: no credential file (clean)")
+                    if re.search(r"no such file", stderr, re.IGNORECASE):
+                        return CheckVerdict("ok", f"{pname}: no credential file (clean)")
+                    return CheckVerdict(
+                        "warn",
+                        f"{pname}: cannot read {cpath} — {stderr.strip() or 'unknown error'}",
+                    )
                 content = stdout.strip()
                 if not content:
                     return CheckVerdict("ok", f"{pname}: credential file empty")
@@ -231,7 +236,7 @@ def _make_base_url_checks(roster: AgentRoster, proxy_port: int) -> list[DoctorCh
                 val = stdout.strip()
                 if not val:
                     return CheckVerdict("warn", f"{env_var}: not set — proxy bypass possible")
-                if host in val:
+                if urlparse(val).netloc == host:
                     return CheckVerdict("ok", f"{env_var}: routed through proxy ({pname})")
                 return CheckVerdict(
                     "error",

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -63,6 +63,10 @@ class TestGhProxyBridgeCheck:
         check = _make_gh_proxy_bridge_check()
         assert check.fix_cmd is not None
 
+    def test_category_is_bridge(self) -> None:
+        check = _make_gh_proxy_bridge_check()
+        assert check.category == "bridge"
+
 
 class TestCredentialFileChecks:
     """Known credential file leak detection."""

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for agent-level container health checks."""
+
+from __future__ import annotations
+
+from terok_sandbox.doctor import DoctorCheck
+
+from terok_agent.doctor import (
+    _PHANTOM_TOKEN_RE,
+    _make_base_url_checks,
+    _make_credential_file_checks,
+    _make_gh_proxy_bridge_check,
+    _make_phantom_token_checks,
+    _make_ssh_bridge_check,
+    agent_doctor_checks,
+)
+from terok_agent.roster import get_roster
+
+PROXY_PORT = 18731
+
+
+class TestSSHBridgeCheck:
+    """SSH agent socat bridge liveness check."""
+
+    def test_ok_when_alive(self) -> None:
+        check = _make_ssh_bridge_check()
+        verdict = check.evaluate(0, "", "")
+        assert verdict.severity == "ok"
+
+    def test_error_when_dead(self) -> None:
+        check = _make_ssh_bridge_check()
+        verdict = check.evaluate(1, "", "")
+        assert verdict.severity == "error"
+        assert verdict.fixable is True
+
+    def test_has_fix_cmd(self) -> None:
+        check = _make_ssh_bridge_check()
+        assert check.fix_cmd is not None
+        assert "ensure-bridges.sh" in " ".join(check.fix_cmd)
+
+    def test_category_is_bridge(self) -> None:
+        check = _make_ssh_bridge_check()
+        assert check.category == "bridge"
+
+
+class TestGhProxyBridgeCheck:
+    """gh credential proxy socat bridge liveness check."""
+
+    def test_ok_when_alive(self) -> None:
+        check = _make_gh_proxy_bridge_check()
+        verdict = check.evaluate(0, "", "")
+        assert verdict.severity == "ok"
+
+    def test_error_when_dead(self) -> None:
+        check = _make_gh_proxy_bridge_check()
+        verdict = check.evaluate(1, "", "")
+        assert verdict.severity == "error"
+        assert verdict.fixable is True
+
+    def test_has_fix_cmd(self) -> None:
+        check = _make_gh_proxy_bridge_check()
+        assert check.fix_cmd is not None
+
+
+class TestCredentialFileChecks:
+    """Known credential file leak detection."""
+
+    def test_generates_checks_for_routed_providers(self) -> None:
+        roster = get_roster()
+        checks = _make_credential_file_checks(roster)
+        # Should have at least one check for providers with credential_file
+        providers_with_cred = [
+            n
+            for n, r in roster.proxy_routes.items()
+            if r.credential_file and n in roster.auth_providers
+        ]
+        assert len(checks) == len(providers_with_cred)
+
+    def test_clean_when_file_missing(self) -> None:
+        roster = get_roster()
+        checks = _make_credential_file_checks(roster)
+        if checks:
+            # rc != 0 means file doesn't exist
+            verdict = checks[0].evaluate(1, "", "No such file")
+            assert verdict.severity == "ok"
+
+    def test_error_on_real_key(self) -> None:
+        roster = get_roster()
+        checks = _make_credential_file_checks(roster)
+        if checks:
+            verdict = checks[0].evaluate(0, '{"api_key": "sk-ant-real-key"}', "")
+            assert verdict.severity == "error"
+            assert verdict.fixable is True
+
+    def test_clean_on_empty_file(self) -> None:
+        roster = get_roster()
+        checks = _make_credential_file_checks(roster)
+        if checks:
+            verdict = checks[0].evaluate(0, "", "")
+            assert verdict.severity == "ok"
+
+
+class TestPhantomTokenChecks:
+    """Phantom token integrity verification."""
+
+    def test_phantom_token_regex(self) -> None:
+        assert _PHANTOM_TOKEN_RE.match("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4")
+        assert not _PHANTOM_TOKEN_RE.match("sk-ant-something")
+        assert not _PHANTOM_TOKEN_RE.match("too-short")
+
+    def test_generates_checks_for_env_vars(self) -> None:
+        roster = get_roster()
+        checks = _make_phantom_token_checks(roster)
+        # Should have at least some checks
+        assert len(checks) > 0
+
+    def test_ok_for_phantom_token(self) -> None:
+        roster = get_roster()
+        checks = _make_phantom_token_checks(roster)
+        if checks:
+            verdict = checks[0].evaluate(0, "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4\n", "")
+            assert verdict.severity == "ok"
+
+    def test_error_for_real_key(self) -> None:
+        roster = get_roster()
+        checks = _make_phantom_token_checks(roster)
+        if checks:
+            verdict = checks[0].evaluate(0, "sk-ant-api03-real-key-here\n", "")
+            assert verdict.severity == "error"
+
+    def test_warn_when_unset(self) -> None:
+        roster = get_roster()
+        checks = _make_phantom_token_checks(roster)
+        if checks:
+            # rc=1 from printenv means var is unset, but stdout is empty
+            verdict = checks[0].evaluate(0, "", "")
+            assert verdict.severity == "warn"
+
+    def test_no_duplicate_env_vars(self) -> None:
+        roster = get_roster()
+        checks = _make_phantom_token_checks(roster)
+        env_vars = [" ".join(c.probe_cmd) for c in checks]
+        assert len(env_vars) == len(set(env_vars)), "duplicate env var checks"
+
+
+class TestBaseUrlChecks:
+    """Base URL override verification."""
+
+    def test_generates_checks(self) -> None:
+        roster = get_roster()
+        checks = _make_base_url_checks(roster, PROXY_PORT)
+        assert len(checks) > 0
+
+    def test_ok_when_routed(self) -> None:
+        roster = get_roster()
+        checks = _make_base_url_checks(roster, PROXY_PORT)
+        if checks:
+            verdict = checks[0].evaluate(0, f"http://host.containers.internal:{PROXY_PORT}\n", "")
+            assert verdict.severity == "ok"
+
+    def test_error_when_bypassed(self) -> None:
+        roster = get_roster()
+        checks = _make_base_url_checks(roster, PROXY_PORT)
+        if checks:
+            verdict = checks[0].evaluate(0, "https://api.anthropic.com\n", "")
+            assert verdict.severity == "error"
+
+    def test_warn_when_unset(self) -> None:
+        roster = get_roster()
+        checks = _make_base_url_checks(roster, PROXY_PORT)
+        if checks:
+            verdict = checks[0].evaluate(0, "", "")
+            assert verdict.severity == "warn"
+
+    def test_no_duplicate_vars(self) -> None:
+        roster = get_roster()
+        checks = _make_base_url_checks(roster, PROXY_PORT)
+        vars_checked = [" ".join(c.probe_cmd) for c in checks]
+        assert len(vars_checked) == len(set(vars_checked))
+
+
+class TestAgentDoctorChecks:
+    """Integration: agent_doctor_checks() assembly."""
+
+    def test_includes_bridge_checks(self) -> None:
+        roster = get_roster()
+        checks = agent_doctor_checks(roster, proxy_port=PROXY_PORT)
+        categories = {c.category for c in checks}
+        assert "bridge" in categories
+
+    def test_includes_mount_checks(self) -> None:
+        roster = get_roster()
+        checks = agent_doctor_checks(roster, proxy_port=PROXY_PORT)
+        categories = {c.category for c in checks}
+        assert "mount" in categories
+
+    def test_includes_env_checks(self) -> None:
+        roster = get_roster()
+        checks = agent_doctor_checks(roster, proxy_port=PROXY_PORT)
+        categories = {c.category for c in checks}
+        assert "env" in categories
+
+    def test_skips_base_url_without_port(self) -> None:
+        roster = get_roster()
+        checks_with = agent_doctor_checks(roster, proxy_port=PROXY_PORT)
+        checks_without = agent_doctor_checks(roster, proxy_port=None)
+        base_url_with = [c for c in checks_with if "Base URL" in c.label]
+        base_url_without = [c for c in checks_without if "Base URL" in c.label]
+        assert len(base_url_with) > 0
+        assert len(base_url_without) == 0
+
+    def test_all_are_doctor_check_instances(self) -> None:
+        roster = get_roster()
+        checks = agent_doctor_checks(roster, proxy_port=PROXY_PORT)
+        for check in checks:
+            assert isinstance(check, DoctorCheck)

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -82,9 +82,17 @@ class TestCredentialFileChecks:
         roster = get_roster()
         checks = _make_credential_file_checks(roster)
         if checks:
-            # rc != 0 means file doesn't exist
-            verdict = checks[0].evaluate(1, "", "No such file")
+            # rc != 0 with "No such file" stderr means file doesn't exist
+            verdict = checks[0].evaluate(1, "", "cat: /path: No such file or directory\n")
             assert verdict.severity == "ok"
+
+    def test_warn_on_permission_denied(self) -> None:
+        roster = get_roster()
+        checks = _make_credential_file_checks(roster)
+        if checks:
+            verdict = checks[0].evaluate(1, "", "cat: /path: Permission denied\n")
+            assert verdict.severity == "warn"
+            assert "Permission denied" in verdict.detail
 
     def test_error_on_real_key(self) -> None:
         roster = get_roster()
@@ -134,8 +142,8 @@ class TestPhantomTokenChecks:
         roster = get_roster()
         checks = _make_phantom_token_checks(roster)
         if checks:
-            # rc=1 from printenv means var is unset, but stdout is empty
-            verdict = checks[0].evaluate(0, "", "")
+            # rc=1 from printenv means var is unset
+            verdict = checks[0].evaluate(1, "", "")
             assert verdict.severity == "warn"
 
     def test_no_duplicate_env_vars(self) -> None:


### PR DESCRIPTION
## Summary

- Implements **5 agent-layer health checks** for the layered doctor protocol:
  1. SSH agent socat bridge liveness (PID + socket check)
  2. gh proxy socat bridge liveness (PID + socket check)  
  3. Known credential file leak detection (from roster `credential_file` metadata)
  4. Phantom token integrity verification (32-char hex vs real key patterns)
  5. Base URL override validation (must point to `host.containers.internal`)
- Re-exports `DoctorCheck`/`CheckVerdict` from terok-sandbox for downstream convenience
- Bridge checks are fixable by re-sourcing `ensure-bridges.sh`
- 27 unit tests, 100% docstring coverage

## Dependencies

- Requires terok-sandbox with doctor module: terok-ai/terok-sandbox#66

## Context

Part of the layered sickbay initiative. These checks detect the exact class of issues from the incident where an agent killed socat bridges and reconfigured `gh` CLI, severing host connectivity.

## Test plan

- [x] `pytest tests/unit/test_doctor.py` — 27 tests pass
- [x] Full unit suite — 352 tests pass, 0 failures
- [x] `ruff check` + `ruff format --check` — clean
- [x] `docstr-coverage` — 100% on new module
- [x] `reuse lint` — compliant
- [x] `bandit` — no findings (nosec for intentional /tmp container paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added container diagnostic health checks for bridge connectivity, credential-file integrity, phantom-token/environment validation, and optional base-URL overrides. Checks report actionable statuses (ok/warn/error) and offer remediation guidance.
  * Exposed the diagnostic checks API at the package top-level for easier access.

* **Tests**
  * Added comprehensive tests validating construction, evaluation, deduplication, and behavior of the diagnostic checks.

* **Chores**
  * Updated sandbox dependency to a newer patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->