### PR TITLE
feat: sidecar L1 image — separate containment for tool runners

### DIFF
--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -69,8 +69,11 @@ from .build import (
     BuildError,
     ImageSet,
     build_base_images,
+    build_sidecar_image,
     l0_image_tag,
     l1_image_tag,
+    l1_sidecar_image_tag,
+    render_l1_sidecar,
     stage_scripts,
     stage_tmux_config,
     stage_toad_agents,
@@ -102,7 +105,7 @@ from .headless_providers import (
 from .instructions import bundled_default_instructions, resolve_instructions
 from .paths import mounts_dir
 from .proxy_commands import PROXY_COMMANDS, scan_leaked_credentials
-from .roster import CredentialProxyRoute, ensure_proxy_routes, get_roster
+from .roster import CredentialProxyRoute, SidecarSpec, ensure_proxy_routes, get_roster
 
 # -- Runner facade -------------------------------------------------------------
 from .runner import AgentRunner
@@ -162,8 +165,11 @@ __all__ = [
     "BuildError",
     "ImageSet",
     "build_base_images",
+    "build_sidecar_image",
     "l0_image_tag",
     "l1_image_tag",
+    "l1_sidecar_image_tag",
+    "render_l1_sidecar",
     "stage_scripts",
     "stage_toad_agents",
     "stage_tmux_config",
@@ -172,6 +178,7 @@ __all__ = [
     "ensure_proxy_routes",
     "extract_credential",
     # Roster
+    "SidecarSpec",
     "get_roster",
     # Command registry
     "AGENT_COMMANDS",

--- a/src/terok_agent/build.py
+++ b/src/terok_agent/build.py
@@ -102,6 +102,11 @@ def l1_image_tag(base_image: str) -> str:
     return f"terok-l1-cli:{_base_tag(base_image)}"
 
 
+def l1_sidecar_image_tag(base_image: str) -> str:
+    """Return the L1 sidecar (tool-only) image tag for *base_image*."""
+    return f"terok-l1-sidecar:{_base_tag(base_image)}"
+
+
 @dataclass(frozen=True)
 class ImageSet:
     """L0 + L1 image tags produced by a build."""
@@ -111,6 +116,9 @@ class ImageSet:
 
     l1: str
     """L1 agent CLI image tag (e.g. ``terok-l1-cli:ubuntu-24.04``)."""
+
+    l1_sidecar: str | None = None
+    """L1 sidecar image tag, if built (e.g. ``terok-l1-sidecar:ubuntu-24.04``)."""
 
 
 # ---------------------------------------------------------------------------
@@ -232,6 +240,21 @@ def render_l1(l0_image: str, *, cache_bust: str = "0") -> str:
     return _render_template(
         "l1.agent-cli.Dockerfile.template",
         {"BASE_IMAGE": l0_image, "AGENT_CACHE_BUST": cache_bust},
+    )
+
+
+def render_l1_sidecar(
+    l0_image: str, *, tool_name: str = "coderabbit", cache_bust: str = "0"
+) -> str:
+    """Render the L1 sidecar (tool-only) Dockerfile.
+
+    The sidecar image is built FROM L0 (not L1) and installs a single
+    tool binary — no agent CLIs, no LLMs.  The *tool_name* selects which
+    tool install block to activate via Jinja2 conditional.
+    """
+    return _render_template(
+        "l1.sidecar.Dockerfile.template",
+        {"BASE_IMAGE": l0_image, "TOOL_CACHE_BUST": cache_bust, "tool_name": tool_name},
     )
 
 
@@ -373,3 +396,75 @@ def build_base_images(
             shutil.rmtree(context, ignore_errors=True)
 
     return ImageSet(l0=l0_tag, l1=l1_tag)
+
+
+def build_sidecar_image(
+    base_image: str = DEFAULT_BASE_IMAGE,
+    *,
+    tool_name: str = "coderabbit",
+    rebuild: bool = False,
+    full_rebuild: bool = False,
+    build_dir: Path | None = None,
+) -> str:
+    """Build the L1 sidecar image for a specific tool. Returns the image tag.
+
+    Ensures L0 exists first (builds it if missing), then builds the
+    sidecar image FROM L0.  The sidecar contains only the named tool —
+    no agent CLIs, no LLMs.
+
+    Args:
+        base_image: Base OS image (passed through to L0 build).
+        tool_name: Tool to install (selects Jinja2 conditional in template).
+        rebuild: Force rebuild with cache bust.
+        full_rebuild: Force rebuild with ``--no-cache``.
+        build_dir: Build context directory (must be empty or absent).
+
+    Returns:
+        The sidecar image tag (e.g. ``terok-l1-sidecar:ubuntu-24.04``).
+
+    Raises:
+        BuildError: If podman is missing or a build step fails.
+    """
+    _check_podman()
+
+    base_image = _normalize_base_image(base_image)
+    l0_tag = l0_image_tag(base_image)
+    sidecar_tag = l1_sidecar_image_tag(base_image)
+
+    if not rebuild and not full_rebuild and _image_exists(sidecar_tag) and _image_exists(l0_tag):
+        return sidecar_tag
+
+    # Ensure L0 exists (build if needed)
+    if not _image_exists(l0_tag) or full_rebuild:
+        build_base_images(base_image, rebuild=rebuild, full_rebuild=full_rebuild)
+
+    import tempfile
+
+    own_tmp = build_dir is None
+    context = build_dir or Path(tempfile.mkdtemp(prefix="terok-agent-sidecar-"))
+
+    try:
+        prepare_build_context(context)
+        cache_bust = str(int(time.time()))
+
+        (context / "L1.sidecar.Dockerfile").write_text(
+            render_l1_sidecar(l0_tag, tool_name=tool_name, cache_bust=cache_bust)
+        )
+
+        cmd = ["podman", "build", "-f", str(context / "L1.sidecar.Dockerfile")]
+        cmd += ["--build-arg", f"BASE_IMAGE={l0_tag}"]
+        cmd += ["--build-arg", f"TOOL_CACHE_BUST={cache_bust}"]
+        cmd += ["-t", sidecar_tag]
+        if full_rebuild:
+            cmd.append("--no-cache")
+        cmd.append(str(context))
+
+        print("$", shlex.join(cmd))
+        subprocess.run(cmd, check=True)
+    except (OSError, subprocess.CalledProcessError) as e:
+        raise BuildError(f"Sidecar image build failed: {e}") from e
+    finally:
+        if own_tmp:
+            shutil.rmtree(context, ignore_errors=True)
+
+    return sidecar_tag

--- a/src/terok_agent/commands.py
+++ b/src/terok_agent/commands.py
@@ -308,7 +308,7 @@ RUN_TOOL_COMMAND = CommandDef(
         ArgDef(name="--no-gate", action="store_true", help="Disable gate"),
         ArgDef(name="--name", help="Container name override"),
         ArgDef(name="--timeout", type=int, default=600, help="Timeout in seconds (default: 600)"),
-        ArgDef(name="--", dest="tool_args", nargs="*", help="Extra args passed to the tool"),
+        ArgDef(name="tool_args", nargs="*", help="Extra args passed to the tool (after --)"),
     ),
 )
 

--- a/src/terok_agent/commands.py
+++ b/src/terok_agent/commands.py
@@ -79,10 +79,14 @@ def _handle_agents(*, show_all: bool = False) -> None:
 
 
 def _handle_build(
-    *, base: str = "ubuntu:24.04", rebuild: bool = False, full_rebuild: bool = False
+    *,
+    base: str = "ubuntu:24.04",
+    rebuild: bool = False,
+    full_rebuild: bool = False,
+    sidecar: bool = False,
 ) -> None:
-    """Build L0+L1 container images."""
-    from .build import BuildError, build_base_images
+    """Build L0+L1 container images (optionally include sidecar L1)."""
+    from .build import BuildError, build_base_images, build_sidecar_image
 
     try:
         images = build_base_images(base, rebuild=rebuild, full_rebuild=full_rebuild)
@@ -90,6 +94,13 @@ def _handle_build(
         raise SystemExit(str(e)) from e
     print(f"\nL0: {images.l0}")
     print(f"L1: {images.l1}")
+
+    if sidecar:
+        try:
+            tag = build_sidecar_image(base, rebuild=rebuild, full_rebuild=full_rebuild)
+        except BuildError as e:
+            raise SystemExit(str(e)) from e
+        print(f"L1 (sidecar): {tag}")
 
 
 def _handle_run(
@@ -169,6 +180,34 @@ def _handle_auth(*, agent: str, api_key: str | None = None) -> None:
     from .proxy_config import write_proxy_config
 
     write_proxy_config(agent)
+
+
+def _handle_run_tool(
+    *,
+    tool: str,
+    repo: str = ".",
+    branch: str | None = None,
+    gate: bool = True,
+    no_gate: bool = False,
+    name: str | None = None,
+    timeout: int = 600,
+    tool_args: list[str] | None = None,
+) -> None:
+    """Run a tool in a sidecar container."""
+    from .runner import AgentRunner
+
+    effective_gate = gate and not no_gate
+    runner = AgentRunner()
+    cname = runner.run_tool(
+        tool,
+        repo,
+        tool_args=tuple(tool_args or ()),
+        branch=branch,
+        gate=effective_gate,
+        name=name,
+        timeout=timeout,
+    )
+    print(f"Container: {cname}")
 
 
 def _handle_ls() -> None:
@@ -253,6 +292,23 @@ BUILD_COMMAND = CommandDef(
         ArgDef(name="--base", default="ubuntu:24.04", help="Base OS image (default: ubuntu:24.04)"),
         ArgDef(name="--rebuild", action="store_true", help="Force rebuild (cache bust)"),
         ArgDef(name="--full-rebuild", action="store_true", help="Force --no-cache --pull=always"),
+        ArgDef(name="--sidecar", action="store_true", help="Also build sidecar L1 (CodeRabbit)"),
+    ),
+)
+
+RUN_TOOL_COMMAND = CommandDef(
+    name="run-tool",
+    help="Run a tool in a sidecar container (separate L1, real API key)",
+    handler=_handle_run_tool,
+    args=(
+        ArgDef(name="tool", help="Tool name (coderabbit)"),
+        ArgDef(name="repo", nargs="?", default=".", help="Local path or git URL (default: .)"),
+        ArgDef(name="--branch", help="Git branch to check out"),
+        ArgDef(name="--gate", action="store_true", default=True, help="Use gate (default)"),
+        ArgDef(name="--no-gate", action="store_true", help="Disable gate"),
+        ArgDef(name="--name", help="Container name override"),
+        ArgDef(name="--timeout", type=int, default=600, help="Timeout in seconds (default: 600)"),
+        ArgDef(name="--", dest="tool_args", nargs="*", help="Extra args passed to the tool"),
     ),
 )
 
@@ -268,6 +324,7 @@ STOP_COMMAND = CommandDef(
 #: All terok-agent commands.
 COMMANDS: tuple[CommandDef, ...] = (
     RUN_COMMAND,
+    RUN_TOOL_COMMAND,
     AUTH_COMMAND,
     AGENTS_COMMAND,
     BUILD_COMMAND,

--- a/src/terok_agent/resources/agents/coderabbit.yaml
+++ b/src/terok_agent/resources/agents/coderabbit.yaml
@@ -19,6 +19,11 @@ credential_proxy:
   # Phantom tokens cannot reach the upstream without proxy routing.
   # Binary not shipped in L1; sidecar architecture under consideration.
 
+sidecar:
+  tool_name: coderabbit
+  env_map:
+    CODERABBIT_API_KEY: key     # inject real key from credential DB
+
 auth:
   host_dir: _coderabbit-config
   container_mount: /home/dev/.coderabbit

--- a/src/terok_agent/resources/templates/l1.sidecar.Dockerfile.template
+++ b/src/terok_agent/resources/templates/l1.sidecar.Dockerfile.template
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+# L1 sidecar — lightweight tool container built FROM L0.
+# No agent CLIs, no LLMs — just the specified tool binary and git.
+# Shares L0's cached layers (git, SSH, locale, dev user, init scripts).
+ARG BASE_IMAGE=terok-l0:latest
+FROM ${BASE_IMAGE}
+
+ENV DEBIAN_FRONTEND=noninteractive
+USER root
+
+# Minimal extras for tool install scripts.
+# L0 already provides: git, SSH, curl, ca-certificates, locale, dev user,
+# init-ssh-and-repo.sh, ensure-bridges.sh, ssh-agent-bridge.sh.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG TOOL_CACHE_BUST=0
+
+{% if tool_name == "coderabbit" %}
+# CodeRabbit CLI — local AI code review (single-binary Node.js SEA).
+# Installed to /usr/local/bin via the official installer script.
+# Needs CODERABBIT_API_KEY at runtime (injected directly, not via proxy).
+RUN set -eux; \
+    CODERABBIT_INSTALL_DIR=/usr/local/bin \
+    curl -fsSL https://cli.coderabbit.ai/install.sh | sh; \
+    coderabbit --version
+{% endif %}
+
+USER dev
+ENV HOME=/home/dev
+WORKDIR /workspace
+# No CMD: reuse init-ssh-and-repo.sh from L0 base image

--- a/src/terok_agent/roster.py
+++ b/src/terok_agent/roster.py
@@ -353,6 +353,36 @@ def _to_proxy_route(name: str, data: dict) -> CredentialProxyRoute | None:
 
 
 @dataclass(frozen=True)
+class SidecarSpec:
+    """Sidecar container configuration parsed from a ``sidecar:`` YAML section.
+
+    Tools with sidecar specs run in a separate lightweight L1 image
+    (no agent CLIs) and receive the real API key instead of phantom tokens.
+    """
+
+    tool_name: str
+    """Tool identifier used to select the Jinja2 install block in the template."""
+
+    env_map: dict[str, str] = field(default_factory=dict)
+    """Maps container env var names to credential dict keys.
+
+    Example: ``{"CODERABBIT_API_KEY": "key"}`` reads ``cred["key"]`` and
+    injects it as ``CODERABBIT_API_KEY``.
+    """
+
+
+def _to_sidecar_spec(name: str, data: dict) -> SidecarSpec | None:
+    """Parse the optional ``sidecar:`` YAML section into a :class:`SidecarSpec`."""
+    sc = data.get("sidecar")
+    if not sc:
+        return None
+    return SidecarSpec(
+        tool_name=sc.get("tool_name", name),
+        env_map=dict(sc.get("env_map", {})),
+    )
+
+
+@dataclass(frozen=True)
 class AgentRoster:
     """Loaded roster of agents and tools from YAML definitions.
 
@@ -362,6 +392,7 @@ class AgentRoster:
     _providers: dict[str, HeadlessProvider] = field(default_factory=dict)
     _auth_providers: dict[str, AuthProvider] = field(default_factory=dict)
     _proxy_routes: dict[str, CredentialProxyRoute] = field(default_factory=dict)
+    _sidecar_specs: dict[str, SidecarSpec] = field(default_factory=dict)
     _mounts: tuple[MountDef, ...] = ()
     _agent_names: tuple[str, ...] = ()
     _all_names: tuple[str, ...] = ()
@@ -420,6 +451,22 @@ class AgentRoster:
             available = ", ".join(sorted(self._auth_providers))
             raise SystemExit(f"Unknown auth provider: {name!r}. Available: {available}")
         return info
+
+    @property
+    def sidecar_specs(self) -> dict[str, SidecarSpec]:
+        """All sidecar tool specs, keyed by tool name."""
+        return dict(self._sidecar_specs)
+
+    def get_sidecar_spec(self, name: str) -> SidecarSpec:
+        """Look up a sidecar spec by tool name.
+
+        Raises ``SystemExit`` if the name has no sidecar configuration.
+        """
+        spec = self._sidecar_specs.get(name)
+        if spec is None:
+            available = ", ".join(sorted(self._sidecar_specs)) or "(none)"
+            raise SystemExit(f"No sidecar config for {name!r}. Available: {available}")
+        return spec
 
     @property
     def proxy_routes(self) -> dict[str, CredentialProxyRoute]:
@@ -494,6 +541,7 @@ def load_roster() -> AgentRoster:
     providers: dict[str, HeadlessProvider] = {}
     auth_providers: dict[str, AuthProvider] = {}
     proxy_routes: dict[str, CredentialProxyRoute] = {}
+    sidecar_specs: dict[str, SidecarSpec] = {}
     agent_names: list[str] = []
     all_names: list[str] = []
 
@@ -548,10 +596,16 @@ def load_roster() -> AgentRoster:
         if proxy_route is not None:
             proxy_routes[name] = proxy_route
 
+        # Sidecar spec
+        sidecar = _to_sidecar_spec(name, data)
+        if sidecar is not None:
+            sidecar_specs[name] = sidecar
+
     return AgentRoster(
         _providers=providers,
         _auth_providers=auth_providers,
         _proxy_routes=proxy_routes,
+        _sidecar_specs=sidecar_specs,
         _mounts=tuple(seen_mounts.values()),
         _agent_names=tuple(agent_names),
         _all_names=tuple(all_names),

--- a/src/terok_agent/runner.py
+++ b/src/terok_agent/runner.py
@@ -254,10 +254,10 @@ class AgentRunner:
         this injects the actual credential.  Safe because sidecar containers
         have no agent code that could leak it.
         """
-        from terok_sandbox import CredentialDB, SandboxConfig
+        from terok_sandbox import CredentialDB
 
         spec = self.roster.get_sidecar_spec(tool_name)
-        cfg = SandboxConfig()
+        cfg = self.sandbox.config
         try:
             db = CredentialDB(cfg.proxy_db_path)
         except Exception as exc:

--- a/src/terok_agent/runner.py
+++ b/src/terok_agent/runner.py
@@ -107,6 +107,12 @@ class AgentRunner:
         images = build_base_images(self._base_image)
         return images.l1
 
+    def _ensure_sidecar_image(self, tool_name: str) -> str:
+        """Ensure sidecar L1 exists for *tool_name*, return its tag."""
+        from .build import build_sidecar_image
+
+        return build_sidecar_image(self._base_image, tool_name=tool_name)
+
     def _shared_mounts(self, mounts_base: Path) -> list[str]:
         """Derive shared volume mounts from the agent roster.
 
@@ -240,6 +246,44 @@ class AgentRunner:
 
         _logger.debug("Credential proxy: injected %d env vars for %s", len(env), stored_providers)
         return env
+
+    def _direct_credential_env(self, tool_name: str) -> dict[str, str]:
+        """Load the real API key for a sidecar tool and return as env dict.
+
+        Unlike :meth:`_credential_proxy_env` (which creates phantom tokens),
+        this injects the actual credential.  Safe because sidecar containers
+        have no agent code that could leak it.
+        """
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        spec = self.roster.get_sidecar_spec(tool_name)
+        cfg = SandboxConfig()
+        try:
+            db = CredentialDB(cfg.proxy_db_path)
+        except Exception as exc:
+            print(
+                f"Warning [runner]: credential DB unavailable: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            return {}
+        try:
+            cred = db.load_credential("default", tool_name)
+        finally:
+            db.close()
+
+        if cred is None:
+            print(
+                f"Warning [runner]: no credentials stored for {tool_name!r}. "
+                f"Run: terok-agent auth {tool_name} --api-key <key>",
+                file=sys.stderr,
+            )
+            return {}
+
+        return {
+            env_var: str(cred.get(cred_key, ""))
+            for env_var, cred_key in spec.env_map.items()
+            if cred.get(cred_key)
+        }
 
     @staticmethod
     def _stream_headless(cname: str, timeout: float) -> None:
@@ -485,6 +529,36 @@ class AgentRunner:
             hooks=hooks,
         )
 
+    def run_tool(
+        self,
+        tool: str,
+        repo: str,
+        *,
+        tool_args: tuple[str, ...] = (),
+        branch: str | None = None,
+        gate: bool = True,
+        name: str | None = None,
+        follow: bool = True,
+        timeout: int = 600,
+    ) -> str:
+        """Launch a sidecar tool container. Returns container name.
+
+        Runs the named tool in a lightweight sidecar L1 image (no agent
+        CLIs).  The tool receives the real API key from the credential
+        store — not a phantom token.
+        """
+        return self._run(
+            provider=tool,
+            repo=repo,
+            mode="tool",
+            gate=gate,
+            name=name,
+            follow=follow,
+            timeout=timeout,
+            tool_args=tool_args,
+            branch=branch,
+        )
+
     def _run(
         self,
         *,
@@ -504,16 +578,22 @@ class AgentRunner:
         unrestricted: bool = True,
         gpu: bool = False,
         hooks: LifecycleHooks | None = None,
+        tool_args: tuple[str, ...] = (),
     ) -> str:
-        """Unified launch flow for all three modes."""
-        from .headless_providers import build_headless_command
-
-        agent = self.roster.get_provider(provider)
+        """Unified launch flow for all modes (headless, interactive, web, tool)."""
+        is_tool = mode == "tool"
         task_id = _generate_task_id()
         code_repo, local_path = _resolve_repo(repo)
 
-        # Ensure images
-        l1_tag = self._ensure_images()
+        # Ensure images — sidecar L1 for tools, agent L1 for everything else
+        if is_tool:
+            sidecar_spec = self.roster.get_sidecar_spec(provider)
+            image_tag = self._ensure_sidecar_image(sidecar_spec.tool_name)
+        else:
+            from .headless_providers import build_headless_command
+
+            agent = self.roster.get_provider(provider)
+            image_tag = self._ensure_images()
 
         # Task directory (ephemeral for standalone runs)
         task_dir = Path(tempfile.mkdtemp(prefix=f"terok-agent-{task_id}-"))
@@ -523,15 +603,16 @@ class AgentRunner:
 
         mounts_base = mounts_dir()
 
-        # Prepare agent config (pass local_path so repo instructions.md is found)
-        agent_config_dir = self._prepare_agent_config(
-            task_dir,
-            task_id,
-            provider,
-            prompt=prompt,
-            mounts_base=mounts_base,
-            project_root=local_path,
-        )
+        # Prepare agent config — tools don't need wrappers or instructions
+        if not is_tool:
+            agent_config_dir = self._prepare_agent_config(
+                task_dir,
+                task_id,
+                provider,
+                prompt=prompt,
+                mounts_base=mounts_base,
+                project_root=local_path,
+            )
 
         # Assemble environment
         env = self._base_env(task_id, provider)
@@ -553,23 +634,26 @@ class AgentRunner:
             workspace.mkdir(parents=True, exist_ok=True)
             volumes.append(f"{workspace}:/workspace:Z")
 
-        # Shared auth mounts (derived from roster)
-        volumes += self._shared_mounts(mounts_base)
-
-        # Credential proxy: inject phantom tokens and base URL overrides
-        env.update(self._credential_proxy_env(task_id))
-
-        # Agent config mount
-        volumes.append(f"{agent_config_dir}:/home/dev/.terok:Z")
-
-        # Permission mode — unrestricted enables auto-approve for all agents
-        if unrestricted:
-            env["TEROK_UNRESTRICTED"] = "1"
-            env.update(self.roster.collect_all_auto_approve_env())
+        if is_tool:
+            # Sidecar: inject real API key, no shared agent mounts
+            env.update(self._direct_credential_env(provider))
+        else:
+            # Agent: shared auth mounts + phantom tokens + agent config + permission mode
+            volumes += self._shared_mounts(mounts_base)
+            env.update(self._credential_proxy_env(task_id))
+            volumes.append(f"{agent_config_dir}:/home/dev/.terok:Z")
+            if unrestricted:
+                env["TEROK_UNRESTRICTED"] = "1"
+                env.update(self.roster.collect_all_auto_approve_env())
 
         # Build command based on mode
         extra_args: list[str] = []
-        if mode == "headless":
+        if mode == "tool":
+            tool_cmd = f"init-ssh-and-repo.sh && {shlex.quote(provider)}"
+            if tool_args:
+                tool_cmd += " " + " ".join(shlex.quote(a) for a in tool_args)
+            command = ["bash", "-lc", tool_cmd]
+        elif mode == "headless":
             cmd_str = build_headless_command(
                 agent, timeout=timeout, model=model, max_turns=max_turns
             )
@@ -592,7 +676,7 @@ class AgentRunner:
 
         # Launch
         cname = self._launch(
-            image=l1_tag,
+            image=image_tag,
             task_id=task_id,
             env=env,
             volumes=volumes,
@@ -606,7 +690,7 @@ class AgentRunner:
         )
 
         # Follow output if requested
-        if follow and mode == "headless":
+        if follow and mode in ("headless", "tool"):
             self._stream_headless(cname, timeout=float(timeout + 60))
         elif mode == "interactive":
             from terok_sandbox import READY_MARKER

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -16,11 +16,14 @@ from terok_agent.build import (
     _base_tag,
     _normalize_base_image,
     build_base_images,
+    build_sidecar_image,
     l0_image_tag,
     l1_image_tag,
+    l1_sidecar_image_tag,
     prepare_build_context,
     render_l0,
     render_l1,
+    render_l1_sidecar,
     stage_scripts,
     stage_tmux_config,
     stage_toad_agents,
@@ -62,6 +65,21 @@ class TestImageNaming:
         s = ImageSet(l0="terok-l0:test", l1="terok-l1-cli:test")
         assert s.l0 == "terok-l0:test"
         assert s.l1 == "terok-l1-cli:test"
+
+    def test_l1_sidecar_tag(self) -> None:
+        assert l1_sidecar_image_tag("ubuntu:24.04") == "terok-l1-sidecar:ubuntu-24.04"
+
+    def test_l1_sidecar_tag_custom(self) -> None:
+        tag = l1_sidecar_image_tag("nvidia/cuda:12.4")
+        assert tag == "terok-l1-sidecar:nvidia-cuda-12.4"
+
+    def test_image_set_with_sidecar(self) -> None:
+        s = ImageSet(l0="terok-l0:test", l1="terok-l1-cli:test", l1_sidecar="terok-l1-sidecar:test")
+        assert s.l1_sidecar == "terok-l1-sidecar:test"
+
+    def test_image_set_sidecar_defaults_none(self) -> None:
+        s = ImageSet(l0="terok-l0:test", l1="terok-l1-cli:test")
+        assert s.l1_sidecar is None
 
 
 class TestNormalization:
@@ -300,6 +318,30 @@ class TestTemplateRendering:
         content = render_l1("terok-l0:nvidia-cuda-12.4")
         assert "FROM" in content
 
+    def test_l1_sidecar_is_valid_dockerfile(self) -> None:
+        content = render_l1_sidecar("terok-l0:test")
+        assert content.startswith("# syntax=docker")
+        assert "FROM" in content
+
+    def test_l1_sidecar_contains_coderabbit(self) -> None:
+        content = render_l1_sidecar("terok-l0:test", tool_name="coderabbit")
+        assert "coderabbit" in content.lower()
+
+    def test_l1_sidecar_no_agent_installs(self) -> None:
+        content = render_l1_sidecar("terok-l0:test")
+        assert "@openai/codex" not in content
+        assert "claude.ai/install" not in content
+
+    def test_l1_sidecar_contains_cache_bust_arg(self) -> None:
+        content = render_l1_sidecar("terok-l0:test")
+        assert "ARG TOOL_CACHE_BUST=" in content
+
+    def test_l1_sidecar_unknown_tool_empty(self) -> None:
+        """Unknown tool_name renders a valid but tool-less Dockerfile."""
+        content = render_l1_sidecar("terok-l0:test", tool_name="nonexistent")
+        assert "FROM" in content
+        assert "coderabbit" not in content.lower()
+
 
 # ---------------------------------------------------------------------------
 # Build context preparation
@@ -430,3 +472,79 @@ class TestStageTmuxConfig:
         dest = tmp_path / "tmux"
         stage_tmux_config(dest)
         assert not (dest / "__init__.py").exists()
+
+
+# ---------------------------------------------------------------------------
+# Sidecar image build
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSidecarImage:
+    """Verify sidecar image build orchestration with mocked podman."""
+
+    def test_skips_when_images_exist(self) -> None:
+        from unittest.mock import patch
+
+        with (
+            patch("terok_agent.build._check_podman"),
+            patch("terok_agent.build._image_exists", return_value=True),
+        ):
+            tag = build_sidecar_image()
+        assert tag.startswith("terok-l1-sidecar:")
+
+    def test_builds_when_missing(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        # L0 exists but sidecar does not
+        def image_exists_side_effect(image: str) -> bool:
+            return "l0" in image
+
+        build_dir = tmp_path / "ctx"
+        with (
+            patch("terok_agent.build._check_podman"),
+            patch("terok_agent.build._image_exists", side_effect=image_exists_side_effect),
+            patch("subprocess.run") as mock_run,
+        ):
+            tag = build_sidecar_image(build_dir=build_dir)
+
+        # One podman build call (sidecar only — L0 already exists)
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args_list[0][0][0]
+        assert "podman" in cmd[0]
+        assert tag in cmd
+
+    def test_sidecar_dockerfile_in_context(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        def image_exists_side_effect(image: str) -> bool:
+            return "l0" in image
+
+        build_dir = tmp_path / "ctx"
+        with (
+            patch("terok_agent.build._check_podman"),
+            patch("terok_agent.build._image_exists", side_effect=image_exists_side_effect),
+            patch("subprocess.run"),
+        ):
+            build_sidecar_image(build_dir=build_dir)
+
+        assert (build_dir / "L1.sidecar.Dockerfile").is_file()
+        content = (build_dir / "L1.sidecar.Dockerfile").read_text()
+        assert "coderabbit" in content.lower()
+
+    def test_build_failure_raises_build_error(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        def image_exists_side_effect(image: str) -> bool:
+            return "l0" in image
+
+        build_dir = tmp_path / "ctx"
+        with (
+            patch("terok_agent.build._check_podman"),
+            patch("terok_agent.build._image_exists", side_effect=image_exists_side_effect),
+            patch(
+                "subprocess.run",
+                side_effect=subprocess.CalledProcessError(1, "podman"),
+            ),
+            pytest.raises(BuildError, match="Sidecar image build failed"),
+        ):
+            build_sidecar_image(build_dir=build_dir)

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -13,9 +13,11 @@ import pytest
 from terok_agent.auth import AuthProvider
 from terok_agent.headless_providers import HeadlessProvider
 from terok_agent.roster import (
+    SidecarSpec,
     _load_bundled_agents,
     _to_auth_provider,
     _to_headless_provider,
+    _to_sidecar_spec,
     load_roster,
 )
 
@@ -280,6 +282,42 @@ class TestLoadRegistry:
         env = reg.collect_opencode_provider_env()
         assert any(k.startswith("TEROK_OC_BLABLADOR_") for k in env)
         assert any(k.startswith("TEROK_OC_KISSKI_") for k in env)
+
+
+# ---------------------------------------------------------------------------
+# Sidecar spec deserialization
+# ---------------------------------------------------------------------------
+
+
+class TestDeserializeSidecar:
+    """Verify YAML → SidecarSpec conversion."""
+
+    def test_coderabbit_sidecar_spec(self) -> None:
+        agents = _load_bundled_agents()
+        spec = _to_sidecar_spec("coderabbit", agents["coderabbit"])
+
+        assert isinstance(spec, SidecarSpec)
+        assert spec.tool_name == "coderabbit"
+        assert spec.env_map == {"CODERABBIT_API_KEY": "key"}
+
+    def test_no_sidecar_returns_none(self) -> None:
+        result = _to_sidecar_spec("claude", {"label": "Claude", "binary": "claude"})
+        assert result is None
+
+    def test_roster_exposes_sidecar_specs(self) -> None:
+        reg = load_roster()
+        assert "coderabbit" in reg.sidecar_specs
+        assert reg.sidecar_specs["coderabbit"].tool_name == "coderabbit"
+
+    def test_get_sidecar_spec_resolves(self) -> None:
+        reg = load_roster()
+        spec = reg.get_sidecar_spec("coderabbit")
+        assert spec.tool_name == "coderabbit"
+
+    def test_get_sidecar_spec_unknown_exits(self) -> None:
+        reg = load_roster()
+        with pytest.raises(SystemExit, match="No sidecar config"):
+            reg.get_sidecar_spec("nonexistent")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Introduce a lightweight **L1 sidecar image** (`terok-l1-sidecar`) branching from L0 alongside the existing agent-cli L1 — installs a single tool binary (CodeRabbit) with no agent CLIs, establishing a distinct security perimeter where real API keys can be injected without exposure to agent code
- Generalise `AgentRunner._run()` with `mode="tool"`, reusing gate/repo/launch infrastructure while skipping agent config and phantom tokens; new `_direct_credential_env()` reads real keys from `CredentialDB`
- Add `SidecarSpec` dataclass to roster, parsed from new `sidecar:` YAML section in `coderabbit.yaml`; CLI gains `run-tool` subcommand and `build --sidecar` flag

## Image layer architecture

```
              L0 (git + SSH + dev user)
             / \
   L1 cli   /   \  L1 sidecar
  (agents)       (tool only, real API key)
```

## Key design decisions

- **Max reuse**: tool mode is a branch in `_run()`, not a separate method — shares gate, repo resolution, container launch
- **First Jinja2 conditional**: `{% if tool_name == "coderabbit" %}` in the sidecar template
- **Security boundary**: sidecar has no agent code → safe to inject real API key (no phantom token needed)
- **`init-ssh-and-repo.sh` reused as-is** from L0 — toolchain introspection guards handle missing tools gracefully

## Test plan

- [x] 16 new tests across `test_build.py` and `test_roster.py`
- [x] `make check` passes (lint, test, tach, docstrings, reuse, security)
- [ ] Manual: `terok-agent build --sidecar` produces `terok-l1-sidecar:ubuntu-24.04`
- [ ] Manual: `terok-agent run-tool coderabbit <repo>` launches sidecar container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New `run-tool` command to run tools in isolated containers (prints container name)
  * L1 sidecar image build support with a `--sidecar` build option and tool-specific sidecar configuration
  * CodeRabbit integrated as a sidecar-capable tool

* **Tests**
  * Expanded tests covering sidecar image building and sidecar configuration parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->