### PR TITLE
chore: relay upgraded sandbox conduit — terok-sandbox 0.0.29, bump 0.0.34

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2413,13 +2413,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.28"
+version = "0.0.29"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.28-py3-none-any.whl", hash = "sha256:5f003b9f36434495d31f369172337ef11ceee1ab8b954114e354c1f87bcf78f3"},
+    {file = "terok_sandbox-0.0.29-py3-none-any.whl", hash = "sha256:827a28e79a58c39f78a99daba19054b8d3aabcb2a96f1ae7d8e24ddee0506c48"},
 ]
 
 [package.dependencies]
@@ -2430,7 +2430,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.28/terok_sandbox-0.0.28-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.29/terok_sandbox-0.0.29-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -2815,4 +2815,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "051132b88642403d9c8acd7383da781b0d74e3b47cdd7e2213e7ad98ad3dcaa9"
+content-hash = "ec93331596bc6d8af19b66da6fd9da8f66744f0ed4bc3cf76b48f7c231776c8a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.31"
+version = "0.0.34"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.28/terok_sandbox-0.0.28-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.29/terok_sandbox-0.0.29-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"


### PR DESCRIPTION
## Summary

- Upgrade terok-sandbox dependency from 0.0.28 to 0.0.29 (gate service stdout/stderr fix, terok-ai/terok-sandbox#72)
- Bump terok-agent version to 0.0.34

## Test plan

- [x] All 402 unit tests pass
- [ ] Merge after terok-sandbox v0.0.29 release is confirmed


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Project version incremented to 0.0.34.
  * Dependency updated to v0.0.29 to incorporate latest improvements and ensure compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->