### PR TITLE
fix: relocate managed-settings write before workspace initialization

### DIFF
--- a/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
@@ -19,6 +19,20 @@ set -euo pipefail
 
 : "${HOME:=/home/dev}"
 
+# Per-task permission mode: write managed settings for agents that need
+# file-based config.  Must run BEFORE git operations — a clone failure under
+# set -e would skip this if it were at the end of the script.
+# Env-var-based agents (Vibe, OpenCode, Copilot) are handled by
+# task_runners.py injecting env vars into the container.
+# Codex has no env var or managed config — it uses CLI flags via the wrapper.
+if [[ "${TEROK_UNRESTRICTED:-}" == "1" ]]; then
+  # Claude: managed-settings.json has highest precedence, per-container.
+  if [[ -d /etc/claude-code ]]; then
+    printf '{"permissions":{"defaultMode":"bypassPermissions"}}\n' \
+      > /etc/claude-code/managed-settings.json
+  fi
+fi
+
 # Socat bridges: SSH agent + gh credential proxy.
 # Delegates to ensure-bridges.sh (single source of truth for both bridges).
 # shellcheck source=ensure-bridges.sh
@@ -311,18 +325,6 @@ fi
 if command -v nvfortran >/dev/null 2>&1; then
   echo "nvfortran:"
   nvfortran --version || true
-fi
-
-# Per-task permission mode: write managed settings for agents that need
-# file-based config.  Env-var-based agents (Vibe, OpenCode, Copilot) are
-# handled by task_runners.py injecting env vars into the container.
-# Codex has no env var or managed config — it uses CLI flags via the wrapper.
-if [[ "${TEROK_UNRESTRICTED:-}" == "1" ]]; then
-  # Claude: managed-settings.json has highest precedence, per-container.
-  if [[ -d /etc/claude-code ]]; then
-    printf '{"permissions":{"defaultMode":"bypassPermissions"}}\n' \
-      > /etc/claude-code/managed-settings.json
-  fi
 fi
 
 # Signal readiness for host tools that watch initial logs


### PR DESCRIPTION
## Summary

- The `managed-settings.json` write (`bypassPermissions` for Claude) was positioned at the **end** of `init-ssh-and-repo.sh`, after all git clone/fetch operations
- Under `set -euo pipefail`, a git clone failure (e.g. unreachable gate server) aborts the script before the permission config is written
- Claude starts without `bypassPermissions` even though `TEROK_UNRESTRICTED=1` is set in the container env
- Fix: move the managed-settings block to the **top** of the script, right after env defaults, before any fallible I/O

## Test plan

- [x] All 402 unit tests pass
- [ ] Start a CLI task where the git clone fails (e.g. gate server not running) — verify `/etc/claude-code/managed-settings.json` exists with `bypassPermissions`
- [ ] Start a CLI task with successful clone — verify same file exists (no regression)
- [ ] Start a CLI task with `unrestricted: false` — verify file is NOT written


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the initialization sequence in internal setup scripts to improve operational ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->