### PR TITLE
feat: install SonarScanner CLI in L1 image + CodeRabbit roster entry

### DIFF
--- a/src/terok_agent/resources/agents/coderabbit.yaml
+++ b/src/terok_agent/resources/agents/coderabbit.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+kind: tool
+label: CodeRabbit
+binary: coderabbit
+
+credential_proxy:
+  route_prefix: coderabbit
+  upstream: https://app.coderabbit.ai
+  auth_header: Authorization
+  auth_prefix: "Bearer "
+  credential_type: api_key
+  phantom_env:
+    CODERABBIT_API_KEY: true
+  # No base_url_env: the CLI has no API endpoint override.  It does
+  # honour HTTPS_PROXY, but the credential proxy is a reverse proxy
+  # (route-prefix), not a forward proxy (CONNECT tunnel).
+  # Phantom tokens cannot reach the upstream without proxy routing.
+  # Binary not shipped in L1; sidecar architecture under consideration.
+
+auth:
+  host_dir: _coderabbit-config
+  container_mount: /home/dev/.coderabbit
+  modes: [api_key]
+  api_key_hint: "Get your API key from https://app.coderabbit.ai/settings"

--- a/src/terok_agent/resources/agents/sonar.yaml
+++ b/src/terok_agent/resources/agents/sonar.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+kind: tool
+label: SonarCloud
+binary: sonar-scanner
+
+credential_proxy:
+  route_prefix: sonar
+  upstream: https://sonarcloud.io
+  auth_header: Authorization
+  auth_prefix: "Bearer "
+  credential_type: api_key
+  phantom_env:
+    SONAR_TOKEN: true
+  base_url_env: SONAR_HOST_URL
+
+auth:
+  host_dir: _sonar-config
+  container_mount: /home/dev/.sonar
+  modes: [api_key]
+  api_key_hint: "Generate a token at https://sonarcloud.io/account/security"

--- a/src/terok_agent/resources/scripts/hilfe
+++ b/src/terok_agent/resources/scripts/hilfe
@@ -41,6 +41,11 @@ _terok_agents() {
     printf '  \033[36mtoad\033[0m       - Multi-agent TUI (ACP)\n'
 }
 
+_terok_dev_tools() {
+    printf '\n\033[1mDev tools:\033[0m\n'
+    printf '  \033[36msonar-scanner\033[0m - SonarQube/SonarCloud static analysis (needs SONAR_TOKEN)\n'
+}
+
 _terok_notes() {
     printf '\n\033[1mterok container notes:\033[0m\n'
     printf '  - \033[36m/workspace\033[0m  main project git checkout for this task\n'
@@ -59,6 +64,7 @@ _terok_notes() {
 
 _terok_permission_mode
 _terok_agents
+_terok_dev_tools
 
 if [[ "$_mode" == "--kurz" ]]; then
     printf '\nRun \033[1mhilfe\033[0m for more container tips.\n\n'

--- a/src/terok_agent/resources/scripts/update-all-the-things
+++ b/src/terok_agent/resources/scripts/update-all-the-things
@@ -53,4 +53,21 @@ echo -e "\n=== Update ALL the Things: yq ===\n" \
         "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH}" \
     && chmod +x /usr/local/bin/yq
 
+# Ensure unzip is available (not present in pre-SonarScanner L1 images)
+if ! command -v unzip >/dev/null 2>&1; then
+    apt-get update && apt-get install -y --no-install-recommends unzip \
+        && rm -rf /var/lib/apt/lists/*
+fi
+
+echo -e "\n=== Update ALL the Things: SonarScanner CLI ===\n" \
+    && SONAR_VERSION="8.0.1.6346" \
+    && ARCH=$(dpkg --print-architecture) \
+    && case "$ARCH" in amd64) SA="linux-x64";; arm64) SA="linux-aarch64";; esac \
+    && curl -fsSL -o /tmp/sonar-scanner.zip \
+        "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_VERSION}-${SA}.zip" \
+    && rm -rf /opt/sonar-scanner \
+    && unzip -q /tmp/sonar-scanner.zip -d /opt \
+    && mv "/opt/sonar-scanner-${SONAR_VERSION}-${SA}" /opt/sonar-scanner \
+    && rm /tmp/sonar-scanner.zip
+
 echo -e "\n=== All the Things have been updated! ===\n"

--- a/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
@@ -25,7 +25,7 @@ RUN set -eux; \
     apt-get install -y --no-install-recommends \
             curl ca-certificates gnupg \
             python-is-python3 python3 python3-pip python3-venv pipx \
-            nodejs fd-find jq wget socat; \
+            nodejs fd-find jq unzip wget socat; \
     rm -rf /var/lib/apt/lists/*
 
 # Binary tools: yq (YAML processor), ast-grep (structural code search via AST),
@@ -75,8 +75,9 @@ RUN mkdir -p /usr/local/share/terok && \
 # === Cache bust point ===
 # Changing AGENT_CACHE_BUST invalidates all layers below: terok scripts,
 # agent CLIs (gh, glab, vibe, codex, copilot, claude, opencode, toad),
-# and ACP adapters.  System packages (apt, nodejs, python, pipx, uv,
-# yq, ast-grep) and shell config are cached above.
+# dev tools (sonar-scanner), and ACP adapters.
+# System packages (apt, nodejs, python, pipx, uv, yq, ast-grep) and
+# shell config are cached above.
 ARG AGENT_CACHE_BUST=0
 
 # terok scripts — single COPY + distribute (refreshed on agent rebuild)
@@ -147,6 +148,28 @@ RUN set -eux; \
     grep "  ${DEB_NAME}$" /tmp/checksums.txt | sed "s|${DEB_NAME}|/tmp/glab.deb|" | sha256sum -c -; \
     dpkg -i /tmp/glab.deb; \
     rm -f /tmp/glab.deb /tmp/checksums.txt
+
+# Install SonarScanner CLI (local static analysis for SonarQube Cloud/Server).
+# Bundles an embedded JRE; multi-arch (amd64/arm64).
+# Needs SONAR_TOKEN at runtime.
+RUN set -eux; \
+    SONAR_VERSION="8.0.1.6346"; \
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in \
+      amd64) SA="linux-x64" ;; \
+      arm64) SA="linux-aarch64" ;; \
+      *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;; \
+    esac; \
+    SONAR_ZIP="sonar-scanner-cli-${SONAR_VERSION}-${SA}.zip"; \
+    MAVEN_BASE="https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_VERSION}"; \
+    curl -fsSL -o /tmp/sonar-scanner.zip "${MAVEN_BASE}/${SONAR_ZIP}"; \
+    curl -fsSL -o /tmp/sonar-scanner.zip.sha256 "${MAVEN_BASE}/${SONAR_ZIP}.sha256"; \
+    echo "$(cat /tmp/sonar-scanner.zip.sha256)  /tmp/sonar-scanner.zip" | sha256sum -c -; \
+    unzip -q /tmp/sonar-scanner.zip -d /opt; \
+    mv "/opt/sonar-scanner-${SONAR_VERSION}-${SA}" /opt/sonar-scanner; \
+    ln -s /opt/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner; \
+    rm /tmp/sonar-scanner.zip; \
+    sonar-scanner --version
 
 # === User operations (agent installs) ===
 ENV HOME=/home/dev

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -40,15 +40,17 @@ class TestLoadBundledAgents:
         agents = _load_bundled_agents()
         expected = {
             "claude",
+            "coderabbit",
             "codex",
             "copilot",
-            "vibe",
+            "gh",
+            "glab",
             "blablador",
             "kisski",
             "opencode",
-            "gh",
-            "glab",
+            "sonar",
             "toad",
+            "vibe",
         }
         assert set(agents.keys()) == expected
 


### PR DESCRIPTION
## Summary

- Install **SonarScanner CLI** v8.0.1.6346 in the L1 agent container image for local static analysis before pushing PRs
- Add credential proxy roster entries for both **SonarCloud** (full proxy routing) and **CodeRabbit** (auth/storage only — binary not shipped)
- Update `hilfe` banner and `update-all-the-things` script

## Motivation

Agents iterate on PRs by pushing to GitHub and waiting for SonarCloud CI analysis — generating notification noise and slow feedback loops. With SonarScanner in the container, agents can run `sonar-scanner` locally, fixing issues before pushing a clean squashed PR.

## Changes

| File | Change |
|------|--------|
| `l1.agent-cli.Dockerfile.template` | Add `unzip` to apt; install SonarScanner CLI v8.0.1.6346 (embedded JRE, multi-arch) below cache bust point |
| `agents/sonar.yaml` | New roster entry — `kind: tool`, API key auth, `SONAR_TOKEN` phantom env, proxy routing via `SONAR_HOST_URL` |
| `agents/coderabbit.yaml` | New roster entry — `kind: tool`, API key auth, `CODERABBIT_API_KEY` phantom env. **Binary not shipped in L1**: the CLI lacks a base URL override, and MITM proxying is out of scope, so the phantom token flow cannot work. Roster entry provides auth/credential storage for future sidecar-based architecture. |
| `scripts/update-all-the-things` | Add SonarScanner update block |
| `scripts/hilfe` | Add "Dev tools" section with sonar-scanner |
| `tests/unit/test_roster.py` | Add new agents to expected bundled set |

## Why no CodeRabbit binary in L1?

CodeRabbit CLI hardcodes its API endpoint (`app.coderabbit.ai`) with no base URL override. The credential proxy is a reverse proxy — it needs the tool to send traffic through it. Options explored:

- **`HTTPS_PROXY`**: CLI respects it, but the credential proxy lacks forward proxy (CONNECT tunnel) mode
- **MITM TLS termination**: would work but is disproportionate complexity
- **Direct key injection**: breaks the phantom token security model

The roster YAML is included for `terok auth coderabbit` (credential storage), ready for a future sidecar-based review architecture where CodeRabbit runs in its own container with different security guarantees.

## Test plan

- [x] `make check` passes (lint, 355 tests, tach, security, docstrings, REUSE)
- [ ] Build L1 image and verify `sonar-scanner --version` works
- [ ] Test `terok auth sonar` API key flow
- [ ] Verify proxy routing: `SONAR_HOST_URL` injected, phantom token swapped for real token

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CodeRabbit and SonarCloud tool integrations with API-key authentication and setup hints

* **Documentation**
  * Added dev tools section to the startup/help banner listing required environment variables

* **Infrastructure & Configuration**
  * Added SonarScanner install/update steps and included unzip in the image build

* **Tests**
  * Updated bundled-agents test expectations to include the new tools
<!-- end of auto-generated comment: release notes by coderabbit.ai -->