### PR TITLE
chore: skip CodeRabbit on automated release PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  auto_review:
+    labels:
+      - "!automated-release"


### PR DESCRIPTION
Add `.coderabbit.yaml` to skip reviews on PRs labelled `automated-release`.