### PR TITLE
chore: bump terok-sandbox to v0.0.27

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2413,13 +2413,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.26"
+version = "0.0.27"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.26-py3-none-any.whl", hash = "sha256:91fc488e51910ec76896d4701571e2f9d28be4d4506805ef2f5ed974e6ec8c51"},
+    {file = "terok_sandbox-0.0.27-py3-none-any.whl", hash = "sha256:b185bae1f03f3575293a96551e7a75ffe9a408f323c75e187e499dda231e5346"},
 ]
 
 [package.dependencies]
@@ -2430,7 +2430,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.26/terok_sandbox-0.0.26-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.27/terok_sandbox-0.0.27-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2815,4 +2815,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "2bd091947322f4fe4dabd39132481086fd53f3a583e86419f11f09ed81916acd"
+content-hash = "8a88d32e7487d4dd396949dec913af5035b0dc2feb94c2c58a0584e155e8c1ae"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.26/terok_sandbox-0.0.26-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.27/terok_sandbox-0.0.27-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"


### PR DESCRIPTION
## Summary
- Bump terok-sandbox from v0.0.26 to v0.0.27
- v0.0.27 decouples CLI binary names from library-layer diagnostics (terok-ai/terok-sandbox#70)

## Test plan
- [x] `poetry lock` resolves cleanly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency to latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->