### PR TITLE
chore: rename umbrella→namespace and fix terokctl references

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2683,13 +2683,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.50"
+version = "0.0.51"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.50-py3-none-any.whl", hash = "sha256:2d45f9c16b910a4edd9e5f31e0aca94d2907481fefdbea6977a1b06f233a13c6"},
+    {file = "terok_sandbox-0.0.51-py3-none-any.whl", hash = "sha256:26843efa8efd232d2b1768ea83c545c7889b7fd2117d27b66997a8360b15b5af"},
 ]
 
 [package.dependencies]
@@ -2700,7 +2700,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.50/terok_sandbox-0.0.50-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.51/terok_sandbox-0.0.51-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3118,4 +3118,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "b86c0079ae5bed569598c8ef87939e416b258f27a9aaa22ffbb5ac1c9f5da0ac"
+content-hash = "efcfce49928c3dde753d0839e52c28c9f6c5cd22b4686219a5694b42fdf085fe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.50/terok_sandbox-0.0.50-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.51/terok_sandbox-0.0.51-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_agent/paths.py
+++ b/src/terok_agent/paths.py
@@ -3,14 +3,14 @@
 
 """Resolves filesystem paths for agent state and bind-mount directories.
 
-Delegates to :func:`terok_sandbox.paths.umbrella_state_dir` for the
+Delegates to :func:`terok_sandbox.paths.namespace_state_dir` for the
 shared XDG/FHS resolution logic — no vendored copy of the platform
 detection code.
 """
 
 from pathlib import Path
 
-from terok_sandbox.paths import umbrella_state_dir
+from terok_sandbox.paths import namespace_state_dir
 
 _SUBDIR = "agent"
 
@@ -22,7 +22,7 @@ def state_root() -> Path:
     → ``platformdirs`` → ``$XDG_DATA_HOME/terok/agent``
     → ``~/.local/share/terok/agent``.
     """
-    return umbrella_state_dir(_SUBDIR, "TEROK_AGENT_STATE_DIR")
+    return namespace_state_dir(_SUBDIR, "TEROK_AGENT_STATE_DIR")
 
 
 def mounts_dir() -> Path:
@@ -37,4 +37,4 @@ def mounts_dir() -> Path:
     intentionally separated from the credentials store since they are
     container-exposed and subject to potential poisoning.
     """
-    return umbrella_state_dir("sandbox-live", "TEROK_SANDBOX_LIVE_DIR") / "mounts"
+    return namespace_state_dir("sandbox-live", "TEROK_SANDBOX_LIVE_DIR") / "mounts"

--- a/src/terok_agent/resources/scripts/allthethings.sh
+++ b/src/terok_agent/resources/scripts/allthethings.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 p=$(tput setaf 5)    # Purple
 y=$(tput setaf 3)    # Yellow

--- a/src/terok_agent/resources/scripts/ensure-bridges.sh
+++ b/src/terok_agent/resources/scripts/ensure-bridges.sh
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # Idempotent socat bridge launcher for container ↔ host-side credential proxy.
 #

--- a/src/terok_agent/resources/scripts/hilfe
+++ b/src/terok_agent/resources/scripts/hilfe
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-FileCopyrightText: 2026 Andreas Knüpfer
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # terok container help banner. Called on login as:
 #   _TEROK_LOGIN=1 hilfe --kurz
@@ -35,7 +36,7 @@ _terok_agents() {
     printf '  \033[36mvibe\033[0m       - Mistral Vibe CLI\n'
     printf '  \033[36mblablador\033[0m  - OpenCode with Helmholtz Blablador\n'
     printf '  \033[36mkisski\033[0m     - OpenCode with KISSKI\n'
-    printf '  \033[36mopencode\033[0m   - OpenCode CLI (\033[2mterokctl config import-opencode\033[0m)\n'
+    printf '  \033[36mopencode\033[0m   - OpenCode CLI (\033[2mterok config import-opencode\033[0m)\n'
     printf '  \033[36mblablatoad\033[0m - Blablador via Toad ACP\n'
     printf '  \033[36mkisskitoad\033[0m  - KISSKI via Toad ACP\n'
     printf '  \033[36mtoad\033[0m       - Multi-agent TUI (ACP)\n'
@@ -54,9 +55,9 @@ _terok_notes() {
     printf '  - agent CLI commands above are terok wrappers with git/session defaults\n'
     printf '  - \033[36msudo update-all-the-things\033[0m updates system packages and agent installs\n'
     printf '    in this running container only\n'
-    printf '  - host/TUI: \033[36mRebuild from L1 with fresh agents\033[0m / \033[36mterokctl build --agents <project>\033[0m\n'
+    printf '  - host/TUI: \033[36mRebuild from L1 with fresh agents\033[0m / \033[36mterok build --agents <project>\033[0m\n'
     printf '    refreshes agent installs for new containers only\n'
-    printf '  - host/TUI: \033[36mRebuild from L0 (no cache)\033[0m / \033[36mterokctl build --full-rebuild <project>\033[0m\n'
+    printf '  - host/TUI: \033[36mRebuild from L0 (no cache)\033[0m / \033[36mterok build --full-rebuild <project>\033[0m\n'
     printf '    refreshes the base image + apt packages for new containers only\n'
     printf '  - tmux inside the container uses \033[36m^a\033[0m; host tmux usually uses \033[36m^b\033[0m\n'
     printf '  - the container is disposable; \033[36msudo\033[0m works without a password\n'

--- a/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_agent/resources/scripts/init-ssh-and-repo.sh
@@ -2,6 +2,7 @@
 
 # SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 set -euo pipefail
 
@@ -84,7 +85,7 @@ if [[ -n "${REPO_ROOT:-}" && -n "${CODE_REPO:-}" ]]; then
 
   # New Task Marker Protocol:
   # -------------------------
-  # The marker file (.new-task-marker) is created by 'terokctl task new' to signal
+  # The marker file (.new-task-marker) is created by 'terok task new' to signal
   # that this workspace should be reset to the latest remote HEAD. This handles:
   #
   # 1. NEW TASK: Marker exists -> clone or reset to latest HEAD, then remove marker
@@ -275,7 +276,7 @@ if [[ -n "${REPO_ROOT:-}" && -n "${CODE_REPO:-}" ]]; then
           echo "NOTE: Gate is ${BEHIND_COUNT} commits behind upstream on ${TARGET_BRANCH}"
           echo "  Local:    ${LOCAL_HEAD:0:8}"
           echo "  Upstream: ${UPSTREAM_HEAD:0:8}"
-          echo "  Run 'terokctl gate-sync <project>' on host to update"
+          echo "  Run 'terok gate-sync <project>' on host to update"
           echo "=========================================="
           echo ""
         else

--- a/src/terok_agent/resources/scripts/mistral-model-sync.py
+++ b/src/terok_agent/resources/scripts/mistral-model-sync.py
@@ -2,6 +2,7 @@
 
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 """
 Mistral Model Synchronization Tool

--- a/src/terok_agent/resources/scripts/opencode-provider
+++ b/src/terok_agent/resources/scripts/opencode-provider
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 """Unified OpenCode provider launcher for Blablador, KISSKI, and future providers.
 

--- a/src/terok_agent/resources/scripts/opencode-provider-acp
+++ b/src/terok_agent/resources/scripts/opencode-provider-acp
@@ -2,6 +2,7 @@
 
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # Unified ACP wrapper for OpenCode-based providers (Blablador, KISSKI, etc.).
 # Derives the provider name from argv[0] (e.g. blablador-acp → blablador)

--- a/src/terok_agent/resources/scripts/opencode-session-plugin.mjs
+++ b/src/terok_agent/resources/scripts/opencode-session-plugin.mjs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 //
 // SPDX-License-Identifier: Apache-2.0
+// terok:container — this file is deployed into task containers, not used on the host.
 
 // OpenCode plugin that captures the session ID for terok session resume.
 // Writes the session ID to the path specified in TEROK_SESSION_FILE env var.

--- a/src/terok_agent/resources/scripts/opencode-toad
+++ b/src/terok_agent/resources/scripts/opencode-toad
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 """Unified toad launcher for OpenCode-based ACP agents.
 

--- a/src/terok_agent/resources/scripts/setup-codex-auth.sh
+++ b/src/terok_agent/resources/scripts/setup-codex-auth.sh
@@ -2,6 +2,7 @@
 
 # SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # Setup port forwarding for codex auth (port 1455)
 # This script configures port forwarding for OAuth callbacks using socat.

--- a/src/terok_agent/resources/scripts/ssh-agent-bridge.sh
+++ b/src/terok_agent/resources/scripts/ssh-agent-bridge.sh
@@ -2,6 +2,7 @@
 
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # Relay between an SSH agent client (via socat SYSTEM: stdin/stdout) and
 # the host-side SSH agent proxy over TCP, injecting the phantom token

--- a/src/terok_agent/resources/scripts/terok-acp-env.sh
+++ b/src/terok_agent/resources/scripts/terok-acp-env.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # Common environment setup for terok ACP wrappers.
 #

--- a/src/terok_agent/resources/scripts/terok-claude-acp
+++ b/src/terok_agent/resources/scripts/terok-claude-acp
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # ACP wrapper for Claude Code.
 #

--- a/src/terok_agent/resources/scripts/terok-codex-acp
+++ b/src/terok_agent/resources/scripts/terok-codex-acp
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # ACP wrapper for OpenAI Codex.
 #

--- a/src/terok_agent/resources/scripts/terok-copilot-acp
+++ b/src/terok_agent/resources/scripts/terok-copilot-acp
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # ACP wrapper for GitHub Copilot.
 #

--- a/src/terok_agent/resources/scripts/terok-env-git-identity.sh
+++ b/src/terok_agent/resources/scripts/terok-env-git-identity.sh
@@ -2,6 +2,7 @@
 
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # Git identity helper for terok task containers (sourced by terok-env.sh).
 #

--- a/src/terok_agent/resources/scripts/terok-env.sh
+++ b/src/terok_agent/resources/scripts/terok-env.sh
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # Core terok container environment — sourced by ALL shell modes:
 #   - Non-interactive (bash -c): via BASH_ENV

--- a/src/terok_agent/resources/scripts/terok-opencode-acp
+++ b/src/terok_agent/resources/scripts/terok-opencode-acp
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # ACP wrapper for OpenCode (base, non-provider variant).
 #

--- a/src/terok_agent/resources/scripts/terok-vibe-acp
+++ b/src/terok_agent/resources/scripts/terok-vibe-acp
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # ACP wrapper for Mistral Vibe.
 #

--- a/src/terok_agent/resources/scripts/toad
+++ b/src/terok_agent/resources/scripts/toad
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-FileCopyrightText: 2026 Andreas Knüpfer
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # Toad launcher wrapper.
 # Seeds launcher.agents into toad.json before exec-ing the real binary.

--- a/src/terok_agent/resources/scripts/update-all-the-things
+++ b/src/terok_agent/resources/scripts/update-all-the-things
@@ -1,6 +1,7 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 #
 # Update all updatable packages inside a terok CLI container.
 # Designed to be run with sudo inside a running container when you want

--- a/src/terok_agent/resources/scripts/vibe-model-sync.sh
+++ b/src/terok_agent/resources/scripts/vibe-model-sync.sh
@@ -2,6 +2,7 @@
 
 # SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
+# terok:container — this file is deployed into task containers, not used on the host.
 
 # Mistral Model Sync Wrapper Script
 # This script is designed to be called from bashrc to check for new Mistral models

--- a/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
@@ -56,7 +56,7 @@ RUN mkdir -p /etc/claude-code && chown dev:dev /etc/claude-code
 #   - terok-env-git-identity.sh  — _terok_apply_git_identity() function
 #   - terok-env-wrappers.sh      — per-task agent CLI wrappers (symlink to mount)
 # The COPY here sets up the wiring; the script is also refreshed below the
-# cache bust point so `terokctl build --agents` picks up content changes.
+# cache bust point so `terok build --agents` picks up content changes.
 COPY scripts/terok-env.sh /etc/profile.d/terok-env.sh
 RUN chmod +x /etc/profile.d/terok-env.sh; \
     if [ -f /etc/bash.bashrc ]; then \

--- a/src/terok_agent/resources/tmux/container-tmux.conf
+++ b/src/terok_agent/resources/tmux/container-tmux.conf
@@ -1,3 +1,5 @@
+# terok:container — this file is deployed into task containers, not used on the host.
+
 # terok container tmux — prefix is ^a
 # Installed at /etc/tmux.conf inside task containers.
 # Green status bar distinguishes container from host tmux.

--- a/src/terok_agent/resources/toad-agents/blablador.helmholtz.de.toml
+++ b/src/terok_agent/resources/toad-agents/blablador.helmholtz.de.toml
@@ -1,3 +1,5 @@
+# terok:container — this file is deployed into task containers, not used on the host.
+
 identity = "blablador.helmholtz.de"
 name = "Blablador"
 short_name = "blablador"

--- a/src/terok_agent/resources/toad-agents/kisski.academiccloud.de.toml
+++ b/src/terok_agent/resources/toad-agents/kisski.academiccloud.de.toml
@@ -1,3 +1,5 @@
+# terok:container — this file is deployed into task containers, not used on the host.
+
 identity = "kisski.academiccloud.de"
 name = "KISSKI"
 short_name = "kisski"

--- a/src/terok_agent/roster/loader.py
+++ b/src/terok_agent/roster/loader.py
@@ -415,9 +415,9 @@ def ensure_proxy_routes(cfg: SandboxConfig | None = None) -> Path:
 
 def _user_agents_dir() -> Path:
     """Return ``~/.config/terok/agent/agents/``."""
-    from terok_sandbox.paths import umbrella_config_dir
+    from terok_sandbox.paths import namespace_config_dir
 
-    return umbrella_config_dir("agent") / _USER_AGENTS_DIR_NAME
+    return namespace_config_dir("agent") / _USER_AGENTS_DIR_NAME
 
 
 def _load_yaml(text: str) -> dict:

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for terok_agent.paths — umbrella directory resolution."""
+"""Tests for terok_agent.paths — namespace directory resolution."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from terok_agent import paths
 
 
 class TestStateRoot:
-    """Verify ``state_root()`` resolution via sandbox umbrella resolver."""
+    """Verify ``state_root()`` resolution via sandbox namespace resolver."""
 
     def test_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """TEROK_AGENT_STATE_DIR takes first priority."""
@@ -61,8 +61,8 @@ class TestMountsDir:
         assert paths.mounts_dir() == tmp_path / "mounts"
 
 
-class TestUmbrellaConstants:
-    """Verify umbrella namespace constants."""
+class TestNamespaceConstants:
+    """Verify namespace constants."""
 
     def test_subdir_is_agent(self) -> None:
         """_SUBDIR is 'agent'."""


### PR DESCRIPTION
## Summary
- Rename `umbrella_state_dir`/`umbrella_config_dir` imports to `namespace_state_dir`/`namespace_config_dir`
- Fix `terokctl` → `terok` in Dockerfile template, hilfe script, and init-ssh-and-repo.sh
- Update test class/docstring names accordingly

Depends on terok-ai/terok-sandbox#116 (namespace rename).

## Test plan
- [x] `make lint` passes
- [x] Zero remaining `terokctl` or `umbrella` references
- [ ] Tests pass once sandbox with namespace API is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command references from `terokctl` to `terok` throughout documentation and scripts.

* **Chores**
  * Updated terok-sandbox dependency to v0.0.51.
  * Refactored internal path resolution logic.
  * Added container deployment metadata annotations to scripts and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->