### PR TITLE
deps: relay upgraded sandbox conduit — terok-sandbox 0.0.32, bump 0.0.37

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2581,34 +2581,34 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.31"
+version = "0.0.32"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.31-py3-none-any.whl", hash = "sha256:34cf61842928530abec330fc7049609245050d515abf094e3387b3bb5d8094b7"},
+    {file = "terok_sandbox-0.0.32-py3-none-any.whl", hash = "sha256:42710e63737092efad3e7c084fe2b0e9e432690a035a9c927070e273a0680631"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.0/terok_shield-0.6.0-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.1/terok_shield-0.6.1-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.31/terok_sandbox-0.0.31-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.32/terok_sandbox-0.0.32-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.0"
+version = "0.6.1"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.0-py3-none-any.whl", hash = "sha256:5db279f029ae591043587ff9fb5a4e7725ffe74df4c87fa928be28953aa31b55"},
+    {file = "terok_shield-0.6.1-py3-none-any.whl", hash = "sha256:8c30eaa02c28b8c892b4a5506d474dbd199defa583789dbacc7396faa30d9999"},
 ]
 
 [package.dependencies]
@@ -2617,7 +2617,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.0/terok_shield-0.6.0-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.1/terok_shield-0.6.1-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -2998,4 +2998,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "9fa7532b06b62d915de3274da0931573b3aa7c329801067215bf9467fdcb49f9"
+content-hash = "16112041d3ba0b3adbcef7084ecfbcac285f4cc046d759d322e43ad13047729c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-agent"
-version = "0.0.36"
+version = "0.0.37"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.31/terok_sandbox-0.0.31-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.32/terok_sandbox-0.0.32-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"


### PR DESCRIPTION
## Summary

- Bump `terok-sandbox` from 0.0.31 to 0.0.32
- Bump agent version from 0.0.36 to 0.0.37

### Dependency chain

```
terok-shield 0.6.1 — restored COMMANDS/ArgDef/CommandDef re-exports
  └─ terok-sandbox 0.0.32
      └─ terok-agent 0.0.37 (this PR)
```

Propagates the shield 0.6.1 fix through the chain to unblock terok-ai/terok#608.

## Test plan

- [ ] CI green
- [ ] After release: update terok PR #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.0.37.
  * Updated terok-sandbox dependency to v0.0.32.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->