### PR TITLE
fix: credential proxy install message for socket activation

### DIFF
--- a/src/terok_agent/credentials/proxy_commands.py
+++ b/src/terok_agent/credentials/proxy_commands.py
@@ -177,7 +177,7 @@ def _handle_install(*, cfg: SandboxConfig | None = None) -> None:
         sys.exit(1)
     _ensure_routes(cfg=cfg)
     install_proxy_systemd(cfg=cfg)
-    print("Credential proxy systemd socket installed and started.")
+    print("Credential proxy installed via systemd socket activation.")
 
 
 def _handle_uninstall(*, cfg: SandboxConfig | None = None) -> None:


### PR DESCRIPTION
## Summary
- Changed "installed and started" to "installed via systemd socket activation" to match reality — the daemon hasn't spawned yet, only the systemd socket is listening

## Context
Companion to terok-ai/terok-sandbox#113 — same misleading message exists in terok-agent's proxy install handler.

## Test plan
- [x] `make lint` passes
- [ ] Manual: run `credential-proxy install`, verify message says "socket activation"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity of credential proxy installation confirmation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->