### PR TITLE
docs: restructure into user guide pages, rewrite README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Instructions
+
+## Verification
+
+Run `make check` before declaring work done — it covers lint, unit
+tests, module boundaries (tach), security, docstring coverage, dead
+code, and SPDX compliance.  Skip tests that need podman or docker;
+those run on a dedicated test machine.
+
+## Code style
+
+- Domain-first docstrings, public entry points above private helpers,
+  top-down reading order.
+- SPDX copyright: author name "Jiri Vyskocil".  Add a new
+  `SPDX-FileCopyrightText` line only for a previously unlisted
+  contributor making a substantive change.
+
+## Docs
+
+- Markdown files under `docs/` are lowercase by convention; root-level
+  files (`README.md`, `AGENTS.md`) are not.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See @AGENTS.md

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 Single-agent task runner for hardened Podman containers.
 
+## What it does
+
 **terok-agent** builds container images, launches instrumented Podman
 containers, and manages the lifecycle of one AI coding agent at a time.
-Designed for standalone use (`terok-agent run claude .`) and as a library
-for [terok](https://github.com/terok-ai/terok) project orchestration.
+Every container runs rootless behind an egress firewall with credential
+isolation — real API keys and SSH private keys never enter the container.
+Use it standalone from the CLI or as a Python library for
+[terok](https://github.com/terok-ai/terok) orchestration.
 
 ## Ecosystem
 
@@ -18,31 +22,17 @@ terok           project orchestration (TUI, presets, multi-agent)
 
 Each layer depends only on the one below it.
 
-## Installation
-
-```bash
-pip install terok-agent
-```
-
-Requires Python 3.12+ and Podman (rootless).
-
 ## Quick start
 
 ```bash
-# Build L0 (base) + L1 (agent CLI) images
-terok-agent build
+pip install terok-agent        # requires Python 3.12+, Podman (rootless)
 
-# Authenticate with a provider
-terok-agent auth claude
+terok-agent build              # build base + agent images
+terok-agent auth claude        # authenticate (OAuth or API key)
 
-# Run an agent — headless with a prompt
 terok-agent run claude . -p "Fix the failing test in test_auth.py"
-
-# Run interactively (user logs into the container)
-terok-agent run claude . --interactive
-
-# Run toad web UI
-terok-agent run claude . --web
+terok-agent run claude . --interactive   # shell into the container
+terok-agent run claude . --web           # toad web UI
 ```
 
 ## Commands
@@ -52,41 +42,34 @@ terok-agent run claude . --web
 | `run` | Run an agent in a hardened container (headless, interactive, or web) |
 | `auth` | Authenticate a provider (OAuth, API key, or `--api-key` direct) |
 | `agents` | List registered agents (`--all` includes tools like gh, glab) |
-| `build` | Build L0+L1 container images |
-| `run-tool` | Run a sidecar tool (e.g. CodeRabbit) |
+| `build` | Build base + agent container images |
+| `run-tool` | Run a sidecar tool (e.g. CodeRabbit, SonarCloud) |
 | `ls` | List running terok-agent containers |
 | `stop` | Stop a running container |
-| `proxy start\|stop\|status\|install\|uninstall\|routes\|clean` | Credential proxy management |
+| `proxy` | Credential proxy management (start, stop, status, install, routes) |
 
 ## Supported agents
 
-| Agent | Type | Auth | Description |
-|-------|------|------|-------------|
-| Claude | native | OAuth, API key | Anthropic Claude Code |
-| Codex | native | OAuth, API key | OpenAI Codex CLI |
-| Vibe | native | API key | Mistral Vibe |
-| Copilot | native | — | GitHub Copilot (no proxy yet) |
-| Blablador | OpenCode | API key | Helmholtz Blablador |
-| KISSKI | OpenCode | API key | KISSKI (AcademicCloud) |
-| gh | tool | OAuth, API key | GitHub CLI |
-| glab | tool | API key | GitLab CLI |
-| CodeRabbit | tool | API key | CodeRabbit (sidecar) |
-| SonarCloud | tool | API key | SonarCloud scanner |
+| Agent | Auth | Description |
+|-------|------|-------------|
+| Claude | OAuth, API key | Anthropic Claude Code |
+| Codex | OAuth, API key | OpenAI Codex CLI |
+| Vibe | API key | Mistral Vibe |
+| Copilot | — | GitHub Copilot |
+| Blablador | API key | Helmholtz Blablador (OpenCode) |
+| KISSKI | API key | KISSKI AcademicCloud (OpenCode) |
+| gh | OAuth, API key | GitHub CLI |
+| glab | API key | GitLab CLI |
+| CodeRabbit | API key | CodeRabbit (sidecar tool) |
+| SonarCloud | API key | SonarCloud scanner (sidecar tool) |
 
-User-defined agents go in `~/.config/terok/agent/agents/` as YAML files.
+## Documentation
 
-## Security
-
-- **Egress firewall** — gate is on by default; agents cannot reach the
-  internet except through allowed domains
-- **Credential proxy** — no real API keys or SSH private keys enter
-  containers; phantom tokens are resolved host-side by the credential
-  proxy and SSH agent proxy in
-  [terok-sandbox](https://terok-ai.github.io/terok-sandbox/)
-  (see [Credential Proxy](https://terok-ai.github.io/terok-agent/credential-proxy/))
-- **Restricted mode** (`--restricted`) — disables auto-approve and sets
-  `--no-new-privileges`
-- **Rootless Podman** — containers run without root privileges
+- [Getting started](https://terok-ai.github.io/terok-agent/) — install, build, authenticate, first run
+- [Agents](https://terok-ai.github.io/terok-agent/agents/) — catalog, custom definitions, auth flows
+- [Launch modes](https://terok-ai.github.io/terok-agent/launch-modes/) — headless, interactive, web, tool
+- [Security](https://terok-ai.github.io/terok-agent/security/) — firewall, credential proxy, restricted mode
+- [API Reference](https://terok-ai.github.io/terok-agent/reference/) — Python API docs
 
 ## Development
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,6 +1,0 @@
-- [Home](index.md)
-- Developer Guide
-    - [Credential Proxy](credential-proxy.md)
-    - [Code Quality](quality_report.md)
-    - [CI Workflow Map](ci_map.md)
-- [API Reference](reference/)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,90 @@
+# Agents
+
+## Supported agents
+
+| Agent | Auth | Description |
+|-------|------|-------------|
+| Claude | OAuth, API key | Anthropic Claude Code |
+| Codex | OAuth, API key | OpenAI Codex CLI |
+| Vibe | API key | Mistral Vibe |
+| Copilot | — | GitHub Copilot (not proxied yet) |
+| Blablador | API key | Helmholtz Blablador via OpenCode |
+| KISSKI | API key | KISSKI AcademicCloud via OpenCode |
+
+### Sidecar tools
+
+Tools run alongside an agent in a separate container:
+
+| Tool | Auth | Description |
+|------|------|-------------|
+| gh | OAuth, API key | GitHub CLI |
+| glab | API key | GitLab CLI |
+| CodeRabbit | API key | CodeRabbit code review |
+| SonarCloud | API key | SonarCloud scanner |
+
+## Listing agents
+
+```bash
+terok-agent agents            # coding agents only
+terok-agent agents --all      # include tools (gh, glab, coderabbit, sonarcloud)
+```
+
+## Authentication
+
+Three auth paths depending on the provider:
+
+**OAuth / interactive login** (Claude, Codex, gh) — launches a temporary
+container with the vendor CLI. After login, the OAuth token is captured
+to the host-side credential database.
+
+```bash
+terok-agent auth claude
+```
+
+**Interactive API key prompt** (Vibe, Blablador, KISSKI, glab) — prompts
+for a key on the terminal. No container needed.
+
+```bash
+terok-agent auth vibe
+```
+
+**Non-interactive** (all providers) — pass the key directly:
+
+```bash
+terok-agent auth gh --api-key ghp_…
+```
+
+After authentication, containers receive phantom tokens instead of real
+credentials. See [Security](security.md) for how this works.
+
+## Running sidecar tools
+
+Tools like CodeRabbit and SonarCloud run via `run-tool`. Arguments after
+`--` are passed to the tool binary:
+
+```bash
+terok-agent run-tool coderabbit . -- --pr 42
+terok-agent run-tool sonarcloud . --timeout 300
+```
+
+## Custom agents
+
+Place YAML files in `~/.config/terok/agent/agents/`. The roster merges
+user definitions with bundled ones using deep merge for dicts and
+`_inherit` splicing for lists.
+
+See the bundled definitions in `resources/agents/` for the schema:
+binary, headless flags, credential proxy routing, auth modes, and git
+identity.
+
+## Git identity
+
+By default, agents commit under a built-in AI identity. To use the
+host machine's git config instead:
+
+```bash
+terok-agent run claude . --git-identity-from-host -p "…"
+```
+
+This injects `user.name` and `user.email` from the host's git config
+into the container.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,100 +1,64 @@
-# terok-agent
+# Getting started
 
-Single-agent task runner for hardened Podman containers.
+## Why terok-agent
 
-## Overview
+AI coding agents need network access and credentials to do useful work,
+but giving them uncontrolled access to both is a risk — a prompt-injected
+or supply-chain-compromised agent can exfiltrate API keys, push to
+arbitrary remotes, or reach services it shouldn't.
 
-**terok-agent** builds container images, launches instrumented Podman
-containers, and manages the lifecycle of one AI coding agent at a time.
-It sits between [terok-sandbox](https://github.com/terok-ai/terok-sandbox)
-(container isolation) and [terok](https://github.com/terok-ai/terok)
-(project orchestration):
+terok-agent runs each agent in an isolated rootless Podman container with
+an egress firewall and a credential proxy that keeps real secrets off the
+container filesystem. One command to build, authenticate, and launch.
 
-```text
-terok  ->  terok-agent  ->  terok-sandbox  ->  terok-shield
-```
+## Prerequisites
 
-### Standalone vs. library
+- Python 3.12+
+- Podman (rootless) — `podman machine init` on macOS
 
-`terok-agent run claude .` is a self-contained command — it builds images,
-prepares config, and launches a container. The same functionality is
-available as a Python library for terok to compose into multi-agent
-workflows:
-
-```python
-from terok_agent import AgentRunner
-
-runner = AgentRunner()
-cname = runner.run_headless("claude", "/path/to/repo", prompt="Fix the bug")
-```
-
-## Quick start
+## Install
 
 ```bash
-pip install terok-agent        # requires Python 3.12+, Podman (rootless)
-terok-agent build              # build L0 (base) + L1 (agent CLI) images
-terok-agent auth claude        # authenticate (OAuth or API key)
-terok-agent run claude . -p "Fix the failing test"
+pip install terok-agent
 ```
 
-## Image layer architecture
+## Build container images
 
-```text
-L0 (base)    Ubuntu + dev tools + init script + dev user
-L1 (agent)   All AI agent CLIs, shell wrappers, ACP config
---- boundary: above owned by terok-agent, below by terok ---
-L2 (project) Optional user Dockerfile snippet (custom packages)
+```bash
+terok-agent build
 ```
 
-L1 is self-sufficient for standalone use. All user config (repo URL, SSH
-keys, branch, gate) is injected at runtime via environment variables and
-volume mounts — no L2 build needed.
+Builds two image layers: a base image (OS, dev tools, init scripts) and
+an agent image (all AI agent CLIs, shell wrappers, ACP config). Rebuild
+with `--rebuild` to bust caches or `--full-rebuild` for a clean pull.
 
-## Launch modes
+## Authenticate
 
-| Mode | Flag | Description |
-|------|------|-------------|
-| Headless | `-p "prompt"` | Fire-and-forget with a prompt; streams output |
-| Interactive | `--interactive` | User logs into the container; agent is ready |
-| Web | `--web` | Toad multi-agent TUI served over HTTP |
-| Tool | `run-tool <name>` | Run a sidecar tool (CodeRabbit, SonarCloud) |
+```bash
+terok-agent auth claude              # OAuth login
+terok-agent auth vibe                # interactive API key prompt
+terok-agent auth gh --api-key ghp_…  # non-interactive
+```
 
-## Agent registry
+Credentials are stored in a host-side database. Containers never see real
+keys — they receive phantom tokens resolved by the credential proxy.
+See [Security](security.md) for details.
 
-Agents are defined in YAML files under `resources/agents/`. Each file
-declares the provider binary, headless flags, credential proxy routing,
-auth modes, and git identity. Users can extend the registry by placing
-YAML files in `~/.config/terok/agent/agents/`.
+## First run
 
-See the [API Reference](reference/) for the full agent roster schema.
+```bash
+terok-agent run claude . -p "Add type hints to utils.py"
+```
 
-## Security model
+This clones the current directory into a hardened container, launches
+Claude in headless mode, and streams its output. The egress firewall
+and credential proxy are active by default.
 
-- **Egress firewall (gate)** — on by default. Containers cannot reach the
-  internet except through explicitly allowed domains. Disable with
-  `--no-gate` for development.
-- **[Credential proxy](credential-proxy.md)** — no real API keys or SSH
-  private keys enter containers. Phantom tokens are resolved host-side
-  by the credential proxy and SSH agent proxy in
-  [terok-sandbox](https://terok-ai.github.io/terok-sandbox/).
-  See the dedicated page for architecture details.
-- **Restricted mode** (`--restricted`) — disables auto-approve flags and
-  sets `--no-new-privileges` on the container.
-- **Rootless Podman** — all containers run without root privileges.
-- **Config isolation** — vendor config directories are bind-mounted
-  read-only where possible. Secrets are never written to shared mounts.
+See [Launch modes](launch-modes.md) for interactive, web, and tool modes.
 
-## Configuration
+## Next steps
 
-terok-agent uses a layered config stack (global -> project -> preset -> CLI)
-resolved via `config_stack`. The roster merges bundled agent definitions
-with user overrides using `_inherit` splicing for lists and deep merge
-for dicts.
-
-Key config paths:
-
-| Path | Purpose |
-|------|---------|
-| `~/.config/terok/agent/agents/` | User agent YAML overrides |
-| `~/.local/share/terok/agent/` | State root (credentials, tasks) |
-| `TEROK_AGENT_STATE_DIR` | Override state root via env var |
+- [Agents](agents.md) — supported agents, custom definitions, auth flows
+- [Security](security.md) — firewall, credential proxy, restricted mode
+- [Launch modes](launch-modes.md) — headless, interactive, web, tool
+- [Credential proxy internals](credential-proxy.md) — architecture deep dive

--- a/docs/launch-modes.md
+++ b/docs/launch-modes.md
@@ -1,0 +1,68 @@
+# Launch modes
+
+terok-agent supports four ways to run an agent, plus a separate tool
+runner for sidecars.
+
+## Headless
+
+```bash
+terok-agent run claude . -p "Fix the failing test"
+terok-agent run claude . -p "Refactor auth" --model sonnet --max-turns 10
+```
+
+Fire-and-forget. The agent runs autonomously and streams output to the
+terminal. Exits when the agent finishes, hits `--max-turns`, or reaches
+`--timeout` (default 1800 s).
+
+## Interactive
+
+```bash
+terok-agent run claude . --interactive
+```
+
+Opens a shell session inside the container. The agent CLI is installed
+and ready; credentials and the repository are pre-configured. Use this
+to drive the agent manually.
+
+## Web
+
+```bash
+terok-agent run claude . --web
+terok-agent run claude . --web --port 8080
+```
+
+Launches [toad](https://github.com/terok-ai/toad), a multi-agent TUI
+served over HTTP. Access it in a browser at the printed URL.
+
+## Tool mode
+
+```bash
+terok-agent run-tool coderabbit . -- --pr 42
+terok-agent run-tool sonarcloud . --timeout 300
+```
+
+Runs a sidecar tool in its own container. Arguments after `--` are
+passed to the tool binary. See [Agents](agents.md#sidecar-tools) for
+the list of supported tools.
+
+## Managing containers
+
+```bash
+terok-agent ls              # list running containers
+terok-agent stop my-task    # stop a specific container
+```
+
+## Common flags
+
+| Flag | Description |
+|------|-------------|
+| `--gate` / `--no-gate` | Enable or disable the egress firewall (default: on) |
+| `--restricted` | No auto-approve, no-new-privileges |
+| `--branch <ref>` | Check out a specific git branch |
+| `--name <name>` | Container name override |
+| `--gpu` | Enable GPU passthrough |
+| `--git-identity-from-host` | Use the host's git user.name and user.email |
+| `--shared-dir` / `--shared-mount` | Mount a host directory into the container |
+| `--timeout <seconds>` | Override the default timeout |
+| `--model <name>` | Model override (headless mode) |
+| `--max-turns <n>` | Limit agent turns (headless mode) |

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,63 @@
+# Security
+
+terok-agent isolates each agent behind four layers: an egress firewall,
+a credential proxy, optional restricted mode, and rootless containers.
+
+## Egress firewall
+
+On by default. The firewall
+([terok-shield](https://terok-ai.github.io/terok-shield/)) restricts
+outbound traffic to explicitly allowed domains — the agent's API endpoint,
+package registries, and git hosts. Everything else is blocked at the
+nftables level.
+
+```bash
+terok-agent run claude . -p "…"         # firewall on (default)
+terok-agent run claude . --no-gate -p "…"  # disable for development
+```
+
+## Credential proxy
+
+No real API keys, OAuth tokens, or SSH private keys enter containers.
+Instead, each container receives per-task **phantom tokens**. A host-side
+proxy ([terok-sandbox](https://terok-ai.github.io/terok-sandbox/))
+resolves phantom tokens to real credentials and forwards requests
+upstream over TLS.
+
+SSH keys are handled the same way: a host-side SSH agent proxy lets
+containers sign git operations without the private key crossing the
+container boundary.
+
+This means a compromised agent cannot read, copy, or exfiltrate real
+credentials — they exist only on the host and are never written to
+container-accessible mounts.
+
+See [Credential proxy internals](credential-proxy.md) for the full
+architecture, per-agent routing table, and YAML configuration.
+
+### Managing the proxy
+
+```bash
+terok-agent proxy status      # health check
+terok-agent proxy start       # start manually
+terok-agent proxy stop        # stop
+terok-agent proxy install     # install systemd unit
+terok-agent proxy routes      # show active routes
+terok-agent proxy clean       # remove stale tokens
+```
+
+## Restricted mode
+
+```bash
+terok-agent run claude . --restricted -p "…"
+```
+
+Disables auto-approve flags and sets `--no-new-privileges` on the
+container. Use for untrusted prompts or when the agent should confirm
+every action with the user.
+
+## Rootless containers
+
+All containers run under rootless Podman — no daemon, no root privileges.
+Combined with SELinux labeling, this limits what a compromised agent can
+reach on the host filesystem.

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -1,0 +1,11 @@
+- [Home](index.md)
+- User Guide
+    - [Agents](agents.md)
+    - [Launch Modes](launch-modes.md)
+    - [Security](security.md)
+- Developer Guide
+    - [Credential Proxy](credential-proxy.md)
+    - [Code Metrics](quality_report.md)
+    - [Module Map](module-map.md)
+    - [CI Workflow Map](ci_map.md)
+- [API Reference](reference/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,10 +54,12 @@ plugins:
       quality_report: true
       quality_report_path: quality_report.md
       quality_report_codecov_repo: terok-ai/terok-agent
+      module_map: true
+      module_map_path: module-map.md
       ref_pages: true
       ref_pages_path: reference
   - literate-nav:
-      nav_file: SUMMARY.md
+      nav_file: summary.md
   - section-index
 
 markdown_extensions:
@@ -79,13 +81,6 @@ markdown_extensions:
   - tables
   - toc:
       permalink: true
-
-nav:
-  - Home: index.md
-  - Developer Guide:
-    - Code Quality Report: quality_report.md
-    - CI Workflow Map: ci_map.md
-  - API Reference: reference/
 
 extra:
   social:

--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -7,36 +7,12 @@ Builds agent images, launches instrumented containers, and manages the
 lifecycle of one AI coding agent at a time.  Designed for standalone use
 (``terok-agent run claude .``) and as a library for terok orchestration.
 
-Public API::
+The public surface is ``__all__`` below.  Key entry points:
 
-    # Provider registry
-    from terok_agent import HEADLESS_PROVIDERS, HeadlessProvider, get_provider
-    from terok_agent import PROVIDER_NAMES, CLIOverrides
-    from terok_agent import apply_provider_config, build_headless_command
-    from terok_agent import collect_opencode_provider_env, collect_all_auto_approve_env
-
-    # Agent config preparation
-    from terok_agent import AgentConfigSpec, prepare_agent_config_dir, parse_md_agent
-
-    # Auth
-    from terok_agent import AUTH_PROVIDERS, AuthProvider, authenticate
-
-    # Instructions
-    from terok_agent import resolve_instructions, bundled_default_instructions
-
-    # Credential proxy
-    from terok_agent import ensure_proxy_routes
-
-    # Config stack
-    from terok_agent import ConfigStack, ConfigScope, resolve_provider_value
-
-Internal symbols (available via submodule import for white-box tests)::
-
-    from terok_agent.provider.headless import generate_agent_wrapper, generate_all_wrappers
-    from terok_agent.provider.headless import OpenCodeProviderConfig, ProviderConfig, WrapperConfig
-    from terok_agent.roster.config_stack import deep_merge, load_yaml_scope, load_json_scope
-    from terok_agent.provider.instructions import has_custom_instructions
-    from terok_agent._util import podman_userns_args
+- :class:`AgentRunner` — launch agents in containers
+- :func:`authenticate` / :func:`store_api_key` — credential flows
+- :func:`build_base_images` — image construction
+- :func:`get_roster` — YAML agent registry
 """
 
 __version__: str = "0.0.0"  # placeholder; replaced at build time


### PR DESCRIPTION
## Summary

- Split monolithic `docs/index.md` into three focused user guide pages: agents, launch modes, security
- Rewrite `README.md` to show WHAT (features + quick examples) with links to docs for HOW
- Add WHY section to getting-started page explaining the motivation for container isolation
- Folds PR #120 changes: `AGENTS.md`, `CLAUDE.md`, module map plugin, lowercase `summary.md`, remove redundant `nav:` key, fix `__init__.py` docstring

Supersedes #120.

## New pages

| Page | Content |
|------|---------|
| `docs/agents.md` | Agent catalog, auth flows, sidecar tools, custom definitions |
| `docs/launch-modes.md` | Headless, interactive, web, tool modes + common flags |
| `docs/security.md` | Egress firewall, credential proxy, restricted mode, rootless |

## Test plan

- [x] `ruff check` + `ruff format --check` — all pass
- [x] `pytest tests/unit/` — 452 passed
- [x] `tach check` — all modules validated
- [x] `reuse lint` — SPDX compliant
- [x] `mkdocs build --strict` — clean build, no warnings
- [x] No competitor names in any docs file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with clearer feature descriptions, prerequisites, and streamlined quick start
  * Added comprehensive guides covering agents, launch modes, and security model
  * Reorganized documentation structure with improved navigation and MkDocs configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->