### PR TITLE
docs: rewrite README and docs to reflect implemented state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,21 @@
 
 Single-agent task runner for hardened Podman containers.
 
-**terok-agent** builds agent images, launches instrumented containers, and
-manages the lifecycle of one AI coding agent at a time.
-
-> **Status:** Early development — the CLI is a stub. Commands shown below are
-> planned features, not yet implemented.
+**terok-agent** builds container images, launches instrumented Podman
+containers, and manages the lifecycle of one AI coding agent at a time.
+Designed for standalone use (`terok-agent run claude .`) and as a library
+for [terok](https://github.com/terok-ai/terok) project orchestration.
 
 ## Ecosystem
 
 ```text
-terok-shield    →  nftables egress firewall (security boundary)
-terok-sandbox   →  hardened container runtime (isolation)
-terok-agent     →  single agent task runner (one agent, one mission)
-terok           →  project orchestration (TUI, presets, task lifecycle)
+terok-shield    nftables egress firewall (security boundary)
+terok-sandbox   hardened container runtime (isolation + credential proxy)
+terok-agent     single-agent task runner (this package)
+terok           project orchestration (TUI, presets, multi-agent)
 ```
+
+Each layer depends only on the one below it.
 
 ## Installation
 
@@ -23,13 +24,66 @@ terok           →  project orchestration (TUI, presets, task lifecycle)
 pip install terok-agent
 ```
 
-## Usage (planned)
+Requires Python 3.12+ and Podman (rootless).
+
+## Quick start
 
 ```bash
-terok-agent run claude .
+# Build L0 (base) + L1 (agent CLI) images
+terok-agent build
+
+# Authenticate with a provider
 terok-agent auth claude
-terok-agent agents
+
+# Run an agent — headless with a prompt
+terok-agent run claude . -p "Fix the failing test in test_auth.py"
+
+# Run interactively (user logs into the container)
+terok-agent run claude . --interactive
+
+# Run toad web UI
+terok-agent run claude . --web
 ```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `run` | Run an agent in a hardened container (headless, interactive, or web) |
+| `auth` | Authenticate a provider (OAuth, API key, or `--api-key` direct) |
+| `agents` | List registered agents (`--all` includes tools like gh, glab) |
+| `build` | Build L0+L1 container images |
+| `run-tool` | Run a sidecar tool (e.g. CodeRabbit) |
+| `ls` | List running terok-agent containers |
+| `stop` | Stop a running container |
+| `proxy start\|stop\|status\|install\|uninstall\|routes\|clean` | Credential proxy management |
+
+## Supported agents
+
+| Agent | Type | Auth | Description |
+|-------|------|------|-------------|
+| Claude | native | OAuth, API key | Anthropic Claude Code |
+| Codex | native | OAuth, API key | OpenAI Codex CLI |
+| Vibe | native | API key | Mistral Vibe |
+| Copilot | native | — | GitHub Copilot (no proxy yet) |
+| Blablador | OpenCode | API key | Helmholtz Blablador |
+| KISSKI | OpenCode | API key | KISSKI (AcademicCloud) |
+| gh | tool | OAuth, API key | GitHub CLI |
+| glab | tool | API key | GitLab CLI |
+| CodeRabbit | tool | API key | CodeRabbit (sidecar) |
+| SonarCloud | tool | API key | SonarCloud scanner |
+
+User-defined agents go in `~/.config/terok/agent/agents/` as YAML files.
+
+## Security
+
+- **Egress firewall** — gate is on by default; agents cannot reach the
+  internet except through allowed domains
+- **Credential proxy** — no real API keys enter containers; phantom tokens
+  are resolved host-side (see [Credential Proxy](https://terok-ai.github.io/terok-agent/credential-proxy/))
+- **Restricted mode** (`--restricted`) — disables auto-approve and sets
+  `--no-new-privileges`
+- **Rootless Podman** — containers run without root privileges
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ User-defined agents go in `~/.config/terok/agent/agents/` as YAML files.
 
 - **Egress firewall** — gate is on by default; agents cannot reach the
   internet except through allowed domains
-- **Credential proxy** — no real API keys enter containers; phantom tokens
-  are resolved host-side (see [Credential Proxy](https://terok-ai.github.io/terok-agent/credential-proxy/))
+- **Credential proxy** — no real API keys or SSH private keys enter
+  containers; phantom tokens are resolved host-side by the credential
+  proxy and SSH agent proxy in
+  [terok-sandbox](https://terok-ai.github.io/terok-sandbox/)
+  (see [Credential Proxy](https://terok-ai.github.io/terok-agent/credential-proxy/))
 - **Restricted mode** (`--restricted`) — disables auto-approve and sets
   `--no-new-privileges`
 - **Rootless Podman** — containers run without root privileges

--- a/docs/credential-proxy.md
+++ b/docs/credential-proxy.md
@@ -71,13 +71,15 @@ their SDK supports:
 
 | Agent | How it reaches the proxy | Notes |
 |-------|-------------------------|-------|
-| **Claude** | `ANTHROPIC_BASE_URL=http://host.containers.internal:<proxy_port> (default: 18731)` | Anthropic SDK respects this env var |
-| **Codex** | `OPENAI_BASE_URL=http://host.containers.internal:18731` | OpenAI SDK respects this env var (deprecated in Codex v0.117, needs config.toml) |
+| **Claude** | `ANTHROPIC_BASE_URL=http://host.containers.internal:<port>` | Anthropic SDK respects this env var (default port: 18731) |
+| **Codex** | `OPENAI_BASE_URL=http://host.containers.internal:18731` | OpenAI SDK respects this env var |
 | **Vibe** | `config.toml` with `api_base` in shared `~/.vibe` mount | Mistral SDK ignores URL path in api_base, only uses host:port. Written by `shared_config_patch` in YAML |
 | **KISSKI** | `TEROK_OC_KISSKI_BASE_URL` env var override | OpenCode reads this; overridden from the real upstream to proxy |
 | **Blablador** | `TEROK_OC_BLABLADOR_BASE_URL` env var override | Same pattern as KISSKI |
 | **gh** | `http_unix_socket` in `~/.config/gh/config.yml` + socat bridge | gh routes ALL API traffic through a Unix socket. socat bridges it to TCP. See below. |
 | **glab** | `GITLAB_API_HOST` + `API_PROTOCOL=http` env vars | glab sends to `http://<api_host>/api/v4/...` |
+| **CodeRabbit** | `CODERABBIT_API_KEY` phantom env | Sidecar tool; runs in a separate L1 container with real API key from env_map |
+| **SonarCloud** | `SONAR_HOST_URL` + `SONAR_TOKEN` phantom env | Tool agent; scanner uses host URL override |
 
 ### gh: socat bridge pattern
 
@@ -177,28 +179,29 @@ After storing credentials, `write_proxy_config()` applies any
 
 ## Per-Provider Credential Extractors
 
-| Provider  | File               | Key fields                    |
-|-----------|--------------------|-------------------------------|
-| Claude    | `.credentials.json`| access_token, refresh_token   |
-| Codex     | `auth.json`        | access_token, refresh_token   |
-| Vibe      | `.env`             | key (MISTRAL_API_KEY)         |
-| Blablador | `config.json`      | key (api_key)                 |
-| KISSKI    | `config.json`      | key (api_key)                 |
-| gh        | `hosts.yml`        | token (oauth_token)           |
-| glab      | `config.yml`       | token (per-host)              |
+| Provider   | File                | Key fields                    |
+|------------|---------------------|-------------------------------|
+| Claude     | `.credentials.json` | access_token, refresh_token   |
+| Codex      | `auth.json`         | access_token, refresh_token   |
+| Vibe       | `.env`              | key (MISTRAL_API_KEY)         |
+| Blablador  | `config.json`       | key (api_key)                 |
+| KISSKI     | `config.json`       | key (api_key)                 |
+| gh         | `hosts.yml`         | token (oauth_token)           |
+| glab       | `config.yml`        | token (per-host)              |
+| CodeRabbit | —                   | API key via `--api-key`       |
+| SonarCloud | —                   | API key via `--api-key`       |
 
 ## Known Limitations
 
-- **Codex**: Needs WebSocket support (proxy only handles HTTP), OAuth token
-  refresh (Codex refreshes via `auth.openai.com`), and config.toml base URL
-  (env var deprecated in v0.117). Filed as bug issues.
+- **Codex**: Needs WebSocket support (proxy only handles HTTP) and OAuth
+  token refresh (Codex refreshes via `auth.openai.com`).
 
 - **OAuth token refresh**: Claude and Codex OAuth tokens expire (~1h). The
   proxy does not refresh them automatically. Re-auth required after expiry.
 
 - **Copilot**: Not proxied yet. No `credential_proxy` section in YAML.
 
-- **SSH keys**: Still bind-mounted as files. SSH agent proxy planned (#551).
+- **SSH keys**: Still bind-mounted as files. An SSH agent proxy is planned.
 
 ## Package Boundaries
 

--- a/docs/credential-proxy.md
+++ b/docs/credential-proxy.md
@@ -10,9 +10,14 @@ API keys, OAuth tokens, or SSH private keys from these shared mounts.
 
 No real secret enters a task container. Instead:
 
-1. **Credential DB** (sqlite3, host-side) stores API keys and OAuth tokens
-2. **Credential proxy** (aiohttp, TCP+Unix socket) injects real auth headers
+1. **Credential DB** (host-side) stores API keys and OAuth tokens
+2. **Credential proxy** ([terok-sandbox](https://terok-ai.github.io/terok-sandbox/))
+   resolves phantom tokens to real credentials and forwards requests upstream
 3. **Per-provider phantom tokens** (per-task, per-provider) are what containers see
+4. **SSH agent proxy** ([terok-sandbox](https://terok-ai.github.io/terok-sandbox/))
+   lets containers sign with host-side SSH keys without the private keys
+   entering the container. A socat bridge inside the container relays
+   SSH agent requests over TCP to the host-side proxy.
 
 ## Architecture
 
@@ -25,29 +30,20 @@ Credential DB (sqlite3)                   Per-provider phantom tokens (env vars)
     (token, project, task,                  GH_TOKEN=<gh-phantom>
      credential_set, provider)              GITLAB_TOKEN=<glab-phantom>
 
-Credential Proxy (aiohttp)                Agent / tool makes API request
-  TCP: 127.0.0.1:18731                      with phantom token in auth header
-  Unix: $XDG_RUNTIME_DIR/terok/sock
-  1. Extracts phantom token                 Routing is by token, not URL path.
-  2. Looks up provider from token           Token encodes which provider it's for.
-  3. Loads real credential from DB
-  4. Injects real auth header
-  5. Forwards to upstream (genuine TLS)
+Credential Proxy (terok-sandbox)          Agent / tool makes API request
+  TCP + Unix socket listeners                with phantom token in auth header
+  Resolves phantom → real credential
+  Injects auth header, forwards             Routing is by token, not URL path.
+  to upstream over TLS                       Token encodes which provider it's for.
 ```
 
 ### Why TCP, not Unix sockets?
 
-SELinux blocks `connect()` on Unix sockets mounted into rootless Podman
-containers. The `connectto` process label check denies `container_t ->
-unconfined_t` regardless of file relabeling. This is intentional per
-Red Hat's container security model.
-
-TCP via `host.containers.internal:<port>` is the same pattern the gate
-server uses. The phantom token provides authentication. Shield's
-`loopback_ports` allows the proxy port through the nftables firewall.
-
-See: [Podman #23972](https://github.com/containers/podman/discussions/23972),
-[Dan Walsh: SELinux and Containers](https://danwalsh.livejournal.com/78643.html).
+SELinux blocks `connect()` on host Unix sockets mounted into rootless
+Podman containers (`container_t -> unconfined_t` denied). Containers
+reach the proxy via TCP (`host.containers.internal:<port>`) instead.
+[terok-shield](https://terok-ai.github.io/terok-shield/) allows the
+proxy port through the nftables firewall via `loopback_ports`.
 
 ### Per-provider phantom token routing
 
@@ -153,10 +149,6 @@ credential_proxy:
   and `GH_TOKEN` are both set. The socket path is hardcoded to
   `/tmp/terok-gh-proxy.sock` (matching the `shared_config_patch`).
 
-- **anthropic-beta header**: The proxy appends `oauth-2025-04-20` to the
-  `anthropic-beta` header for OAuth credentials. Claude Code sends its own
-  beta features in this header, so the proxy must append (not replace).
-
 ## Auth Flow
 
 ### Three auth paths
@@ -193,18 +185,18 @@ After storing credentials, `write_proxy_config()` applies any
 
 ## Known Limitations
 
-- **Codex**: Needs WebSocket support (proxy only handles HTTP) and OAuth
-  token refresh (Codex refreshes via `auth.openai.com`).
-
-- **OAuth token refresh**: Claude and Codex OAuth tokens expire (~1h). The
-  proxy does not refresh them automatically. Re-auth required after expiry.
+- **Codex**: The credential proxy only handles HTTP. Codex needs WebSocket
+  support for its realtime protocol, which the proxy does not yet provide.
 
 - **Copilot**: Not proxied yet. No `credential_proxy` section in YAML.
 
-- **SSH keys**: Still bind-mounted as files. An SSH agent proxy is planned.
-
 ## Package Boundaries
 
-- **terok-sandbox**: Credential DB, proxy server, TCP+Unix listener, lifecycle
-- **terok-agent**: YAML registry, extractors, auth interceptor, runner proxy env
-- **terok**: Environment builder, phantom token injection for full-stack tasks
+- **[terok-sandbox](https://terok-ai.github.io/terok-sandbox/)**: Credential
+  DB, proxy server (HTTP forwarding, phantom token resolution, OAuth token
+  refresh, SSH agent proxy), TCP+Unix listeners, lifecycle management
+- **terok-agent** (this package): YAML agent registry, credential extractors,
+  auth CLI, container environment wiring (phantom env vars, base URL overrides,
+  socat bridges, `shared_config_patch`)
+- **[terok](https://terok-ai.github.io/terok/)**: Environment builder, phantom
+  token injection for full-stack multi-agent tasks

--- a/docs/credential-proxy.md
+++ b/docs/credential-proxy.md
@@ -72,13 +72,13 @@ their SDK supports:
 | Agent | How it reaches the proxy | Notes |
 |-------|-------------------------|-------|
 | **Claude** | `ANTHROPIC_BASE_URL=http://host.containers.internal:<port>` | Anthropic SDK respects this env var (default port: 18731) |
-| **Codex** | `OPENAI_BASE_URL=http://host.containers.internal:18731` | OpenAI SDK respects this env var |
+| **Codex** | `OPENAI_BASE_URL=http://host.containers.internal:<port>` | OpenAI SDK respects this env var (default port: 18731) |
 | **Vibe** | `config.toml` with `api_base` in shared `~/.vibe` mount | Mistral SDK ignores URL path in api_base, only uses host:port. Written by `shared_config_patch` in YAML |
 | **KISSKI** | `TEROK_OC_KISSKI_BASE_URL` env var override | OpenCode reads this; overridden from the real upstream to proxy |
 | **Blablador** | `TEROK_OC_BLABLADOR_BASE_URL` env var override | Same pattern as KISSKI |
 | **gh** | `http_unix_socket` in `~/.config/gh/config.yml` + socat bridge | gh routes ALL API traffic through a Unix socket. socat bridges it to TCP. See below. |
 | **glab** | `GITLAB_API_HOST` + `API_PROTOCOL=http` env vars | glab sends to `http://<api_host>/api/v4/...` |
-| **CodeRabbit** | `CODERABBIT_API_KEY` phantom env | Sidecar tool; runs in a separate L1 container with real API key from env_map |
+| **CodeRabbit** | Real API key via sidecar `env_map` | CLI has no base URL override, so proxy routing is not possible. Sidecar receives the real key directly from the credential DB. |
 | **SonarCloud** | `SONAR_HOST_URL` + `SONAR_TOKEN` phantom env | Tool agent; scanner uses host URL override |
 
 ### gh: socat bridge pattern

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,9 +73,11 @@ See the [API Reference](reference/) for the full agent roster schema.
 - **Egress firewall (gate)** — on by default. Containers cannot reach the
   internet except through explicitly allowed domains. Disable with
   `--no-gate` for development.
-- **[Credential proxy](credential-proxy.md)** — no real API keys enter
-  containers. Phantom tokens are resolved host-side by the credential
-  proxy. See the dedicated page for architecture details.
+- **[Credential proxy](credential-proxy.md)** — no real API keys or SSH
+  private keys enter containers. Phantom tokens are resolved host-side
+  by the credential proxy and SSH agent proxy in
+  [terok-sandbox](https://terok-ai.github.io/terok-sandbox/).
+  See the dedicated page for architecture details.
 - **Restricted mode** (`--restricted`) — disables auto-approve flags and
   sets `--no-new-privileges` on the container.
 - **Rootless Podman** — all containers run without root privileges.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,31 +4,95 @@ Single-agent task runner for hardened Podman containers.
 
 ## Overview
 
-**terok-agent** builds agent images, launches instrumented containers, and
-manages the lifecycle of one AI coding agent at a time.  It sits between
-[terok-sandbox](https://github.com/terok-ai/terok-sandbox) (container
-isolation) and [terok](https://github.com/terok-ai/terok) (project
-orchestration) in the dependency chain:
+**terok-agent** builds container images, launches instrumented Podman
+containers, and manages the lifecycle of one AI coding agent at a time.
+It sits between [terok-sandbox](https://github.com/terok-ai/terok-sandbox)
+(container isolation) and [terok](https://github.com/terok-ai/terok)
+(project orchestration):
 
 ```text
-terok → terok-agent → terok-sandbox → terok-shield
+terok  ->  terok-agent  ->  terok-sandbox  ->  terok-shield
 ```
 
-!!! note "Early development"
-    This package currently provides only the project scaffold and a stub CLI.
-    The features and commands listed below are planned — not yet implemented.
+### Standalone vs. library
 
-## Quick start (planned)
+`terok-agent run claude .` is a self-contained command — it builds images,
+prepares config, and launches a container. The same functionality is
+available as a Python library for terok to compose into multi-agent
+workflows:
+
+```python
+from terok_agent import AgentRunner
+
+runner = AgentRunner()
+cname = runner.run_headless("claude", "/path/to/repo", prompt="Fix the bug")
+```
+
+## Quick start
 
 ```bash
-pip install terok-agent
-terok-agent run claude .
+pip install terok-agent        # requires Python 3.12+, Podman (rootless)
+terok-agent build              # build L0 (base) + L1 (agent CLI) images
+terok-agent auth claude        # authenticate (OAuth or API key)
+terok-agent run claude . -p "Fix the failing test"
 ```
 
-## Planned features
+## Image layer architecture
 
-- **Agent registry** — YAML-driven agent definitions (Claude, Codex, Copilot, …)
-- **Image building** — parametrized L0 (base) + L1 (agent) Dockerfile layers
-- **Auth flows** — per-agent authentication (API keys, OAuth)
-- **Shield required** — refuses to run without nftables egress firewall
-- **Config stack** — layered config resolution (global → project → preset → CLI)
+```text
+L0 (base)    Ubuntu + dev tools + init script + dev user
+L1 (agent)   All AI agent CLIs, shell wrappers, ACP config
+--- boundary: above owned by terok-agent, below by terok ---
+L2 (project) Optional user Dockerfile snippet (custom packages)
+```
+
+L1 is self-sufficient for standalone use. All user config (repo URL, SSH
+keys, branch, gate) is injected at runtime via environment variables and
+volume mounts — no L2 build needed.
+
+## Launch modes
+
+| Mode | Flag | Description |
+|------|------|-------------|
+| Headless | `-p "prompt"` | Fire-and-forget with a prompt; streams output |
+| Interactive | `--interactive` | User logs into the container; agent is ready |
+| Web | `--web` | Toad multi-agent TUI served over HTTP |
+| Tool | `run-tool <name>` | Run a sidecar tool (CodeRabbit, SonarCloud) |
+
+## Agent registry
+
+Agents are defined in YAML files under `resources/agents/`. Each file
+declares the provider binary, headless flags, credential proxy routing,
+auth modes, and git identity. Users can extend the registry by placing
+YAML files in `~/.config/terok/agent/agents/`.
+
+See the [API Reference](reference/) for the full agent roster schema.
+
+## Security model
+
+- **Egress firewall (gate)** — on by default. Containers cannot reach the
+  internet except through explicitly allowed domains. Disable with
+  `--no-gate` for development.
+- **[Credential proxy](credential-proxy.md)** — no real API keys enter
+  containers. Phantom tokens are resolved host-side by the credential
+  proxy. See the dedicated page for architecture details.
+- **Restricted mode** (`--restricted`) — disables auto-approve flags and
+  sets `--no-new-privileges` on the container.
+- **Rootless Podman** — all containers run without root privileges.
+- **Config isolation** — vendor config directories are bind-mounted
+  read-only where possible. Secrets are never written to shared mounts.
+
+## Configuration
+
+terok-agent uses a layered config stack (global -> project -> preset -> CLI)
+resolved via `config_stack`. The roster merges bundled agent definitions
+with user overrides using `_inherit` splicing for lists and deep merge
+for dicts.
+
+Key config paths:
+
+| Path | Purpose |
+|------|---------|
+| `~/.config/terok/agent/agents/` | User agent YAML overrides |
+| `~/.local/share/terok/agent/` | State root (credentials, tasks) |
+| `TEROK_AGENT_STATE_DIR` | Override state root via env var |


### PR DESCRIPTION
## Summary

- **README.md**: Removed "CLI is a stub" / "planned features" language. Now documents the actual commands, agent table, security model, and quick start.
- **docs/index.md**: Rewritten from "planned features" to architecture overview, launch modes, config paths, and library usage example.
- **docs/credential-proxy.md**: Added CodeRabbit and SonarCloud to routing and extractor tables. Removed stale issue reference (`#551`).

## Test plan
- [ ] `mkdocs build --strict` passes
- [ ] All cross-links resolve
- [ ] Agent table matches `resources/agents/*.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated user docs with a concrete CLI quick start, implemented command reference, and supported agent list
  * Added credential proxy guidance (terok-sandbox) including SSH agent proxy and CodeRabbit/SonarCloud integrations and routing notes
  * New end-to-end docs covering image layer architecture, launch modes (headless/interactive/web/tool), layered config merge semantics, agent registry/location, filesystem paths, and detailed security model (egress, proxy, restricted mode)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->