### PR TITLE
refactor: extract container env assembly into assemble_container_env()

### DIFF
--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -48,6 +48,7 @@ try:
 except PackageNotFoundError:
     pass  # editable install or running from source without metadata
 
+# -- Container environment assembly --------------------------------------------
 # -- Config resolution ---------------------------------------------------------
 # Re-export protocol types from terok-sandbox for convenience
 from terok_sandbox.doctor import CheckVerdict, DoctorCheck
@@ -91,6 +92,7 @@ from .config_stack import ConfigScope, ConfigStack
 # -- Credential proxy ----------------------------------------------------------
 from .credential_extractors import extract_credential
 from .doctor import agent_doctor_checks
+from .env_builder import ContainerEnvResult, ContainerEnvSpec, assemble_container_env
 
 # -- Provider registry ---------------------------------------------------------
 from .headless_providers import (
@@ -196,4 +198,8 @@ __all__ = [
     "agent_doctor_checks",
     # Runner facade
     "AgentRunner",
+    # Container environment assembly
+    "ContainerEnvSpec",
+    "ContainerEnvResult",
+    "assemble_container_env",
 ]

--- a/src/terok_agent/commands.py
+++ b/src/terok_agent/commands.py
@@ -103,6 +103,28 @@ def _handle_build(
         print(f"L1 (sidecar): {tag}")
 
 
+def _resolve_host_git_identity() -> tuple[str | None, str | None]:
+    """Read git user.name / user.email from the host's global config."""
+    import subprocess
+
+    name = email = None
+    for key, target in (("user.name", "name"), ("user.email", "email")):
+        try:
+            result = subprocess.run(
+                ["git", "config", "--global", key],
+                capture_output=True,
+                timeout=5,
+            )
+            val = result.stdout.decode().strip() if result.returncode == 0 else None
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            val = None
+        if target == "name":
+            name = val
+        else:
+            email = val
+    return name, email
+
+
 def _handle_run(
     *,
     agent: str,
@@ -120,18 +142,32 @@ def _handle_run(
     name: str | None = None,
     restricted: bool = False,
     gpu: bool = False,
+    git_identity_from_host: bool = False,
 ) -> None:
     """Run an agent in a hardened container."""
     from .runner import AgentRunner
 
+    # Resolve human identity from host git config if requested
+    human_name = human_email = authorship = None
+    if git_identity_from_host:
+        human_name, human_email = _resolve_host_git_identity()
+        if human_name:
+            authorship = "agent-human"
+            print(f"Git identity from host: {human_name} <{human_email or 'nobody@localhost'}>")
+        else:
+            print("Warning: --git-identity-from-host: git config user.name not set, skipping")
+
     effective_gate = gate and not no_gate
     runner = AgentRunner()
-    common = {
+    common: dict = {
         "gate": effective_gate,
         "name": name,
         "branch": branch,
         "unrestricted": not restricted,
         "gpu": gpu,
+        "human_name": human_name,
+        "human_email": human_email,
+        "authorship": authorship,
     }
 
     if web:
@@ -262,6 +298,11 @@ RUN_COMMAND = CommandDef(
             help="Restrict agent permissions (no auto-approve, no-new-privileges)",
         ),
         ArgDef(name="--gpu", action="store_true", help="Enable GPU passthrough"),
+        ArgDef(
+            name="--git-identity-from-host",
+            action="store_true",
+            help="Use host git config user.name/email as human committer identity",
+        ),
     ),
 )
 

--- a/src/terok_agent/env_builder.py
+++ b/src/terok_agent/env_builder.py
@@ -150,7 +150,8 @@ class ContainerEnvResult:
     """Volume mount strings (``host:container[:opts]``)."""
 
     task_dir: Path
-    """Host-side task directory (may have been auto-created)."""
+    """Host-side task directory.  When ``spec.task_dir`` was ``None``, this is
+    an auto-created temporary directory — the **caller owns cleanup**."""
 
 
 # ---------------------------------------------------------------------------

--- a/src/terok_agent/env_builder.py
+++ b/src/terok_agent/env_builder.py
@@ -23,7 +23,6 @@ Usage::
 from __future__ import annotations
 
 import logging
-import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -186,28 +185,15 @@ def _resolve_git_identity(spec: ContainerEnvSpec, roster: AgentRoster) -> dict[s
 def _shared_config_mounts(roster: AgentRoster, mounts_base: Path) -> list[str]:
     """Derive shared volume mounts from the agent roster.
 
-    Iterates auth providers then explicit roster mounts, deduplicating by
-    host directory name.  Creates host directories on demand.
+    Uses ``roster.mounts`` — the already-deduplicated list that merges auth
+    provider mounts and explicit ``mounts:`` YAML sections.  Creates host
+    directories on demand.
     """
-    seen: set[str] = set()
     mounts: list[str] = []
-
-    for _name, ap in sorted(roster.auth_providers.items()):
-        if ap.host_dir_name in seen:
-            continue
-        host_dir = mounts_base / ap.host_dir_name
-        host_dir.mkdir(parents=True, exist_ok=True)
-        mounts.append(f"{host_dir}:{ap.container_mount}:z")
-        seen.add(ap.host_dir_name)
-
     for m in roster.mounts:
-        if m.host_dir in seen:
-            continue
         host_dir = mounts_base / m.host_dir
         host_dir.mkdir(parents=True, exist_ok=True)
         mounts.append(f"{host_dir}:{m.container_path}:z")
-        seen.add(m.host_dir)
-
     return mounts
 
 
@@ -234,10 +220,7 @@ def _inject_proxy_tokens(roster: AgentRoster, scope: str, task_id: str) -> dict[
     try:
         db = CredentialDB(cfg.proxy_db_path)
     except Exception as exc:
-        print(
-            f"Warning [env_builder]: credential proxy DB unavailable: {type(exc).__name__}: {exc}",
-            file=sys.stderr,
-        )
+        _logger.warning("Credential proxy DB unavailable: %s: %s", type(exc).__name__, exc)
         return {}
 
     try:
@@ -249,10 +232,13 @@ def _inject_proxy_tokens(roster: AgentRoster, scope: str, task_id: str) -> dict[
         tokens = {
             name: db.create_proxy_token(scope, task_id, credential_set, name) for name in routed
         }
+        port = get_proxy_port(cfg)
+    except Exception as exc:
+        _logger.warning("Credential proxy token injection failed: %s: %s", type(exc).__name__, exc)
+        return {}
     finally:
         db.close()
 
-    port = get_proxy_port(cfg)
     proxy_base = f"http://host.containers.internal:{port}"
     env: dict[str, str] = {}
 

--- a/src/terok_agent/env_builder.py
+++ b/src/terok_agent/env_builder.py
@@ -1,0 +1,371 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single source of truth for container environment and volume assembly.
+
+Both ``terok-agent run`` (standalone) and ``terok`` (project orchestrator)
+construct identical container environments — shared config mounts, credential
+proxy tokens, git identity, unrestricted-mode flags.  This module provides
+the canonical assembly function so that logic lives in one place.
+
+Usage::
+
+    from terok_agent.env_builder import ContainerEnvSpec, assemble_container_env
+    from terok_agent import get_roster
+
+    result = assemble_container_env(
+        ContainerEnvSpec(task_id="abc", provider_name="claude", workspace_host_path=ws),
+        get_roster(),
+    )
+    # result.env, result.volumes, result.task_dir
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .roster import AgentRoster
+
+_logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Specification (input)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContainerEnvSpec:
+    """Specification for container environment assembly.
+
+    All fields use primitives or :class:`~pathlib.Path` — no terok-specific
+    types.  Callers pre-resolve domain-specific decisions (security class,
+    authorship mode, SSH mount, gate mirror creation) and pass results here.
+    """
+
+    # -- Required ----------------------------------------------------------
+
+    task_id: str
+    """Unique task identifier."""
+
+    provider_name: str
+    """Agent provider name (e.g. ``"claude"``, ``"codex"``)."""
+
+    workspace_host_path: Path
+    """Host-side workspace directory — caller pre-creates, mounted as ``/workspace:Z``."""
+
+    # -- Repository setup --------------------------------------------------
+
+    code_repo: str | None = None
+    """Git URL to clone inside the container (→ ``CODE_REPO``)."""
+
+    clone_from: str | None = None
+    """Secondary clone source for online-mode gate optimization (→ ``CLONE_FROM``)."""
+
+    branch: str | None = None
+    """Git branch to check out (→ ``GIT_BRANCH``)."""
+
+    # -- Git identity (container-level defaults) ---------------------------
+
+    git_author_name: str | None = None
+    """Resolved from roster provider if ``None``."""
+
+    git_author_email: str | None = None
+    git_committer_name: str | None = None
+    git_committer_email: str | None = None
+
+    # -- Authorship mode (for per-agent shell wrappers) --------------------
+
+    authorship: str = "agent"
+    """Authorship mode consumed by in-container wrappers (→ ``TEROK_GIT_AUTHORSHIP``)."""
+
+    human_name: str = "Nobody"
+    """Human operator name (→ ``HUMAN_GIT_NAME``).  terok resolves from project
+    config / ``git config``; standalone uses the default or ``--git-identity-from-host``."""
+
+    human_email: str = "nobody@localhost"
+    """Human operator email (→ ``HUMAN_GIT_EMAIL``)."""
+
+    # -- Credential proxy --------------------------------------------------
+
+    credential_scope: str = "standalone"
+    """Scope for proxy token creation.  terok passes ``project.id``."""
+
+    # -- Permissions -------------------------------------------------------
+
+    unrestricted: bool = True
+    """Enable auto-approve flags for all agents."""
+
+    # -- Agent config ------------------------------------------------------
+
+    agent_config_dir: Path | None = None
+    """Pre-prepared agent config directory (→ ``/home/dev/.terok:Z``)."""
+
+    # -- Shared task directory (multi-agent IPC) ---------------------------
+
+    shared_dir: Path | None = None
+    """Host-side shared directory.  Created by the assembly function if set."""
+
+    shared_mount: str = "/shared"
+    """Container-side mount point for the shared directory."""
+
+    # -- Directories -------------------------------------------------------
+
+    task_dir: Path | None = None
+    """Host-side task directory.  A temp dir is created if ``None``."""
+
+    envs_dir: Path | None = None
+    """Base directory for shared config mounts.  Uses :func:`paths.mounts_dir`
+    if ``None``."""
+
+    # -- Caller-specific mounts --------------------------------------------
+
+    extra_volumes: tuple[str, ...] = ()
+    """Additional volume mount strings (e.g. SSH mounts from terok's security
+    mode logic)."""
+
+
+# ---------------------------------------------------------------------------
+# Result (output)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ContainerEnvResult:
+    """Assembled container environment ready for RunSpec construction.
+
+    Not a ``RunSpec`` — omits launch-time concerns (container name, image,
+    command, GPU, shield bypass).  Callers add those and construct ``RunSpec``.
+    """
+
+    env: dict[str, str]
+    """Environment variables for the container."""
+
+    volumes: tuple[str, ...]
+    """Volume mount strings (``host:container[:opts]``)."""
+
+    task_dir: Path
+    """Host-side task directory (may have been auto-created)."""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_git_identity(spec: ContainerEnvSpec, roster: AgentRoster) -> dict[str, str]:
+    """Resolve the four git identity env vars.
+
+    Uses explicit spec fields when provided, otherwise falls back to the
+    roster provider's configured identity (same name for both author and
+    committer — standalone default).
+    """
+    provider = roster.providers.get(spec.provider_name)
+
+    author_name = spec.git_author_name or (provider.git_author_name if provider else "AI Agent")
+    author_email = spec.git_author_email or (
+        provider.git_author_email if provider else "ai@localhost"
+    )
+    committer_name = spec.git_committer_name or author_name
+    committer_email = spec.git_committer_email or author_email
+
+    return {
+        "GIT_AUTHOR_NAME": author_name,
+        "GIT_AUTHOR_EMAIL": author_email,
+        "GIT_COMMITTER_NAME": committer_name,
+        "GIT_COMMITTER_EMAIL": committer_email,
+    }
+
+
+def _shared_config_mounts(roster: AgentRoster, mounts_base: Path) -> list[str]:
+    """Derive shared volume mounts from the agent roster.
+
+    Iterates auth providers then explicit roster mounts, deduplicating by
+    host directory name.  Creates host directories on demand.
+    """
+    seen: set[str] = set()
+    mounts: list[str] = []
+
+    for _name, ap in sorted(roster.auth_providers.items()):
+        if ap.host_dir_name in seen:
+            continue
+        host_dir = mounts_base / ap.host_dir_name
+        host_dir.mkdir(parents=True, exist_ok=True)
+        mounts.append(f"{host_dir}:{ap.container_mount}:z")
+        seen.add(ap.host_dir_name)
+
+    for m in roster.mounts:
+        if m.host_dir in seen:
+            continue
+        host_dir = mounts_base / m.host_dir
+        host_dir.mkdir(parents=True, exist_ok=True)
+        mounts.append(f"{host_dir}:{m.container_path}:z")
+        seen.add(m.host_dir)
+
+    return mounts
+
+
+def _inject_proxy_tokens(roster: AgentRoster, scope: str, task_id: str) -> dict[str, str]:
+    """Inject credential proxy phantom tokens if the proxy is running.
+
+    Always soft-fails: returns an empty dict when the proxy is not available.
+    Callers that require the proxy (e.g. terok project mode) should call
+    ``ensure_proxy_reachable()`` **before** invoking the assembly function.
+    """
+    from terok_sandbox import (
+        CredentialDB,
+        SandboxConfig,
+        get_proxy_port,
+        is_proxy_running,
+        is_proxy_socket_active,
+    )
+
+    cfg = SandboxConfig()
+    if not (is_proxy_socket_active() or is_proxy_running(cfg)):
+        return {}
+
+    proxy_routes = roster.proxy_routes
+    try:
+        db = CredentialDB(cfg.proxy_db_path)
+    except Exception as exc:
+        print(
+            f"Warning [env_builder]: credential proxy DB unavailable: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return {}
+
+    try:
+        credential_set = "default"
+        stored = set(db.list_credentials(credential_set))
+        routed = stored & proxy_routes.keys()
+        if not routed:
+            return {}
+        tokens = {
+            name: db.create_proxy_token(scope, task_id, credential_set, name) for name in routed
+        }
+    finally:
+        db.close()
+
+    port = get_proxy_port(cfg)
+    proxy_base = f"http://host.containers.internal:{port}"
+    env: dict[str, str] = {}
+
+    for name, route in proxy_routes.items():
+        if name not in routed:
+            continue
+        for env_var in route.phantom_env:
+            env[env_var] = tokens[name]
+        if route.base_url_env:
+            env[route.base_url_env] = proxy_base
+        # OpenCode base URL override for proxied providers
+        provider = roster.providers.get(name)
+        if provider and provider.opencode_config:
+            env[f"TEROK_OC_{name.upper()}_BASE_URL"] = f"{proxy_base}/v1"
+        # glab: redirect API to proxy
+        if name == "glab":
+            env["GITLAB_API_HOST"] = f"host.containers.internal:{port}"
+            env["API_PROTOCOL"] = "http"
+
+    if routed:
+        env["TEROK_PROXY_PORT"] = str(port)
+
+    _logger.debug("Credential proxy: injected %d env vars for %s", len(env), routed)
+    return env
+
+
+# ---------------------------------------------------------------------------
+# Main assembly function
+# ---------------------------------------------------------------------------
+
+
+def assemble_container_env(
+    spec: ContainerEnvSpec,
+    roster: AgentRoster,
+    *,
+    proxy_bypass: bool = False,
+) -> ContainerEnvResult:
+    """Assemble container environment variables and volume mounts.
+
+    This is the **single source of truth** for container env/volume assembly.
+    Both ``AgentRunner._run()`` and terok's ``build_task_env_and_volumes()``
+    delegate here.
+
+    Args:
+        spec: What the caller wants — all host↔container contract fields.
+        roster: Agent roster for shared mounts, proxy routes, provider identity.
+        proxy_bypass: Skip credential proxy entirely (terok's explicit opt-out).
+
+    Returns:
+        Assembled env dict, volume tuple, and resolved task_dir.
+    """
+    from .paths import mounts_dir as _mounts_dir
+
+    env: dict[str, str] = {}
+    volumes: list[str] = []
+
+    # 1. Base env
+    env["TASK_ID"] = spec.task_id
+    env["REPO_ROOT"] = "/workspace"
+    env["GIT_RESET_MODE"] = "none"
+    env["CLAUDE_CONFIG_DIR"] = "/home/dev/.claude"
+
+    # 2. OpenCode provider env
+    env.update(roster.collect_opencode_provider_env())
+
+    # 3. Git identity
+    env.update(_resolve_git_identity(spec, roster))
+
+    # 4. Authorship env (for per-agent wrappers inside container)
+    env["TEROK_GIT_AUTHORSHIP"] = spec.authorship
+    env["HUMAN_GIT_NAME"] = spec.human_name
+    env["HUMAN_GIT_EMAIL"] = spec.human_email
+
+    # 5. Branch
+    if spec.branch:
+        env["GIT_BRANCH"] = spec.branch
+
+    # 6. Repo URLs
+    if spec.code_repo:
+        env["CODE_REPO"] = spec.code_repo
+    if spec.clone_from:
+        env["CLONE_FROM"] = spec.clone_from
+
+    # 7. Workspace volume
+    volumes.append(f"{spec.workspace_host_path}:/workspace:Z")
+
+    # 8. Shared config mounts from roster
+    mounts_base = spec.envs_dir or _mounts_dir()
+    volumes += _shared_config_mounts(roster, mounts_base)
+
+    # 9. Credential proxy
+    if not proxy_bypass:
+        env.update(_inject_proxy_tokens(roster, spec.credential_scope, spec.task_id))
+
+    # 10. Agent config mount
+    if spec.agent_config_dir:
+        volumes.append(f"{spec.agent_config_dir}:/home/dev/.terok:Z")
+
+    # 11. Unrestricted mode
+    if spec.unrestricted:
+        env["TEROK_UNRESTRICTED"] = "1"
+        env.update(roster.collect_all_auto_approve_env())
+
+    # 12. Shared task directory
+    if spec.shared_dir:
+        spec.shared_dir.mkdir(parents=True, exist_ok=True)
+        volumes.append(f"{spec.shared_dir}:{spec.shared_mount}:z")
+        env["TEROK_SHARED_DIR"] = spec.shared_mount
+
+    # 13. Extra volumes
+    volumes.extend(spec.extra_volumes)
+
+    # Resolve task_dir
+    task_dir = spec.task_dir or Path(tempfile.mkdtemp(prefix=f"terok-agent-{spec.task_id}-"))
+
+    return ContainerEnvResult(env=env, volumes=tuple(volumes), task_dir=task_dir)

--- a/src/terok_agent/runner.py
+++ b/src/terok_agent/runner.py
@@ -113,28 +113,7 @@ class AgentRunner:
 
         return build_sidecar_image(self._base_image, tool_name=tool_name)
 
-    def _shared_mounts(self, mounts_base: Path) -> list[str]:
-        """Derive shared volume mounts from the agent roster.
-
-        Includes both auth config mounts (per-provider) and general mounts
-        (e.g. OpenCode runtime dirs) from the ``mounts:`` YAML section.
-        """
-        seen: set[str] = set()
-        mounts = []
-        for _name, ap in sorted(self.roster.auth_providers.items()):
-            host_dir = mounts_base / ap.host_dir_name
-            host_dir.mkdir(parents=True, exist_ok=True)
-            mount = f"{host_dir}:{ap.container_mount}:z"
-            if ap.host_dir_name not in seen:
-                mounts.append(mount)
-                seen.add(ap.host_dir_name)
-        for m in self.roster.mounts:
-            if m.host_dir not in seen:
-                host_dir = mounts_base / m.host_dir
-                host_dir.mkdir(parents=True, exist_ok=True)
-                mounts.append(f"{host_dir}:{m.container_path}:z")
-                seen.add(m.host_dir)
-        return mounts
+    # _shared_mounts() removed — absorbed into env_builder.assemble_container_env()
 
     def _setup_gate(self, repo_url: str, task_id: str) -> str:
         """Mirror a repo via the sandbox gate and return the gate HTTP URL.
@@ -174,78 +153,7 @@ class AgentRunner:
         token = self.sandbox.create_token(repo_key, task_id)
         return self.sandbox.gate_url(gate_path, token)
 
-    def _credential_proxy_env(self, task_id: str) -> dict[str, str]:
-        """Inject phantom tokens and base URL overrides if the proxy is running.
-
-        Unlike terok (which hard-fails when the proxy is down), the standalone
-        runner silently skips proxy integration — credentials may come from
-        shared config mounts instead.
-
-        The proxy listens on a TCP port on the host; containers reach it via
-        ``host.containers.internal:<port>`` (same pattern as the gate server).
-        """
-        from terok_sandbox import (
-            CredentialDB,
-            get_proxy_port,
-            is_proxy_running,
-            is_proxy_socket_active,
-        )
-
-        cfg = self.sandbox.config
-        if not (is_proxy_socket_active() or is_proxy_running(cfg)):
-            return {}
-
-        proxy_routes = self.roster.proxy_routes
-        try:
-            db = CredentialDB(cfg.proxy_db_path)
-        except Exception as exc:
-            print(
-                f"Warning [runner]: credential proxy is running but DB at "
-                f"{cfg.proxy_db_path} is unavailable: {type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            return {}
-        try:
-            credential_set = "default"
-            stored_providers = set(db.list_credentials(credential_set))
-            routed = stored_providers & proxy_routes.keys()
-            if not routed:
-                return {}
-            # Per-provider phantom tokens — each token encodes the provider
-            tokens = {
-                name: db.create_proxy_token("standalone", task_id, credential_set, name)
-                for name in routed
-            }
-        finally:
-            db.close()
-
-        port = get_proxy_port(cfg)
-        proxy_base = f"http://host.containers.internal:{port}"
-        env: dict[str, str] = {}
-
-        for name, route in proxy_routes.items():
-            if name not in routed:
-                continue
-            for env_var in route.phantom_env:
-                env[env_var] = tokens[name]
-            if route.base_url_env:
-                env[route.base_url_env] = proxy_base
-            # Override OpenCode base URL for proxied providers
-            provider = self.roster.providers.get(name)
-            if provider and provider.opencode_config:
-                oc_base_key = f"TEROK_OC_{name.upper()}_BASE_URL"
-                env[oc_base_key] = f"{proxy_base}/v1"
-            # glab: redirect API to proxy via env vars
-            if name == "glab":
-                env["GITLAB_API_HOST"] = f"host.containers.internal:{port}"
-                env["API_PROTOCOL"] = "http"
-
-        # Signal for init script to start socat bridges
-        if routed:
-            env["TEROK_PROXY_PORT"] = str(port)
-
-        _logger.debug("Credential proxy: injected %d env vars for %s", len(env), stored_providers)
-        return env
+    # _credential_proxy_env() removed — absorbed into env_builder.assemble_container_env()
 
     def _direct_credential_env(self, tool_name: str) -> dict[str, str]:
         """Load the real API key for a sidecar tool and return as env dict.
@@ -326,26 +234,7 @@ class AgentRunner:
         if exit_code != 0:
             print(f"Agent exited with code {exit_code}")
 
-    def _base_env(self, task_id: str, provider_name: str) -> dict[str, str]:
-        """Assemble the base environment variables for a container."""
-        env: dict[str, str] = {
-            "TASK_ID": task_id,
-            "REPO_ROOT": "/workspace",
-            "GIT_RESET_MODE": "none",
-        }
-
-        # OpenCode provider env vars (TEROK_OC_* for Blablador, KISSKI, etc.)
-        env.update(self.roster.collect_opencode_provider_env())
-
-        # Git identity — use the agent's configured identity from roster
-        provider = self.roster.providers.get(provider_name)
-        if provider:
-            env["GIT_AUTHOR_NAME"] = provider.git_author_name
-            env["GIT_AUTHOR_EMAIL"] = provider.git_author_email
-            env["GIT_COMMITTER_NAME"] = provider.git_author_name
-            env["GIT_COMMITTER_EMAIL"] = provider.git_author_email
-
-        return env
+    # _base_env() removed — absorbed into env_builder.assemble_container_env()
 
     def _prepare_agent_config(
         self,
@@ -442,6 +331,9 @@ class AgentRunner:
         unrestricted: bool = True,
         gpu: bool = False,
         hooks: LifecycleHooks | None = None,
+        human_name: str | None = None,
+        human_email: str | None = None,
+        authorship: str | None = None,
     ) -> str:
         """Launch a headless agent run. Returns container name.
 
@@ -464,6 +356,9 @@ class AgentRunner:
             unrestricted=unrestricted,
             gpu=gpu,
             hooks=hooks,
+            human_name=human_name,
+            human_email=human_email,
+            authorship=authorship,
         )
 
     def run_interactive(
@@ -477,6 +372,9 @@ class AgentRunner:
         unrestricted: bool = True,
         gpu: bool = False,
         hooks: LifecycleHooks | None = None,
+        human_name: str | None = None,
+        human_email: str | None = None,
+        authorship: str | None = None,
     ) -> str:
         """Launch an interactive container. Returns container name.
 
@@ -492,6 +390,9 @@ class AgentRunner:
             unrestricted=unrestricted,
             gpu=gpu,
             hooks=hooks,
+            human_name=human_name,
+            human_email=human_email,
+            authorship=authorship,
         )
 
     def run_web(
@@ -506,6 +407,9 @@ class AgentRunner:
         unrestricted: bool = True,
         gpu: bool = False,
         hooks: LifecycleHooks | None = None,
+        human_name: str | None = None,
+        human_email: str | None = None,
+        authorship: str | None = None,
     ) -> str:
         """Launch a toad web container. Returns container name.
 
@@ -527,6 +431,9 @@ class AgentRunner:
             unrestricted=unrestricted,
             gpu=gpu,
             hooks=hooks,
+            human_name=human_name,
+            human_email=human_email,
+            authorship=authorship,
         )
 
     def run_tool(
@@ -579,8 +486,14 @@ class AgentRunner:
         gpu: bool = False,
         hooks: LifecycleHooks | None = None,
         tool_args: tuple[str, ...] = (),
+        human_name: str | None = None,
+        human_email: str | None = None,
+        authorship: str | None = None,
     ) -> str:
         """Unified launch flow for all modes (headless, interactive, web, tool)."""
+        from .env_builder import ContainerEnvSpec, assemble_container_env
+        from .paths import mounts_dir
+
         is_tool = mode == "tool"
         task_id = _generate_task_id()
         code_repo, local_path = _resolve_repo(repo)
@@ -598,13 +511,30 @@ class AgentRunner:
         # Task directory (ephemeral for standalone runs)
         task_dir = Path(tempfile.mkdtemp(prefix=f"terok-agent-{task_id}-"))
 
-        # Env base for shared auth mounts
-        from .paths import mounts_dir
-
         mounts_base = mounts_dir()
 
-        # Prepare agent config — tools don't need wrappers or instructions
-        if not is_tool:
+        if is_tool:
+            # Sidecar tools: minimal env, no shared mounts, real API key
+            env: dict[str, str] = {
+                "TASK_ID": task_id,
+                "REPO_ROOT": "/workspace",
+                "GIT_RESET_MODE": "none",
+            }
+            if branch:
+                env["GIT_BRANCH"] = branch
+            env.update(self._direct_credential_env(provider))
+
+            volumes: list[str] = []
+            if local_path:
+                volumes.append(f"{local_path}:/workspace:Z")
+            elif code_repo:
+                effective_repo = self._setup_gate(code_repo, task_id) if gate else code_repo
+                env["CODE_REPO"] = effective_repo
+                workspace = task_dir / "workspace"
+                workspace.mkdir(parents=True, exist_ok=True)
+                volumes.append(f"{workspace}:/workspace:Z")
+        else:
+            # Agent modes: full env assembly via canonical builder
             agent_config_dir = self._prepare_agent_config(
                 task_dir,
                 task_id,
@@ -614,37 +544,44 @@ class AgentRunner:
                 project_root=local_path,
             )
 
-        # Assemble environment
-        env = self._base_env(task_id, provider)
-        if branch:
-            env["GIT_BRANCH"] = branch
-
-        # Repo access: local bind-mount or git clone (with optional gate)
-        volumes: list[str] = []
-        if local_path:
-            volumes.append(f"{local_path}:/workspace:Z")
-        elif code_repo:
-            if gate:
-                # Gate mode: mirror repo, serve via HTTP, block other egress
-                effective_repo = self._setup_gate(code_repo, task_id)
+            # Resolve workspace and gate URL
+            if local_path:
+                ws_host = local_path
+                resolved_code_repo = None
+            elif code_repo:
+                effective_repo = self._setup_gate(code_repo, task_id) if gate else code_repo
+                ws_host = task_dir / "workspace"
+                ws_host.mkdir(parents=True, exist_ok=True)
+                resolved_code_repo = effective_repo
             else:
-                effective_repo = code_repo
-            env["CODE_REPO"] = effective_repo
-            workspace = task_dir / "workspace"
-            workspace.mkdir(parents=True, exist_ok=True)
-            volumes.append(f"{workspace}:/workspace:Z")
+                ws_host = task_dir / "workspace"
+                ws_host.mkdir(parents=True, exist_ok=True)
+                resolved_code_repo = None
 
-        if is_tool:
-            # Sidecar: inject real API key, no shared agent mounts
-            env.update(self._direct_credential_env(provider))
-        else:
-            # Agent: shared auth mounts + phantom tokens + agent config + permission mode
-            volumes += self._shared_mounts(mounts_base)
-            env.update(self._credential_proxy_env(task_id))
-            volumes.append(f"{agent_config_dir}:/home/dev/.terok:Z")
-            if unrestricted:
-                env["TEROK_UNRESTRICTED"] = "1"
-                env.update(self.roster.collect_all_auto_approve_env())
+            spec_kwargs: dict = {
+                "task_id": task_id,
+                "provider_name": provider,
+                "workspace_host_path": ws_host,
+                "code_repo": resolved_code_repo,
+                "branch": branch,
+                "unrestricted": unrestricted,
+                "agent_config_dir": agent_config_dir,
+                "task_dir": task_dir,
+                "envs_dir": mounts_base,
+            }
+            if human_name:
+                spec_kwargs["human_name"] = human_name
+            if human_email:
+                spec_kwargs["human_email"] = human_email
+            if authorship:
+                spec_kwargs["authorship"] = authorship
+
+            result = assemble_container_env(
+                ContainerEnvSpec(**spec_kwargs),
+                self.roster,
+            )
+            env = dict(result.env)
+            volumes = list(result.volumes)
 
         # Build command based on mode
         extra_args: list[str] = []

--- a/tach.toml
+++ b/tach.toml
@@ -109,12 +109,20 @@ depends_on = []
 path = "terok_agent.build"
 depends_on = []
 
+# Container environment assembly — single source of truth for env + volumes
+[[modules]]
+path = "terok_agent.env_builder"
+depends_on = [
+    "terok_agent.paths",
+]
+
 # Agent runner facade — composes sandbox + agent config + container launch
 [[modules]]
 path = "terok_agent.runner"
 depends_on = [
     "terok_agent.agents",
     "terok_agent.build",
+    "terok_agent.env_builder",
     "terok_agent.headless_providers",
     "terok_agent.instructions",
     "terok_agent.paths",
@@ -160,6 +168,7 @@ depends_on = [
     "terok_agent.commands",
     "terok_agent.config_stack",
     "terok_agent.credential_extractors",
+    "terok_agent.env_builder",
     "terok_agent.headless_providers",
     "terok_agent.instructions",
     "terok_agent.paths",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -78,3 +78,42 @@ class TestAgentsCommand:
     def test_unknown_subcommand_exits_nonzero(self) -> None:
         _, _, rc = _run_cli("nonexistent")
         assert rc != 0
+
+
+class TestResolveHostGitIdentity:
+    """Verify _resolve_host_git_identity reads from host git config."""
+
+    def test_reads_name_and_email(self) -> None:
+        from terok_agent.commands import _resolve_host_git_identity
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                type("R", (), {"returncode": 0, "stdout": b"Jane Doe\n"})(),
+                type("R", (), {"returncode": 0, "stdout": b"jane@example.com\n"})(),
+            ]
+            name, email = _resolve_host_git_identity()
+
+        assert name == "Jane Doe"
+        assert email == "jane@example.com"
+
+    def test_returns_none_on_missing_config(self) -> None:
+        from terok_agent.commands import _resolve_host_git_identity
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                type("R", (), {"returncode": 1, "stdout": b""})(),
+                type("R", (), {"returncode": 1, "stdout": b""})(),
+            ]
+            name, email = _resolve_host_git_identity()
+
+        assert name is None
+        assert email is None
+
+    def test_returns_none_when_git_not_found(self) -> None:
+        from terok_agent.commands import _resolve_host_git_identity
+
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            name, email = _resolve_host_git_identity()
+
+        assert name is None
+        assert email is None

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -1,0 +1,532 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the container environment assembly function."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from terok_agent.env_builder import (
+    ContainerEnvResult,
+    ContainerEnvSpec,
+    _resolve_git_identity,
+    _shared_config_mounts,
+    assemble_container_env,
+)
+from terok_agent.roster import get_roster
+
+
+@pytest.fixture
+def roster():
+    """Return the live agent roster (loaded from bundled YAML)."""
+    return get_roster()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Return a pre-created workspace directory."""
+    ws = tmp_path / "workspace"
+    ws.mkdir()
+    return ws
+
+
+@pytest.fixture
+def base_spec(workspace: Path) -> ContainerEnvSpec:
+    """Minimal spec with only required fields."""
+    return ContainerEnvSpec(
+        task_id="test-123",
+        provider_name="claude",
+        workspace_host_path=workspace,
+    )
+
+
+# ---------------------------------------------------------------------------
+# assemble_container_env — base env
+# ---------------------------------------------------------------------------
+
+
+class TestBaseEnv:
+    """Verify base environment variables are always set."""
+
+    def test_task_id(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert result.env["TASK_ID"] == "test-123"
+
+    def test_repo_root(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert result.env["REPO_ROOT"] == "/workspace"
+
+    def test_git_reset_mode(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert result.env["GIT_RESET_MODE"] == "none"
+
+    def test_claude_config_dir(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert result.env["CLAUDE_CONFIG_DIR"] == "/home/dev/.claude"
+
+    def test_returns_frozen_result(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert isinstance(result, ContainerEnvResult)
+
+
+# ---------------------------------------------------------------------------
+# Git identity
+# ---------------------------------------------------------------------------
+
+
+class TestGitIdentity:
+    """Verify git identity resolution from spec fields or roster fallback."""
+
+    def test_identity_from_roster_provider(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.env["GIT_AUTHOR_NAME"] == "Claude"
+        assert result.env["GIT_AUTHOR_EMAIL"] == "noreply@anthropic.com"
+        # Standalone default: committer = author (no human specified)
+        assert result.env["GIT_COMMITTER_NAME"] == "Claude"
+
+    def test_explicit_identity_overrides_roster(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            git_author_name="Human Author",
+            git_author_email="human@example.com",
+            git_committer_name="AI Committer",
+            git_committer_email="ai@example.com",
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.env["GIT_AUTHOR_NAME"] == "Human Author"
+        assert result.env["GIT_AUTHOR_EMAIL"] == "human@example.com"
+        assert result.env["GIT_COMMITTER_NAME"] == "AI Committer"
+        assert result.env["GIT_COMMITTER_EMAIL"] == "ai@example.com"
+
+    def test_committer_defaults_to_author(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            git_author_name="Custom",
+            git_author_email="custom@test.com",
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.env["GIT_COMMITTER_NAME"] == "Custom"
+        assert result.env["GIT_COMMITTER_EMAIL"] == "custom@test.com"
+
+    def test_unknown_provider_uses_fallback(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="nonexistent",
+            workspace_host_path=workspace,
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.env["GIT_AUTHOR_NAME"] == "AI Agent"
+
+
+# ---------------------------------------------------------------------------
+# Authorship env
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorship:
+    """Verify authorship mode and human identity env vars."""
+
+    def test_defaults(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert result.env["TEROK_GIT_AUTHORSHIP"] == "agent"
+        assert result.env["HUMAN_GIT_NAME"] == "Nobody"
+        assert result.env["HUMAN_GIT_EMAIL"] == "nobody@localhost"
+
+    def test_custom_authorship(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            authorship="agent-human",
+            human_name="Jane Doe",
+            human_email="jane@example.com",
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.env["TEROK_GIT_AUTHORSHIP"] == "agent-human"
+        assert result.env["HUMAN_GIT_NAME"] == "Jane Doe"
+        assert result.env["HUMAN_GIT_EMAIL"] == "jane@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Repository setup
+# ---------------------------------------------------------------------------
+
+
+class TestRepoSetup:
+    """Verify repository env vars and branch."""
+
+    def test_code_repo(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            code_repo="http://gate@host:9418/repo",
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.env["CODE_REPO"] == "http://gate@host:9418/repo"
+
+    def test_clone_from(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            clone_from="http://gate@host:9418/mirror",
+            code_repo="https://github.com/user/repo",
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.env["CLONE_FROM"] == "http://gate@host:9418/mirror"
+        assert result.env["CODE_REPO"] == "https://github.com/user/repo"
+
+    def test_branch(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            branch="feat/my-branch",
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.env["GIT_BRANCH"] == "feat/my-branch"
+
+    def test_no_branch_omits_key(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert "GIT_BRANCH" not in result.env
+
+    def test_no_code_repo_omits_key(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert "CODE_REPO" not in result.env
+
+
+# ---------------------------------------------------------------------------
+# Workspace volume
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceVolume:
+    """Verify workspace volume mount."""
+
+    def test_workspace_mounted_with_exclusive_label(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        ws_mount = f"{base_spec.workspace_host_path}:/workspace:Z"
+        assert ws_mount in result.volumes
+
+
+# ---------------------------------------------------------------------------
+# Shared config mounts
+# ---------------------------------------------------------------------------
+
+
+class TestSharedConfigMounts:
+    """Verify roster-derived shared config mounts."""
+
+    def test_claude_config_mounted(self, base_spec, roster, tmp_path):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=base_spec.workspace_host_path,
+            envs_dir=tmp_path / "mounts",
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        mount_str = " ".join(result.volumes)
+        assert "_claude-config" in mount_str
+        assert "/home/dev/.claude:z" in mount_str
+
+    def test_shared_mounts_use_lowercase_z(self, base_spec, roster, tmp_path):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=base_spec.workspace_host_path,
+            envs_dir=tmp_path / "mounts",
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        shared = [v for v in result.volumes if ":z" in v and ":Z" not in v]
+        assert len(shared) > 0
+
+    def test_host_dirs_created(self, base_spec, roster, tmp_path):
+        mounts_base = tmp_path / "mounts"
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=base_spec.workspace_host_path,
+            envs_dir=mounts_base,
+        )
+        assemble_container_env(spec, roster, proxy_bypass=True)
+        assert (mounts_base / "_claude-config").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Agent config mount
+# ---------------------------------------------------------------------------
+
+
+class TestAgentConfigMount:
+    """Verify agent config directory mount."""
+
+    def test_agent_config_mounted_when_set(self, workspace, roster, tmp_path):
+        cfg_dir = tmp_path / "agent-config"
+        cfg_dir.mkdir()
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            agent_config_dir=cfg_dir,
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        expected = f"{cfg_dir}:/home/dev/.terok:Z"
+        assert expected in result.volumes
+
+    def test_no_agent_config_when_none(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert not any("/home/dev/.terok" in v for v in result.volumes)
+
+
+# ---------------------------------------------------------------------------
+# Unrestricted mode
+# ---------------------------------------------------------------------------
+
+
+class TestUnrestrictedMode:
+    """Verify unrestricted/auto-approve env injection."""
+
+    def test_unrestricted_sets_env(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            unrestricted=True,
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.env["TEROK_UNRESTRICTED"] == "1"
+
+    def test_restricted_omits_env(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            unrestricted=False,
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert "TEROK_UNRESTRICTED" not in result.env
+
+
+# ---------------------------------------------------------------------------
+# Shared task directory
+# ---------------------------------------------------------------------------
+
+
+class TestSharedTaskDir:
+    """Verify shared task directory mount and env var."""
+
+    def test_shared_dir_mounted_when_set(self, workspace, roster, tmp_path):
+        shared = tmp_path / "shared"
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            shared_dir=shared,
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert f"{shared}:/shared:z" in result.volumes
+        assert result.env["TEROK_SHARED_DIR"] == "/shared"
+
+    def test_shared_dir_custom_mount(self, workspace, roster, tmp_path):
+        shared = tmp_path / "data"
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            shared_dir=shared,
+            shared_mount="/data/ipc",
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert f"{shared}:/data/ipc:z" in result.volumes
+        assert result.env["TEROK_SHARED_DIR"] == "/data/ipc"
+
+    def test_shared_dir_created(self, workspace, roster, tmp_path):
+        shared = tmp_path / "new-shared"
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            shared_dir=shared,
+        )
+        assemble_container_env(spec, roster, proxy_bypass=True)
+        assert shared.is_dir()
+
+    def test_no_shared_dir_by_default(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert "TEROK_SHARED_DIR" not in result.env
+        assert not any("/shared" in v for v in result.volumes)
+
+
+# ---------------------------------------------------------------------------
+# Extra volumes
+# ---------------------------------------------------------------------------
+
+
+class TestExtraVolumes:
+    """Verify caller-provided extra volumes are appended."""
+
+    def test_extra_volumes_appended(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            extra_volumes=("/host/ssh:/home/dev/.ssh:z",),
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert "/host/ssh:/home/dev/.ssh:z" in result.volumes
+
+
+# ---------------------------------------------------------------------------
+# Credential proxy
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialProxy:
+    """Verify credential proxy token injection."""
+
+    def test_proxy_bypass_skips_injection(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert "TEROK_PROXY_PORT" not in result.env
+
+    def test_proxy_not_running_returns_no_tokens(self, base_spec, roster):
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=False),
+            patch("terok_sandbox.is_proxy_running", return_value=False),
+        ):
+            result = assemble_container_env(base_spec, roster, proxy_bypass=False)
+        assert "TEROK_PROXY_PORT" not in result.env
+
+    def test_proxy_running_injects_tokens(self, workspace, roster, tmp_path):
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
+        db.close()
+
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            credential_scope="test-project",
+        )
+
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=False),
+            patch("terok_sandbox.is_proxy_running", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, proxy_bypass=False)
+
+        assert "ANTHROPIC_API_KEY" in result.env
+        assert result.env["ANTHROPIC_API_KEY"].startswith("terok-p-")
+
+
+# ---------------------------------------------------------------------------
+# Task dir
+# ---------------------------------------------------------------------------
+
+
+class TestTaskDir:
+    """Verify task_dir resolution."""
+
+    def test_explicit_task_dir(self, workspace, roster, tmp_path):
+        td = tmp_path / "my-task"
+        td.mkdir()
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            task_dir=td,
+        )
+        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        assert result.task_dir == td
+
+    def test_auto_creates_temp_dir(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        assert result.task_dir.exists()
+        assert "terok-agent-test-123" in str(result.task_dir)
+
+
+# ---------------------------------------------------------------------------
+# OpenCode provider env
+# ---------------------------------------------------------------------------
+
+
+class TestOpenCodeEnv:
+    """Verify OpenCode provider env vars from roster."""
+
+    def test_opencode_vars_present(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        # Blablador/KISSKI contribute TEROK_OC_* vars
+        oc_vars = [k for k in result.env if k.startswith("TEROK_OC_")]
+        assert len(oc_vars) > 0
+
+
+# ---------------------------------------------------------------------------
+# _resolve_git_identity (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveGitIdentityUnit:
+    """Unit tests for the internal git identity resolver."""
+
+    def test_spec_fields_take_precedence(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+            git_author_name="Override",
+        )
+        identity = _resolve_git_identity(spec, roster)
+        assert identity["GIT_AUTHOR_NAME"] == "Override"
+        # Committer defaults to author when not specified
+        assert identity["GIT_COMMITTER_NAME"] == "Override"
+
+    def test_roster_fallback(self, workspace, roster):
+        spec = ContainerEnvSpec(
+            task_id="t1",
+            provider_name="claude",
+            workspace_host_path=workspace,
+        )
+        identity = _resolve_git_identity(spec, roster)
+        assert identity["GIT_AUTHOR_NAME"] == "Claude"
+
+
+# ---------------------------------------------------------------------------
+# _shared_config_mounts (unit)
+# ---------------------------------------------------------------------------
+
+
+class TestSharedConfigMountsUnit:
+    """Unit tests for the internal shared mount builder."""
+
+    def test_creates_host_dirs(self, roster, tmp_path):
+        mounts = _shared_config_mounts(roster, tmp_path)
+        assert len(mounts) > 0
+        assert (tmp_path / "_claude-config").is_dir()
+
+    def test_deduplicates_by_host_dir(self, roster, tmp_path):
+        mounts = _shared_config_mounts(roster, tmp_path)
+        host_dirs = [m.split(":")[0] for m in mounts]
+        assert len(host_dirs) == len(set(host_dirs))
+
+    def test_all_use_shared_label(self, roster, tmp_path):
+        mounts = _shared_config_mounts(roster, tmp_path)
+        for m in mounts:
+            assert m.endswith(":z"), f"Expected :z label, got: {m}"

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -370,6 +370,25 @@ class TestCredentialProxy:
         assert "ANTHROPIC_API_KEY" in result.env
         assert result.env["ANTHROPIC_API_KEY"].startswith("terok-p-")
 
+    def test_no_routed_providers_returns_empty(self, workspace, envs_dir, roster, tmp_path):
+        """Stored credentials that don't match any proxy route produce no tokens."""
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "nonexistent-provider", {"type": "api_key", "key": "k"})
+        db.close()
+
+        spec = _spec(workspace, envs_dir)
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, proxy_bypass=False)
+        assert "TEROK_PROXY_PORT" not in result.env
+        assert "ANTHROPIC_API_KEY" not in result.env
+
     def test_proxy_db_error_returns_empty(self, base_spec, roster):
         """DB open failure returns empty env gracefully."""
         with (

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -35,13 +35,33 @@ def workspace(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def base_spec(workspace: Path) -> ContainerEnvSpec:
-    """Minimal spec with only required fields."""
+def envs_dir(tmp_path: Path) -> Path:
+    """Temp-backed envs directory — prevents mutating real home."""
+    d = tmp_path / "envs"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def base_spec(workspace: Path, envs_dir: Path) -> ContainerEnvSpec:
+    """Minimal spec with only required fields (all dirs tmp-backed)."""
     return ContainerEnvSpec(
         task_id="test-123",
         provider_name="claude",
         workspace_host_path=workspace,
+        envs_dir=envs_dir,
     )
+
+
+def _spec(workspace: Path, envs_dir: Path, **overrides) -> ContainerEnvSpec:
+    """Shorthand for a tmp-backed spec with overrides."""
+    defaults = {
+        "task_id": "t1",
+        "provider_name": "claude",
+        "workspace_host_path": workspace,
+        "envs_dir": envs_dir,
+    }
+    return ContainerEnvSpec(**(defaults | overrides))
 
 
 # ---------------------------------------------------------------------------
@@ -81,23 +101,17 @@ class TestBaseEnv:
 class TestGitIdentity:
     """Verify git identity resolution from spec fields or roster fallback."""
 
-    def test_identity_from_roster_provider(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-        )
+    def test_identity_from_roster_provider(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir)
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert result.env["GIT_AUTHOR_NAME"] == "Claude"
         assert result.env["GIT_AUTHOR_EMAIL"] == "noreply@anthropic.com"
-        # Standalone default: committer = author (no human specified)
         assert result.env["GIT_COMMITTER_NAME"] == "Claude"
 
-    def test_explicit_identity_overrides_roster(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
+    def test_explicit_identity_overrides_roster(self, workspace, envs_dir, roster):
+        spec = _spec(
+            workspace,
+            envs_dir,
             git_author_name="Human Author",
             git_author_email="human@example.com",
             git_committer_name="AI Committer",
@@ -109,24 +123,14 @@ class TestGitIdentity:
         assert result.env["GIT_COMMITTER_NAME"] == "AI Committer"
         assert result.env["GIT_COMMITTER_EMAIL"] == "ai@example.com"
 
-    def test_committer_defaults_to_author(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            git_author_name="Custom",
-            git_author_email="custom@test.com",
-        )
+    def test_committer_defaults_to_author(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir, git_author_name="Custom", git_author_email="custom@t.com")
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert result.env["GIT_COMMITTER_NAME"] == "Custom"
-        assert result.env["GIT_COMMITTER_EMAIL"] == "custom@test.com"
+        assert result.env["GIT_COMMITTER_EMAIL"] == "custom@t.com"
 
-    def test_unknown_provider_uses_fallback(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="nonexistent",
-            workspace_host_path=workspace,
-        )
+    def test_unknown_provider_uses_fallback(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir, provider_name="nonexistent")
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert result.env["GIT_AUTHOR_NAME"] == "AI Agent"
 
@@ -145,11 +149,10 @@ class TestAuthorship:
         assert result.env["HUMAN_GIT_NAME"] == "Nobody"
         assert result.env["HUMAN_GIT_EMAIL"] == "nobody@localhost"
 
-    def test_custom_authorship(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
+    def test_custom_authorship(self, workspace, envs_dir, roster):
+        spec = _spec(
+            workspace,
+            envs_dir,
             authorship="agent-human",
             human_name="Jane Doe",
             human_email="jane@example.com",
@@ -168,21 +171,15 @@ class TestAuthorship:
 class TestRepoSetup:
     """Verify repository env vars and branch."""
 
-    def test_code_repo(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            code_repo="http://gate@host:9418/repo",
-        )
+    def test_code_repo(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir, code_repo="http://gate@host:9418/repo")
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert result.env["CODE_REPO"] == "http://gate@host:9418/repo"
 
-    def test_clone_from(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
+    def test_clone_from(self, workspace, envs_dir, roster):
+        spec = _spec(
+            workspace,
+            envs_dir,
             clone_from="http://gate@host:9418/mirror",
             code_repo="https://github.com/user/repo",
         )
@@ -190,13 +187,8 @@ class TestRepoSetup:
         assert result.env["CLONE_FROM"] == "http://gate@host:9418/mirror"
         assert result.env["CODE_REPO"] == "https://github.com/user/repo"
 
-    def test_branch(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            branch="feat/my-branch",
-        )
+    def test_branch(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir, branch="feat/my-branch")
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert result.env["GIT_BRANCH"] == "feat/my-branch"
 
@@ -231,39 +223,23 @@ class TestWorkspaceVolume:
 class TestSharedConfigMounts:
     """Verify roster-derived shared config mounts."""
 
-    def test_claude_config_mounted(self, base_spec, roster, tmp_path):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=base_spec.workspace_host_path,
-            envs_dir=tmp_path / "mounts",
-        )
+    def test_claude_config_mounted(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir)
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         mount_str = " ".join(result.volumes)
         assert "_claude-config" in mount_str
         assert "/home/dev/.claude:z" in mount_str
 
-    def test_shared_mounts_use_lowercase_z(self, base_spec, roster, tmp_path):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=base_spec.workspace_host_path,
-            envs_dir=tmp_path / "mounts",
-        )
+    def test_shared_mounts_use_lowercase_z(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir)
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         shared = [v for v in result.volumes if ":z" in v and ":Z" not in v]
         assert len(shared) > 0
 
-    def test_host_dirs_created(self, base_spec, roster, tmp_path):
-        mounts_base = tmp_path / "mounts"
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=base_spec.workspace_host_path,
-            envs_dir=mounts_base,
-        )
+    def test_host_dirs_created(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir)
         assemble_container_env(spec, roster, proxy_bypass=True)
-        assert (mounts_base / "_claude-config").is_dir()
+        assert (envs_dir / "_claude-config").is_dir()
 
 
 # ---------------------------------------------------------------------------
@@ -274,18 +250,12 @@ class TestSharedConfigMounts:
 class TestAgentConfigMount:
     """Verify agent config directory mount."""
 
-    def test_agent_config_mounted_when_set(self, workspace, roster, tmp_path):
+    def test_agent_config_mounted_when_set(self, workspace, envs_dir, roster, tmp_path):
         cfg_dir = tmp_path / "agent-config"
         cfg_dir.mkdir()
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            agent_config_dir=cfg_dir,
-        )
+        spec = _spec(workspace, envs_dir, agent_config_dir=cfg_dir)
         result = assemble_container_env(spec, roster, proxy_bypass=True)
-        expected = f"{cfg_dir}:/home/dev/.terok:Z"
-        assert expected in result.volumes
+        assert f"{cfg_dir}:/home/dev/.terok:Z" in result.volumes
 
     def test_no_agent_config_when_none(self, base_spec, roster):
         result = assemble_container_env(base_spec, roster, proxy_bypass=True)
@@ -300,23 +270,13 @@ class TestAgentConfigMount:
 class TestUnrestrictedMode:
     """Verify unrestricted/auto-approve env injection."""
 
-    def test_unrestricted_sets_env(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            unrestricted=True,
-        )
+    def test_unrestricted_sets_env(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir, unrestricted=True)
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert result.env["TEROK_UNRESTRICTED"] == "1"
 
-    def test_restricted_omits_env(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            unrestricted=False,
-        )
+    def test_restricted_omits_env(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir, unrestricted=False)
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert "TEROK_UNRESTRICTED" not in result.env
 
@@ -329,39 +289,23 @@ class TestUnrestrictedMode:
 class TestSharedTaskDir:
     """Verify shared task directory mount and env var."""
 
-    def test_shared_dir_mounted_when_set(self, workspace, roster, tmp_path):
+    def test_shared_dir_mounted_when_set(self, workspace, envs_dir, roster, tmp_path):
         shared = tmp_path / "shared"
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            shared_dir=shared,
-        )
+        spec = _spec(workspace, envs_dir, shared_dir=shared)
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert f"{shared}:/shared:z" in result.volumes
         assert result.env["TEROK_SHARED_DIR"] == "/shared"
 
-    def test_shared_dir_custom_mount(self, workspace, roster, tmp_path):
+    def test_shared_dir_custom_mount(self, workspace, envs_dir, roster, tmp_path):
         shared = tmp_path / "data"
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            shared_dir=shared,
-            shared_mount="/data/ipc",
-        )
+        spec = _spec(workspace, envs_dir, shared_dir=shared, shared_mount="/data/ipc")
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert f"{shared}:/data/ipc:z" in result.volumes
         assert result.env["TEROK_SHARED_DIR"] == "/data/ipc"
 
-    def test_shared_dir_created(self, workspace, roster, tmp_path):
+    def test_shared_dir_created(self, workspace, envs_dir, roster, tmp_path):
         shared = tmp_path / "new-shared"
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            shared_dir=shared,
-        )
+        spec = _spec(workspace, envs_dir, shared_dir=shared)
         assemble_container_env(spec, roster, proxy_bypass=True)
         assert shared.is_dir()
 
@@ -379,13 +323,8 @@ class TestSharedTaskDir:
 class TestExtraVolumes:
     """Verify caller-provided extra volumes are appended."""
 
-    def test_extra_volumes_appended(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            extra_volumes=("/host/ssh:/home/dev/.ssh:z",),
-        )
+    def test_extra_volumes_appended(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir, extra_volumes=("/host/ssh:/home/dev/.ssh:z",))
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert "/host/ssh:/home/dev/.ssh:z" in result.volumes
 
@@ -410,7 +349,7 @@ class TestCredentialProxy:
             result = assemble_container_env(base_spec, roster, proxy_bypass=False)
         assert "TEROK_PROXY_PORT" not in result.env
 
-    def test_proxy_running_injects_tokens(self, workspace, roster, tmp_path):
+    def test_proxy_running_injects_tokens(self, workspace, envs_dir, roster, tmp_path):
         from terok_sandbox import CredentialDB, SandboxConfig
 
         cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
@@ -419,12 +358,7 @@ class TestCredentialProxy:
         db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
         db.close()
 
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            credential_scope="test-project",
-        )
+        spec = _spec(workspace, envs_dir, credential_scope="test-project")
 
         with (
             patch("terok_sandbox.is_proxy_socket_active", return_value=False),
@@ -436,6 +370,37 @@ class TestCredentialProxy:
         assert "ANTHROPIC_API_KEY" in result.env
         assert result.env["ANTHROPIC_API_KEY"].startswith("terok-p-")
 
+    def test_proxy_db_error_returns_empty(self, base_spec, roster):
+        """DB open failure returns empty env gracefully."""
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.CredentialDB", side_effect=OSError("corrupt")),
+        ):
+            result = assemble_container_env(base_spec, roster, proxy_bypass=False)
+        assert "TEROK_PROXY_PORT" not in result.env
+
+    def test_proxy_token_creation_error_returns_empty(self, workspace, envs_dir, roster, tmp_path):
+        """Token creation failure returns empty env gracefully."""
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
+        db.close()
+
+        spec = _spec(workspace, envs_dir)
+
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+            patch(
+                "terok_sandbox.CredentialDB.create_proxy_token", side_effect=RuntimeError("boom")
+            ),
+        ):
+            result = assemble_container_env(spec, roster, proxy_bypass=False)
+        assert "TEROK_PROXY_PORT" not in result.env
+
 
 # ---------------------------------------------------------------------------
 # Task dir
@@ -445,15 +410,10 @@ class TestCredentialProxy:
 class TestTaskDir:
     """Verify task_dir resolution."""
 
-    def test_explicit_task_dir(self, workspace, roster, tmp_path):
+    def test_explicit_task_dir(self, workspace, envs_dir, roster, tmp_path):
         td = tmp_path / "my-task"
         td.mkdir()
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            task_dir=td,
-        )
+        spec = _spec(workspace, envs_dir, task_dir=td)
         result = assemble_container_env(spec, roster, proxy_bypass=True)
         assert result.task_dir == td
 
@@ -473,7 +433,6 @@ class TestOpenCodeEnv:
 
     def test_opencode_vars_present(self, base_spec, roster):
         result = assemble_container_env(base_spec, roster, proxy_bypass=True)
-        # Blablador/KISSKI contribute TEROK_OC_* vars
         oc_vars = [k for k in result.env if k.startswith("TEROK_OC_")]
         assert len(oc_vars) > 0
 
@@ -486,24 +445,14 @@ class TestOpenCodeEnv:
 class TestResolveGitIdentityUnit:
     """Unit tests for the internal git identity resolver."""
 
-    def test_spec_fields_take_precedence(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-            git_author_name="Override",
-        )
+    def test_spec_fields_take_precedence(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir, git_author_name="Override")
         identity = _resolve_git_identity(spec, roster)
         assert identity["GIT_AUTHOR_NAME"] == "Override"
-        # Committer defaults to author when not specified
         assert identity["GIT_COMMITTER_NAME"] == "Override"
 
-    def test_roster_fallback(self, workspace, roster):
-        spec = ContainerEnvSpec(
-            task_id="t1",
-            provider_name="claude",
-            workspace_host_path=workspace,
-        )
+    def test_roster_fallback(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir)
         identity = _resolve_git_identity(spec, roster)
         assert identity["GIT_AUTHOR_NAME"] == "Claude"
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -63,26 +63,8 @@ class TestAgentRunner:
         reg = runner.roster
         assert "claude" in reg.agent_names
 
-    def test_shared_mounts_from_roster(self, tmp_path: Path) -> None:
-        runner = AgentRunner()
-        mounts = runner._shared_mounts(tmp_path)
-        # Should have mounts for agents with auth (claude, codex, vibe, gh, glab, etc.)
-        mount_str = " ".join(mounts)
-        assert "_claude-config" in mount_str
-        assert "/home/dev/.claude" in mount_str
-
-    def test_base_env_has_essentials(self) -> None:
-        runner = AgentRunner()
-        env = runner._base_env("task123", "claude")
-        assert env["TASK_ID"] == "task123"
-        assert env["REPO_ROOT"] == "/workspace"
-        assert env["GIT_AUTHOR_NAME"] == "Claude"
-
-    def test_base_env_opencode_vars(self) -> None:
-        runner = AgentRunner()
-        env = runner._base_env("task123", "blablador")
-        # Should include OpenCode provider env vars
-        assert any(k.startswith("TEROK_OC_") for k in env)
+    # test_shared_mounts_from_roster, test_base_env_has_essentials,
+    # test_base_env_opencode_vars moved to test_env_builder.py
 
     def test_run_headless_delegates_to_sandbox_run(self, tmp_path: Path) -> None:
         """Verify headless run delegates to sandbox.run() with correct RunSpec."""
@@ -292,75 +274,26 @@ class TestGateIntegration:
 
 
 class TestCredentialProxyEnv:
-    """Verify _credential_proxy_env integration."""
+    """Verify credential proxy integration (now via env_builder).
 
-    def test_proxy_not_running_returns_empty(self) -> None:
-        """When proxy is not running, returns empty dict."""
+    Detailed token injection tests are in test_env_builder.py.
+    These tests verify the runner delegates correctly.
+    """
+
+    def test_proxy_not_running_no_tokens_in_run(self, tmp_path: Path) -> None:
+        """When proxy is not running, headless run has no TEROK_PROXY_PORT."""
         sandbox = _mock_sandbox()
         runner = AgentRunner(sandbox=sandbox)
 
         with (
+            patch.object(runner, "_ensure_images", return_value="terok-l1-cli:test"),
             patch("terok_sandbox.is_proxy_socket_active", return_value=False),
             patch("terok_sandbox.is_proxy_running", return_value=False),
         ):
-            env = runner._credential_proxy_env("task-1")
+            runner.run_headless("claude", str(tmp_path), prompt="test", follow=False)
 
-        assert env == {}
-
-    def test_proxy_running_injects_phantom_tokens(self, tmp_path: Path) -> None:
-        """When proxy runs and credentials exist, injects phantom env vars."""
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        # SandboxConfig derives proxy_db_path from state_dir, so set state_dir
-        # to tmp_path and create the DB at the expected location.
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
-
-        sandbox = _mock_sandbox()
-        sandbox.config = cfg
-        runner = AgentRunner(sandbox=sandbox)
-
-        with (
-            patch("terok_sandbox.is_proxy_socket_active", return_value=False),
-            patch("terok_sandbox.is_proxy_running", return_value=True),
-        ):
-            env = runner._credential_proxy_env("task-1")
-
-        assert "ANTHROPIC_API_KEY" in env
-        assert env["ANTHROPIC_API_KEY"].startswith("terok-p-")
-        assert len(env["ANTHROPIC_API_KEY"]) == 40
-        assert "ANTHROPIC_BASE_URL" in env
-        assert (
-            f"host.containers.internal:{cfg.proxy_port}"
-            == env["ANTHROPIC_BASE_URL"].split("://")[1]
-        )
-
-    def test_no_routed_providers_returns_empty(self, tmp_path: Path) -> None:
-        """When credentials exist but none map to proxy routes, returns empty."""
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "nonexistent-provider", {"type": "api_key", "key": "k"})
-        db.close()
-
-        sandbox = _mock_sandbox()
-        sandbox.config = cfg
-        runner = AgentRunner(sandbox=sandbox)
-
-        with (
-            patch("terok_sandbox.is_proxy_socket_active", return_value=False),
-            patch("terok_sandbox.is_proxy_running", return_value=True),
-        ):
-            env = runner._credential_proxy_env("task-1")
-
-        assert env == {}
+        spec = sandbox.run.call_args[0][0]
+        assert "TEROK_PROXY_PORT" not in spec.env
 
 
 class TestCommandRegistry:


### PR DESCRIPTION
## Summary

- Introduce `ContainerEnvSpec` + `ContainerEnvResult` + `assemble_container_env()` as the **single source of truth** for container env/volume assembly
- Wire `AgentRunner._run()` to delegate to the builder for agent modes
- Delete duplicated methods: `_base_env()`, `_shared_mounts()`, `_credential_proxy_env()`
- Add `--git-identity-from-host` CLI flag for standalone runs

## Design

- **Pure function** pattern: `assemble_container_env(spec, roster, *, proxy_bypass=False) -> ContainerEnvResult`
- **Named fields** for all env vars in the host↔container contract (no `extra_env` escape hatch)
- **`extra_volumes`** as the one escape hatch for caller-specific mounts (SSH, etc.)
- **`credential_scope`** instead of `project_id` — no project-level concepts leak down
- **Credential proxy**: always soft-fail internally; caller does `ensure_proxy_reachable()` before if needed
- **`proxy_bypass`** flag for explicit opt-out (terok's `bypass_no_secret_protection` config)

## Test plan

- [x] 40 new tests for `assemble_container_env()` covering all 13 assembly steps
- [x] Updated runner tests (deleted tests for removed methods, added proxy delegation test)
- [x] Full suite: 438 tests pass
- [x] Lint + format clean
- [x] 100% docstring coverage on new module
- [x] REUSE compliant

## Cross-references

- Closes #102
- Phase 3 (terok side): terok-ai/terok#619
- Shared task dir (Phase 4): #101 + terok-ai/terok#618

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI flag to optionally use the host machine’s Git identity for container tasks.

* **Refactor**
  * Centralized container environment and volume assembly for consistent run-mode behavior.
  * Exposed container environment assembly interfaces in the package public API.
  * Run entrypoints accept optional human identity/authorship parameters.

* **Tests**
  * Added comprehensive tests for environment assembly and host-Git identity resolution; updated runner tests to match refactor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->