### PR TITLE
refactor: split headless.py into providers/wrappers/headless + lazy model sync

### DIFF
--- a/src/terok_agent/__init__.py
+++ b/src/terok_agent/__init__.py
@@ -67,39 +67,41 @@ from .paths import mounts_dir
 from .provider.agents import AgentConfigSpec, parse_md_agent, prepare_agent_config_dir
 from .provider.config import resolve_provider_value
 from .provider.headless import (
-    HEADLESS_PROVIDERS,
-    PROVIDER_NAMES,
     CLIOverrides,
-    HeadlessProvider,
     apply_provider_config,
     build_headless_command,
+)
+from .provider.instructions import bundled_default_instructions, resolve_instructions
+from .provider.providers import (
+    AGENT_PROVIDERS,
+    PROVIDER_NAMES,
+    AgentProvider,
     collect_all_auto_approve_env,
     collect_opencode_provider_env,
     get_provider,
 )
-from .provider.instructions import bundled_default_instructions, resolve_instructions
 
 # -- Roster (agent catalog + config resolution) --------------------------------
 from .roster import CredentialProxyRoute, SidecarSpec, ensure_proxy_routes, get_roster
 from .roster.config_stack import ConfigScope, ConfigStack
 
 # -- Bootstrap YAML roster into module-level dicts ---------------------------
-# HEADLESS_PROVIDERS and AUTH_PROVIDERS are empty dicts populated here to avoid
-# circular imports (roster → auth/headless_providers → roster).
+# AGENT_PROVIDERS and AUTH_PROVIDERS are empty dicts populated here to avoid
+# circular imports (roster → auth/providers → roster).
 
 
 def _bootstrap_roster() -> None:
     """Populate module-level provider dicts from the YAML roster."""
     global PROVIDER_NAMES  # noqa: PLW0603 — tuple requires rebind
 
-    import terok_agent.provider.headless as _hp
+    import terok_agent.provider.providers as _reg
 
     from .roster import get_roster
 
     roster = get_roster()
-    HEADLESS_PROVIDERS.update(roster.providers)
+    AGENT_PROVIDERS.update(roster.providers)
     AUTH_PROVIDERS.update(roster.auth_providers)
-    PROVIDER_NAMES = _hp.PROVIDER_NAMES = roster.agent_names
+    PROVIDER_NAMES = _reg.PROVIDER_NAMES = roster.agent_names
 
 
 _bootstrap_roster()
@@ -107,9 +109,9 @@ _bootstrap_roster()
 __all__ = [
     "__version__",
     # Provider registry
-    "HEADLESS_PROVIDERS",
+    "AGENT_PROVIDERS",
     "PROVIDER_NAMES",
-    "HeadlessProvider",
+    "AgentProvider",
     "get_provider",
     "CLIOverrides",
     "apply_provider_config",

--- a/src/terok_agent/provider/__init__.py
+++ b/src/terok_agent/provider/__init__.py
@@ -1,10 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""AI provider behavior — headless modes, wrapper generation, instructions.
+"""AI provider behavior — provider definitions, headless modes, wrapper generation, instructions.
 
-Delegates to :mod:`.config` for provider-aware config value extraction,
-:mod:`.headless` for the autopilot provider registry and CLI command building,
-:mod:`.instructions` for per-provider instruction resolution, and
-:mod:`.agents` for agent config directory preparation and wrapper scripts.
+Delegates to :mod:`.providers` for the agent provider registry and environment
+collection, :mod:`.wrappers` for shell wrapper generation, :mod:`.headless`
+for headless command construction and config resolution, :mod:`.config` for
+provider-aware config value extraction, :mod:`.instructions` for per-provider
+instruction resolution, and :mod:`.agents` for agent config directory
+preparation and wrapper scripts.
 """

--- a/src/terok_agent/provider/agents.py
+++ b/src/terok_agent/provider/agents.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from terok_agent._util import ensure_dir, ensure_dir_writable, yaml_load as _yaml_load
 
-from .headless import WrapperConfig
+from .wrappers import WrapperConfig
 
 # TODO: future — support global agent definitions in terok-config.yml (agent.subagents).
 # When implemented, global subagents would be merged with per-project subagents before
@@ -95,7 +95,7 @@ def prepare_agent_config_dir(spec: AgentConfigSpec) -> Path:
 
     Returns the agent_config_dir path.
     """
-    from .headless import get_provider as _get_provider
+    from .providers import get_provider as _get_provider
 
     resolved = _get_provider(spec.provider, default_agent=spec.default_agent)
 
@@ -132,13 +132,13 @@ def prepare_agent_config_dir(spec: AgentConfigSpec) -> Path:
     # Inject instructions path into opencode.json configs on the host so
     # all OpenCode-based providers discover them natively (works for both
     # interactive and headless modes).
-    from .headless import HEADLESS_PROVIDERS
+    from .providers import AGENT_PROVIDERS
 
     mounts_base = spec.mounts_base
     if mounts_base is None:
         raise ValueError("mounts_base is required in AgentConfigSpec")
     _inject_opencode_instructions(mounts_base / "_opencode-config" / "opencode.json")
-    for _p in HEADLESS_PROVIDERS.values():
+    for _p in AGENT_PROVIDERS.values():
         if _p.opencode_config is not None:
             _inject_opencode_instructions(
                 mounts_base / f"_{_p.name}-config" / "opencode" / "opencode.json"
@@ -146,7 +146,7 @@ def prepare_agent_config_dir(spec: AgentConfigSpec) -> Path:
 
     # Write shell wrapper functions for ALL providers so interactive CLI users
     # can invoke any agent (each provider gets its own shell function).
-    from .headless import generate_all_wrappers
+    from .wrappers import generate_all_wrappers
 
     def _claude_wrapper_with_instructions(cfg: WrapperConfig) -> str:
         """Wrap _generate_claude_wrapper with the resolved has_instructions flag."""

--- a/src/terok_agent/provider/headless.py
+++ b/src/terok_agent/provider/headless.py
@@ -2,37 +2,18 @@
 # SPDX-FileCopyrightText: 2026 Andreas Knüpfer
 # SPDX-License-Identifier: Apache-2.0
 
-"""Dispatches headless AI agent runs across multiple providers.
+"""Headless (autopilot) command construction and config resolution.
 
-Resolves the active provider, builds the headless CLI command, and generates
-per-provider shell wrappers.  Each provider is a frozen dataclass; the
-``HEADLESS_PROVIDERS`` registry maps names to descriptors.
-
-Instruction delivery
-~~~~~~~~~~~~~~~~~~~~
-Custom instructions are delivered via a provider-specific channel:
-
-- **Claude**: ``--append-system-prompt`` flag (injected by the wrapper).
-- **Codex**: ``model_instructions_file`` config (``-c`` flag in the wrapper).
-- **OpenCode / Blablador / KISSKI**: ``"instructions"`` array in ``opencode.json``
-  pointing to ``/home/dev/.terok/instructions.md`` (injected on the host by
-  :func:`~terok.lib.instrumentation.agents._inject_opencode_instructions`).
-- **Other providers** (Copilot, Vibe, …): best-effort prompt prepending
-  via ``prompt_extra`` in :class:`ProviderConfig`.
-
-The instructions file is always written (with a neutral default when no
-custom text is configured) so that config-file references never dangle.
+Provider definitions live in :mod:`providers`, shell wrapper generation
+lives in :mod:`wrappers`.
 """
 
 from __future__ import annotations
 
 import shlex
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
+from .providers import AgentProvider
 
 # ── Dataclasses / types ─────────────────────────────────────────────────────
 
@@ -77,197 +58,11 @@ class CLIOverrides:
     """Resolved instructions text. Delivery is provider-aware."""
 
 
-@dataclass(frozen=True)
-class WrapperConfig:
-    """Groups parameters for generating the Claude shell wrapper."""
-
-    has_agents: bool
-    has_instructions: bool = False
-
-
-@dataclass(frozen=True)
-class OpenCodeProviderConfig:
-    """Immutable descriptor for an OpenCode-based provider wrapper."""
-
-    display_name: str
-    """Human-readable display name (e.g., 'Helmholtz Blablador')."""
-
-    base_url: str
-    """Base URL for the OpenAI-compatible API (e.g., 'https://api.helmholtz-blablador.fz-juelich.de/v1')."""
-
-    preferred_model: str
-    """Preferred model ID (e.g., 'alias-huge')."""
-
-    fallback_model: str
-    """Fallback model ID if preferred is unavailable (e.g., 'alias-code')."""
-
-    env_var_prefix: str
-    """Environment variable prefix for API key (e.g., 'BLABLADOR' → BLABLADOR_API_KEY)."""
-
-    config_dir: str
-    """Configuration directory name (e.g., '.blablador')."""
-
-    auth_key_url: str
-    """URL where users can obtain API keys for documentation."""
-
-    def to_env(self, name: str) -> dict[str, str]:
-        """Return env vars for container injection, keyed by TEROK_OC_{NAME}_*."""
-        prefix = f"TEROK_OC_{name.upper()}_"
-        return {
-            f"{prefix}BASE_URL": self.base_url,
-            f"{prefix}PREFERRED_MODEL": self.preferred_model,
-            f"{prefix}FALLBACK_MODEL": self.fallback_model,
-            f"{prefix}DISPLAY_NAME": self.display_name,
-            f"{prefix}ENV_VAR_PREFIX": self.env_var_prefix,
-            f"{prefix}CONFIG_DIR": self.config_dir,
-        }
-
-
-@dataclass(frozen=True)
-class HeadlessProvider:
-    """Describes how to run one AI agent in headless (autopilot) mode."""
-
-    name: str
-    """Short key used in CLI dispatch (e.g. ``"claude"``, ``"codex"``)."""
-
-    label: str
-    """Human-readable display name (e.g. ``"Claude"``, ``"Codex"``)."""
-
-    binary: str
-    """CLI binary name (e.g. ``"claude"``, ``"codex"``, ``"opencode"``)."""
-
-    git_author_name: str
-    """AI identity name for Git author/committer policy application."""
-
-    git_author_email: str
-    """AI identity email for Git author/committer policy application."""
-
-    # -- Headless command construction --
-
-    headless_subcommand: str | None
-    """Subcommand for headless mode (e.g. ``"exec"`` for codex, ``"run"`` for opencode).
-
-    ``None`` means the binary uses flags only (e.g. ``claude -p``).
-    """
-
-    prompt_flag: str
-    """Flag for passing the prompt.
-
-    ``"-p"`` for flag-based, ``""`` for positional (after subcommand).
-    """
-
-    auto_approve_env: dict[str, str]
-    """Environment variables for fully autonomous execution.
-
-    Injected into the container env by ``_apply_unrestricted_env()`` when
-    ``TEROK_UNRESTRICTED=1``.  Read by agents regardless of launch path.
-    Claude uses ``/etc/claude-code/managed-settings.json`` instead.
-    """
-
-    auto_approve_flags: tuple[str, ...]
-    """CLI flags injected by the shell wrapper when ``TEROK_UNRESTRICTED=1``.
-
-    Only for agents that lack an env var or managed config mechanism
-    (currently Codex only).  Empty for all other agents — their env vars
-    and ``/etc/`` config files handle permissions across all launch paths.
-    """
-
-    output_format_flags: tuple[str, ...]
-    """Flags for structured output (e.g. ``("--output-format", "stream-json")``)."""
-
-    model_flag: str | None
-    """Flag for model override (``"--model"``, ``"--agent"``, or ``None``)."""
-
-    max_turns_flag: str | None
-    """Flag for maximum turns (``"--max-turns"`` or ``None``)."""
-
-    verbose_flag: str | None
-    """Flag for verbose output (``"--verbose"`` or ``None``)."""
-
-    # -- Session support --
-
-    supports_session_resume: bool
-    """Whether the provider supports resuming a previous session."""
-
-    resume_flag: str | None
-    """Flag to resume a session (e.g. ``"--resume"``, ``"--session"``)."""
-
-    continue_flag: str | None
-    """Flag to continue a session (e.g. ``"--continue"``)."""
-
-    session_file: str | None
-    """Filename in ``/home/dev/.terok/`` for stored session ID.
-
-    Providers that capture session IDs via plugin or post-run parsing set this
-    to a filename (e.g. ``"opencode-session.txt"``).  Providers with their own
-    hook mechanism (Claude) or no session support set this to ``None``.
-    """
-
-    # -- Claude-specific capabilities --
-
-    supports_agents_json: bool
-    """Whether the provider supports ``--agents`` JSON (Claude only)."""
-
-    supports_session_hook: bool
-    """Whether the provider supports SessionStart hooks (Claude only)."""
-
-    supports_add_dir: bool
-    """Whether the provider supports ``--add-dir "/"`` (Claude only)."""
-
-    # -- Log formatting --
-
-    log_format: str
-    """Log format identifier: ``"claude-stream-json"`` or ``"plain"``."""
-
-    opencode_config: OpenCodeProviderConfig | None = None
-    """Configuration for OpenCode-based providers (Blablador, KISSKI, etc.).
-
-    When set, this provider uses OpenCode with a custom OpenAI-compatible API.
-    The configuration includes API endpoints, model preferences, and provider-specific
-    settings that are injected into the container environment.
-    """
-
-    @property
-    def uses_opencode_instructions(self) -> bool:
-        """Whether the provider uses OpenCode's instruction system."""
-        return self.opencode_config is not None or self.name == "opencode"
-
-
-# ── Constants ────────────────────────────────────────────────────────────────
-
-# ---------------------------------------------------------------------------
-# Provider registry — populated from YAML by __init__.py at package load time
-# ---------------------------------------------------------------------------
-
-HEADLESS_PROVIDERS: dict[str, HeadlessProvider] = {}
-"""All headless agent providers, keyed by name.  Loaded from ``resources/agents/*.yaml``."""
-
-PROVIDER_NAMES: tuple[str, ...] = ()
-
-
 # ── Public API ───────────────────────────────────────────────────────────────
 
 
-def get_provider(name: str | None, *, default_agent: str | None = None) -> HeadlessProvider:
-    """Resolve a provider name to a ``HeadlessProvider``.
-
-    Resolution order:
-      1. Explicit *name* if given
-      2. *default_agent* (from project config)
-      3. ``"claude"`` (ultimate fallback)
-
-    Raises ``SystemExit`` if the resolved name is not in the registry.
-    """
-    resolved = name or default_agent or "claude"
-    provider = HEADLESS_PROVIDERS.get(resolved)
-    if provider is None:
-        valid = ", ".join(sorted(HEADLESS_PROVIDERS))
-        raise SystemExit(f"Unknown headless provider {resolved!r}. Valid providers: {valid}")
-    return provider
-
-
 def apply_provider_config(
-    provider: HeadlessProvider,
+    provider: AgentProvider,
     config: dict,
     overrides: CLIOverrides | None = None,
 ) -> ProviderConfig:
@@ -351,7 +146,7 @@ def apply_provider_config(
 
 
 def build_headless_command(
-    provider: HeadlessProvider,
+    provider: AgentProvider,
     *,
     timeout: int,
     model: str | None = None,
@@ -371,106 +166,11 @@ def build_headless_command(
     return _build_generic_command(provider, timeout=timeout, model=model, max_turns=max_turns)
 
 
-def collect_all_auto_approve_env() -> dict[str, str]:
-    """Collect ``auto_approve_env`` from all providers into one dict.
-
-    Used by task runners to inject these env vars at the container level
-    (not just inside shell wrappers) so that ACP-spawned agents also
-    inherit unrestricted permissions.
-    """
-    merged: dict[str, str] = {}
-    for p in HEADLESS_PROVIDERS.values():
-        for key, value in p.auto_approve_env.items():
-            if key in merged and merged[key] != value:
-                raise ValueError(
-                    f"Conflicting auto_approve_env for {key!r}: "
-                    f"{merged[key]!r} vs {value!r} (provider {p.name!r})"
-                )
-            merged[key] = value
-    return merged
-
-
-def collect_opencode_provider_env() -> dict[str, str]:
-    """Collect environment variables for all OpenCode-based providers.
-
-    Returns a dictionary of environment variables that will be injected into containers
-    to configure OpenCode-based providers. Each provider with opencode_config set
-    contributes variables prefixed with TEROK_OC_{PROVIDER_NAME}_*.
-    """
-    env: dict[str, str] = {}
-    for provider in HEADLESS_PROVIDERS.values():
-        if provider.opencode_config is not None:
-            env.update(provider.opencode_config.to_env(provider.name))
-    return env
-
-
-def generate_agent_wrapper(
-    provider: HeadlessProvider,
-    has_agents: bool,
-    *,
-    claude_wrapper_fn: Callable[[WrapperConfig], str] | None = None,
-) -> str:
-    """Generate the shell wrapper function content for a single provider.
-
-    For Claude, uses *claude_wrapper_fn* (which should be
-    ``agents._generate_claude_wrapper``) to produce the full wrapper with
-    ``--add-dir /``, ``--agents``, and session resume support.  The function is passed in by the caller to
-    avoid a circular import between this module and ``agents``.
-
-    For other providers, produces a simpler wrapper that sets git env vars
-    and delegates to the binary.  Instructions are delivered via
-    ``opencode.json`` (OpenCode/Blablador), ``model_instructions_file``
-    (Codex), or ``--append-system-prompt`` (Claude) — not via the wrapper.
-
-    Args:
-        claude_wrapper_fn: ``(cfg: WrapperConfig) -> str``.
-            Required when ``provider.name == "claude"``.
-
-    See also :func:`generate_all_wrappers` which produces wrappers for every
-    registered provider in one file.
-    """
-    if provider.name == "claude":
-        if claude_wrapper_fn is None:
-            raise ValueError("claude_wrapper_fn is required for Claude provider")
-        return claude_wrapper_fn(WrapperConfig(has_agents=has_agents))
-
-    return _generate_generic_wrapper(provider)
-
-
-def generate_all_wrappers(
-    has_agents: bool,
-    *,
-    claude_wrapper_fn: Callable[[WrapperConfig], str] | None = None,
-) -> str:
-    """Generate shell wrappers for **all** registered providers in one file.
-
-    The output file contains a shell function per provider (``claude()``,
-    ``codex()``, ``vibe()``, etc.), each with correct git env vars, timeout
-    support, and session resume logic.  This allows interactive CLI users to
-    invoke any agent regardless of which provider was configured as default.
-
-    A shared ``_terok_resume_or_fresh`` helper is emitted at the top of the
-    file for stale-session fallback (see :data:`_RESUME_FALLBACK_FN`).
-
-    Args:
-        claude_wrapper_fn: Required — produces the Claude wrapper.
-    """
-    sections: list[str] = [_RESUME_FALLBACK_FN]
-    for provider in HEADLESS_PROVIDERS.values():
-        section = generate_agent_wrapper(
-            provider,
-            has_agents,
-            claude_wrapper_fn=claude_wrapper_fn,
-        )
-        sections.append(section)
-    return "\n".join(sections)
-
-
 # ── Private helpers ──────────────────────────────────────────────────────────
 
 
 def _build_claude_command(
-    provider: HeadlessProvider,
+    provider: AgentProvider,
     *,
     timeout: int,
     model: str | None,
@@ -495,7 +195,7 @@ def _build_claude_command(
 
 
 def _build_generic_command(
-    provider: HeadlessProvider,
+    provider: AgentProvider,
     *,
     timeout: int,
     model: str | None,
@@ -520,8 +220,8 @@ def _build_generic_command(
     if provider.headless_subcommand:
         parts.append(provider.headless_subcommand)
 
-    # Auto-approve flags are injected by the wrapper function based on
-    # TEROK_UNRESTRICTED env var — not here.  See _generate_generic_wrapper().
+    # Auto-approve flags are injected by the shell wrapper (wrappers.py)
+    # based on TEROK_UNRESTRICTED env var — not here.
 
     # Model
     if model and provider.model_flag:
@@ -547,209 +247,3 @@ def _build_generic_command(
     parts.append('"$(cat /home/dev/.terok/prompt.txt)"')
 
     return " ".join(parts)
-
-
-def _auto_approve_block(provider: HeadlessProvider) -> list[str]:
-    """Emit bash lines for auto-approve flag injection (Codex only today)."""
-    if not provider.auto_approve_flags:
-        return []
-    lines = ["    local _approve_args=()"]
-    lines.append('    if [[ "${TEROK_UNRESTRICTED:-}" == "1" ]]; then')
-    for flag in provider.auto_approve_flags:
-        lines.append(f"        _approve_args+=({shlex.quote(flag)})")
-    lines.append("    fi")
-    return lines
-
-
-def _opencode_plugin_block(provider: HeadlessProvider) -> list[str]:
-    """Emit bash lines for OpenCode session plugin symlink setup."""
-    if not (provider.session_file and provider.uses_opencode_instructions):
-        return []
-    if provider.opencode_config is not None:
-        plugin_dir = f"$HOME/{provider.opencode_config.config_dir}/opencode/plugins"
-    else:
-        plugin_dir = "$HOME/.config/opencode/plugins"
-    return [
-        "    # Ensure OpenCode session plugin is installed",
-        "    local _plugin_src=/usr/local/share/terok/opencode-session-plugin.mjs",
-        f"    local _plugin_dir={plugin_dir}",
-        '    if [ -f "$_plugin_src" ]; then',
-        '        mkdir -p "$_plugin_dir"',
-        '        ln -sf "$_plugin_src" "$_plugin_dir/terok-session.mjs"',
-        "    fi",
-    ]
-
-
-def _session_resume_block(provider: HeadlessProvider, session_path: str | None) -> list[str]:
-    """Emit bash lines for session resume arg injection."""
-    if not (session_path and provider.resume_flag):
-        return []
-    return [
-        "    local _resume_args=()",
-        f"    if [ -s {session_path} ] && \\",
-        '       { [ -n "$_timeout" ] || [ $# -eq 0 ]; }; then',
-        f'        _resume_args+=({provider.resume_flag} "$(cat {session_path})")',
-        "    fi",
-    ]
-
-
-def _codex_instr_block(provider: HeadlessProvider) -> list[str]:
-    """Emit bash lines for Codex model_instructions_file injection."""
-    if provider.name != "codex":
-        return []
-    return [
-        "    local _instr_args=()",
-        "    [ -f /home/dev/.terok/instructions.md ] && \\",
-        "        _instr_args+=(-c 'model_instructions_file=\"/home/dev/.terok/instructions.md\"')",
-    ]
-
-
-def _vibe_capture_fn(provider: HeadlessProvider, session_path: str | None) -> list[str]:
-    """Emit bash lines for Vibe post-run session capture helper."""
-    if not (provider.name == "vibe" and session_path):
-        return []
-    return [
-        "    _terok_capture_vibe_session() {",
-        '        python3 -c "',
-        "import json, os, glob",
-        "files = sorted(glob.glob(os.path.expanduser('~/.vibe/logs/session/session_*/meta.json')),",
-        "               key=os.path.getmtime, reverse=True)",
-        "if files:",
-        "    with open(files[0]) as f:",
-        "        sid = json.load(f).get('session_id', '')",
-        "    if sid:",
-        "        print(sid)",
-        f'" > {session_path} 2>/dev/null || true',
-        "    }",
-    ]
-
-
-def _extra_args_expansion(provider: HeadlessProvider, session_path: str | None) -> str:
-    """Build the extra-args shell expansions between the binary and ``"$@"``."""
-    parts: list[str] = []
-    if provider.auto_approve_flags:
-        parts.append('"${_approve_args[@]}"')
-    if session_path and provider.resume_flag:
-        parts.append('"${_resume_args[@]}"')
-    if provider.name == "codex":
-        parts.append('"${_instr_args[@]}"')
-    return (" " + " ".join(parts)) if parts else ""
-
-
-def _wrap_invocation(cmd: str, provider: HeadlessProvider, session_path: str | None) -> str:
-    """Wrap a shell invocation with the stale-session fallback when resume is active."""
-    if session_path and provider.resume_flag:
-        return f"_terok_resume_or_fresh {session_path} {provider.resume_flag} {cmd}"
-    return cmd
-
-
-_RESUME_FALLBACK_FN = """\
-# WORKAROUND: stale-session guard (timing-based heuristic).
-#
-# When a user starts an agent, exits immediately (no real interaction),
-# and re-runs, the captured session ID points to a conversation that was
-# never persisted.  The agent then fails with "No conversation found".
-#
-# This is a best-effort mitigation, not a proper fix: we assume that
-# any non-zero exit within 2 seconds of launch is a stale-session error
-# and retry without --resume.  This heuristic can misfire (e.g. a fast
-# config error would also trigger a retry), but the retry is harmless —
-# it just runs without resume, which is the correct fallback anyway.
-#
-# A proper fix would validate the session ID against the agent's storage
-# before injecting --resume, but that requires agent-specific probes
-# that don't exist yet.
-_terok_resume_or_fresh() {
-    local _session_file="$1" _resume_flag="$2"; shift 2
-    local _start; _start=$(date +%s)
-    "$@"; local _rc=$?
-    local _elapsed=$(( $(date +%s) - _start ))
-    if [ $_rc -ne 0 ] && [ $_elapsed -lt 2 ] && [ -s "$_session_file" ]; then
-        echo "terok: session not found (stale?), retrying without resume" >&2
-        rm -f "$_session_file"
-        local _retry=() _skip=false
-        for _a in "$@"; do
-            if $_skip; then _skip=false; continue; fi
-            if [ "$_a" = "$_resume_flag" ]; then _skip=true; continue; fi
-            _retry+=("$_a")
-        done
-        "${_retry[@]}"; _rc=$?
-    fi
-    return $_rc
-}
-"""
-
-
-def _generate_generic_wrapper(provider: HeadlessProvider) -> str:
-    """Generate a shell wrapper for non-Claude providers.
-
-    Sets git identity env vars and wraps the binary with optional timeout
-    support (``--terok-timeout``), matching the Claude wrapper's interface.
-
-    Session resume logic (for providers with ``session_file``):
-
-    - An OpenCode plugin (or post-run parse for Vibe) captures the session
-      ID to ``/home/dev/.terok/<session_file>``.
-    - Resume args (``--session <id>`` or ``--resume <id>``) are injected
-      only in headless mode (``--terok-timeout`` present) or on bare
-      interactive launch (no user args).
-    - When the user passes their own arguments, passthrough is transparent
-      — no resume args are injected.
-    """
-    author_name = shlex.quote(provider.git_author_name)
-    author_email = shlex.quote(provider.git_author_email)
-    binary = provider.binary
-    session_path = f"/home/dev/.terok/{provider.session_file}" if provider.session_file else None
-    extra = _extra_args_expansion(provider, session_path)
-
-    lines = [
-        "# Generated by terok",
-        f"{binary}() {{",
-        '    local _timeout=""',
-        "    # Extract terok-specific flags (must come before agent flags)",
-        "    while [[ $# -gt 0 ]]; do",
-        '        case "$1" in',
-        '            --terok-timeout) _timeout="$2"; shift 2 ;;',
-        "            *) break ;;",
-        "        esac",
-        "    done",
-        "    [ -r /usr/local/share/terok/terok-env-git-identity.sh ] && \\",
-        "        . /usr/local/share/terok/terok-env-git-identity.sh",
-    ]
-
-    lines.extend(_auto_approve_block(provider))
-    lines.extend(_opencode_plugin_block(provider))
-    lines.extend(_session_resume_block(provider, session_path))
-    lines.extend(_codex_instr_block(provider))
-    lines.extend(_vibe_capture_fn(provider, session_path))
-
-    headless_cmd = _wrap_invocation(
-        f'timeout "$_timeout" {binary}{extra} "$@"', provider, session_path
-    )
-    interactive_cmd = _wrap_invocation(f'command {binary}{extra} "$@"', provider, session_path)
-
-    # Headless mode (with timeout)
-    lines.append('    if [ -n "$_timeout" ]; then')
-    lines.append("        (")
-    lines.append(f"            _terok_apply_git_identity {author_name} {author_email}")
-    if session_path:
-        lines.append(f"            export TEROK_SESSION_FILE={session_path}")
-    lines.append(f"        {headless_cmd}")
-    if provider.name == "vibe" and session_path:
-        lines.append("        local _rc=$?; _terok_capture_vibe_session; return $_rc")
-    lines.append("        )")
-
-    # Interactive mode (no timeout)
-    lines.append("    else")
-    lines.append("        (")
-    lines.append(f"            _terok_apply_git_identity {author_name} {author_email}")
-    if session_path:
-        lines.append(f"            export TEROK_SESSION_FILE={session_path}")
-    lines.append(f"        {interactive_cmd}")
-    if provider.name == "vibe" and session_path:
-        lines.append("        local _rc=$?; _terok_capture_vibe_session; return $_rc")
-    lines.append("        )")
-    lines.append("    fi")
-    lines.append("}")
-
-    return "\n".join(lines) + "\n"

--- a/src/terok_agent/provider/providers.py
+++ b/src/terok_agent/provider/providers.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-FileCopyrightText: 2026 Andreas Knüpfer
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent provider registry: definitions, lookup, and environment collection.
+
+Each supported AI coding agent is described by an :class:`AgentProvider`
+dataclass.  The ``AGENT_PROVIDERS`` dict maps short names to descriptors
+and is populated at package load time from the YAML roster.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OpenCodeProviderConfig:
+    """Immutable descriptor for an OpenCode-based provider wrapper."""
+
+    display_name: str
+    """Human-readable display name (e.g., 'Helmholtz Blablador')."""
+
+    base_url: str
+    """Base URL for the OpenAI-compatible API (e.g., 'https://api.helmholtz-blablador.fz-juelich.de/v1')."""
+
+    preferred_model: str
+    """Preferred model ID (e.g., 'alias-huge')."""
+
+    fallback_model: str
+    """Fallback model ID if preferred is unavailable (e.g., 'alias-code')."""
+
+    env_var_prefix: str
+    """Environment variable prefix for API key (e.g., 'BLABLADOR' → BLABLADOR_API_KEY)."""
+
+    config_dir: str
+    """Configuration directory name (e.g., '.blablador')."""
+
+    auth_key_url: str
+    """URL where users can obtain API keys for documentation."""
+
+    def to_env(self, name: str) -> dict[str, str]:
+        """Return env vars for container injection, keyed by TEROK_OC_{NAME}_*."""
+        prefix = f"TEROK_OC_{name.upper()}_"
+        return {
+            f"{prefix}BASE_URL": self.base_url,
+            f"{prefix}PREFERRED_MODEL": self.preferred_model,
+            f"{prefix}FALLBACK_MODEL": self.fallback_model,
+            f"{prefix}DISPLAY_NAME": self.display_name,
+            f"{prefix}ENV_VAR_PREFIX": self.env_var_prefix,
+            f"{prefix}CONFIG_DIR": self.config_dir,
+        }
+
+
+@dataclass(frozen=True)
+class AgentProvider:
+    """Describes how to run one AI coding agent (all modes: interactive + headless)."""
+
+    name: str
+    """Short key used in CLI dispatch (e.g. ``"claude"``, ``"codex"``)."""
+
+    label: str
+    """Human-readable display name (e.g. ``"Claude"``, ``"Codex"``)."""
+
+    binary: str
+    """CLI binary name (e.g. ``"claude"``, ``"codex"``, ``"opencode"``)."""
+
+    git_author_name: str
+    """AI identity name for Git author/committer policy application."""
+
+    git_author_email: str
+    """AI identity email for Git author/committer policy application."""
+
+    # -- Headless command construction --
+
+    headless_subcommand: str | None
+    """Subcommand for headless mode (e.g. ``"exec"`` for codex, ``"run"`` for opencode).
+
+    ``None`` means the binary uses flags only (e.g. ``claude -p``).
+    """
+
+    prompt_flag: str
+    """Flag for passing the prompt.
+
+    ``"-p"`` for flag-based, ``""`` for positional (after subcommand).
+    """
+
+    auto_approve_env: dict[str, str]
+    """Environment variables for fully autonomous execution.
+
+    Injected into the container env by ``_apply_unrestricted_env()`` when
+    ``TEROK_UNRESTRICTED=1``.  Read by agents regardless of launch path.
+    Claude uses ``/etc/claude-code/managed-settings.json`` instead.
+    """
+
+    auto_approve_flags: tuple[str, ...]
+    """CLI flags injected by the shell wrapper when ``TEROK_UNRESTRICTED=1``.
+
+    Only for agents that lack an env var or managed config mechanism
+    (currently Codex only).  Empty for all other agents — their env vars
+    and ``/etc/`` config files handle permissions across all launch paths.
+    """
+
+    output_format_flags: tuple[str, ...]
+    """Flags for structured output (e.g. ``("--output-format", "stream-json")``)."""
+
+    model_flag: str | None
+    """Flag for model override (``"--model"``, ``"--agent"``, or ``None``)."""
+
+    max_turns_flag: str | None
+    """Flag for maximum turns (``"--max-turns"`` or ``None``)."""
+
+    verbose_flag: str | None
+    """Flag for verbose output (``"--verbose"`` or ``None``)."""
+
+    # -- Session support --
+
+    supports_session_resume: bool
+    """Whether the provider supports resuming a previous session."""
+
+    resume_flag: str | None
+    """Flag to resume a session (e.g. ``"--resume"``, ``"--session"``)."""
+
+    continue_flag: str | None
+    """Flag to continue a session (e.g. ``"--continue"``)."""
+
+    session_file: str | None
+    """Filename in ``/home/dev/.terok/`` for stored session ID.
+
+    Providers that capture session IDs via plugin or post-run parsing set this
+    to a filename (e.g. ``"opencode-session.txt"``).  Providers with their own
+    hook mechanism (Claude) or no session support set this to ``None``.
+    """
+
+    # -- Claude-specific capabilities --
+
+    supports_agents_json: bool
+    """Whether the provider supports ``--agents`` JSON (Claude only)."""
+
+    supports_session_hook: bool
+    """Whether the provider supports SessionStart hooks (Claude only)."""
+
+    supports_add_dir: bool
+    """Whether the provider supports ``--add-dir "/"`` (Claude only)."""
+
+    # -- Log formatting --
+
+    log_format: str
+    """Log format identifier: ``"claude-stream-json"`` or ``"plain"``."""
+
+    opencode_config: OpenCodeProviderConfig | None = None
+    """Configuration for OpenCode-based providers (Blablador, KISSKI, etc.).
+
+    When set, this provider uses OpenCode with a custom OpenAI-compatible API.
+    The configuration includes API endpoints, model preferences, and provider-specific
+    settings that are injected into the container environment.
+    """
+
+    @property
+    def uses_opencode_instructions(self) -> bool:
+        """Whether the provider uses OpenCode's instruction system."""
+        return self.opencode_config is not None or self.name == "opencode"
+
+
+# ---------------------------------------------------------------------------
+# Provider registry — populated from YAML by __init__.py at package load time
+# ---------------------------------------------------------------------------
+
+AGENT_PROVIDERS: dict[str, AgentProvider] = {}
+"""All agent providers, keyed by name.  Loaded from ``resources/agents/*.yaml``."""
+
+PROVIDER_NAMES: tuple[str, ...] = ()
+
+
+# ── Public API ──────────────────────────────────────────────────────────────
+
+
+def get_provider(name: str | None, *, default_agent: str | None = None) -> AgentProvider:
+    """Resolve a provider name to an :class:`AgentProvider`.
+
+    Resolution order:
+      1. Explicit *name* if given
+      2. *default_agent* (from project config)
+      3. ``"claude"`` (ultimate fallback)
+
+    Raises ``SystemExit`` if the resolved name is not in the registry.
+    """
+    resolved = name or default_agent or "claude"
+    provider = AGENT_PROVIDERS.get(resolved)
+    if provider is None:
+        valid = ", ".join(sorted(AGENT_PROVIDERS))
+        raise SystemExit(f"Unknown provider {resolved!r}. Valid providers: {valid}")
+    return provider
+
+
+def collect_all_auto_approve_env() -> dict[str, str]:
+    """Collect ``auto_approve_env`` from all providers into one dict.
+
+    Used by task runners to inject these env vars at the container level
+    (not just inside shell wrappers) so that ACP-spawned agents also
+    inherit unrestricted permissions.
+    """
+    merged: dict[str, str] = {}
+    for p in AGENT_PROVIDERS.values():
+        for key, value in p.auto_approve_env.items():
+            if key in merged and merged[key] != value:
+                raise ValueError(
+                    f"Conflicting auto_approve_env for {key!r}: "
+                    f"{merged[key]!r} vs {value!r} (provider {p.name!r})"
+                )
+            merged[key] = value
+    return merged
+
+
+def collect_opencode_provider_env() -> dict[str, str]:
+    """Collect environment variables for all OpenCode-based providers.
+
+    Returns a dictionary of environment variables that will be injected into containers
+    to configure OpenCode-based providers. Each provider with opencode_config set
+    contributes variables prefixed with TEROK_OC_{PROVIDER_NAME}_*.
+    """
+    env: dict[str, str] = {}
+    for provider in AGENT_PROVIDERS.values():
+        if provider.opencode_config is not None:
+            env.update(provider.opencode_config.to_env(provider.name))
+    return env

--- a/src/terok_agent/provider/providers.py
+++ b/src/terok_agent/provider/providers.py
@@ -175,22 +175,31 @@ PROVIDER_NAMES: tuple[str, ...] = ()
 # ── Public API ──────────────────────────────────────────────────────────────
 
 
-def get_provider(name: str | None, *, default_agent: str | None = None) -> AgentProvider:
-    """Resolve a provider name to an :class:`AgentProvider`.
+def resolve_provider(
+    providers: dict[str, AgentProvider],
+    name: str | None,
+    *,
+    default_agent: str | None = None,
+) -> AgentProvider:
+    """Look up a provider by name from *providers*, with fallback chain.
 
-    Resolution order:
-      1. Explicit *name* if given
-      2. *default_agent* (from project config)
-      3. ``"claude"`` (ultimate fallback)
-
-    Raises ``SystemExit`` if the resolved name is not in the registry.
+    Resolution order: explicit *name* → *default_agent* → ``"claude"``.
+    Raises ``SystemExit`` if the resolved name is not found.
     """
     resolved = name or default_agent or "claude"
-    provider = AGENT_PROVIDERS.get(resolved)
+    provider = providers.get(resolved)
     if provider is None:
-        valid = ", ".join(sorted(AGENT_PROVIDERS))
+        valid = ", ".join(sorted(providers))
         raise SystemExit(f"Unknown provider {resolved!r}. Valid providers: {valid}")
     return provider
+
+
+def get_provider(name: str | None, *, default_agent: str | None = None) -> AgentProvider:
+    """Resolve a provider name against the global :data:`AGENT_PROVIDERS` registry.
+
+    Convenience wrapper around :func:`resolve_provider`.
+    """
+    return resolve_provider(AGENT_PROVIDERS, name, default_agent=default_agent)
 
 
 def collect_all_auto_approve_env() -> dict[str, str]:

--- a/src/terok_agent/provider/wrappers.py
+++ b/src/terok_agent/provider/wrappers.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-FileCopyrightText: 2026 Andreas Knüpfer
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shell wrapper generation for agent CLI commands.
+
+Produces per-provider bash functions (``claude()``, ``codex()``, ``vibe()``,
+etc.) that set git identity, handle session resume, and support both
+interactive and headless (``--terok-timeout``) modes.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .providers import AGENT_PROVIDERS, AgentProvider
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@dataclass(frozen=True)
+class WrapperConfig:
+    """Groups parameters for generating the Claude shell wrapper."""
+
+    has_agents: bool
+    has_instructions: bool = False
+
+
+def generate_agent_wrapper(
+    provider: AgentProvider,
+    has_agents: bool,
+    *,
+    claude_wrapper_fn: Callable[[WrapperConfig], str] | None = None,
+) -> str:
+    """Generate the shell wrapper function content for a single provider.
+
+    For Claude, uses *claude_wrapper_fn* (which should be
+    ``agents._generate_claude_wrapper``) to produce the full wrapper with
+    ``--add-dir /``, ``--agents``, and session resume support.  The function
+    is passed in by the caller to avoid a circular import between this module
+    and ``agents``.
+
+    For other providers, produces a simpler wrapper that sets git env vars
+    and delegates to the binary.  Instructions are delivered via
+    ``opencode.json`` (OpenCode/Blablador), ``model_instructions_file``
+    (Codex), or ``--append-system-prompt`` (Claude) -- not via the wrapper.
+
+    Args:
+        claude_wrapper_fn: ``(cfg: WrapperConfig) -> str``.
+            Required when ``provider.name == "claude"``.
+
+    See also :func:`generate_all_wrappers` which produces wrappers for every
+    registered provider in one file.
+    """
+    if provider.name == "claude":
+        if claude_wrapper_fn is None:
+            raise ValueError("claude_wrapper_fn is required for Claude provider")
+        return claude_wrapper_fn(WrapperConfig(has_agents=has_agents))
+
+    return _generate_generic_wrapper(provider)
+
+
+def generate_all_wrappers(
+    has_agents: bool,
+    *,
+    claude_wrapper_fn: Callable[[WrapperConfig], str] | None = None,
+) -> str:
+    """Generate shell wrappers for **all** registered providers in one file.
+
+    The output file contains a shell function per provider (``claude()``,
+    ``codex()``, ``vibe()``, etc.), each with correct git env vars, timeout
+    support, and session resume logic.  This allows interactive CLI users to
+    invoke any agent regardless of which provider was configured as default.
+
+    A shared ``_terok_resume_or_fresh`` helper is emitted at the top of the
+    file for stale-session fallback (see :data:`_RESUME_FALLBACK_FN`).
+
+    Args:
+        claude_wrapper_fn: Required -- produces the Claude wrapper.
+    """
+    sections: list[str] = [_RESUME_FALLBACK_FN]
+    for provider in AGENT_PROVIDERS.values():
+        section = generate_agent_wrapper(
+            provider,
+            has_agents,
+            claude_wrapper_fn=claude_wrapper_fn,
+        )
+        sections.append(section)
+    return "\n".join(sections)
+
+
+# -- Private helpers ----------------------------------------------------------
+
+
+def _auto_approve_block(provider: AgentProvider) -> list[str]:
+    """Emit bash lines for auto-approve flag injection (Codex only today)."""
+    if not provider.auto_approve_flags:
+        return []
+    lines = ["    local _approve_args=()"]
+    lines.append('    if [[ "${TEROK_UNRESTRICTED:-}" == "1" ]]; then')
+    for flag in provider.auto_approve_flags:
+        lines.append(f"        _approve_args+=({shlex.quote(flag)})")
+    lines.append("    fi")
+    return lines
+
+
+def _opencode_plugin_block(provider: AgentProvider) -> list[str]:
+    """Emit bash lines for OpenCode session plugin symlink setup."""
+    if not (provider.session_file and provider.uses_opencode_instructions):
+        return []
+    if provider.opencode_config is not None:
+        plugin_dir = f"$HOME/{provider.opencode_config.config_dir}/opencode/plugins"
+    else:
+        plugin_dir = "$HOME/.config/opencode/plugins"
+    return [
+        "    # Ensure OpenCode session plugin is installed",
+        "    local _plugin_src=/usr/local/share/terok/opencode-session-plugin.mjs",
+        f"    local _plugin_dir={plugin_dir}",
+        '    if [ -f "$_plugin_src" ]; then',
+        '        mkdir -p "$_plugin_dir"',
+        '        ln -sf "$_plugin_src" "$_plugin_dir/terok-session.mjs"',
+        "    fi",
+    ]
+
+
+def _session_resume_block(provider: AgentProvider, session_path: str | None) -> list[str]:
+    """Emit bash lines for session resume arg injection."""
+    if not (session_path and provider.resume_flag):
+        return []
+    return [
+        "    local _resume_args=()",
+        f"    if [ -s {session_path} ] && \\",
+        '       { [ -n "$_timeout" ] || [ $# -eq 0 ]; }; then',
+        f'        _resume_args+=({provider.resume_flag} "$(cat {session_path})")',
+        "    fi",
+    ]
+
+
+def _codex_instr_block(provider: AgentProvider) -> list[str]:
+    """Emit bash lines for Codex model_instructions_file injection."""
+    if provider.name != "codex":
+        return []
+    return [
+        "    local _instr_args=()",
+        "    [ -f /home/dev/.terok/instructions.md ] && \\",
+        "        _instr_args+=(-c 'model_instructions_file=\"/home/dev/.terok/instructions.md\"')",
+    ]
+
+
+def _vibe_model_sync_block(provider: AgentProvider) -> list[str]:
+    """Emit bash lines for lazy Mistral model sync before vibe runs.
+
+    Uses a pure-bash mtime check to avoid Python startup overhead when
+    the cache is fresh (<24h).  Only invoked from the vibe() wrapper,
+    keeping login shells fast.
+    """
+    if provider.name != "vibe":
+        return []
+    return [
+        "    # Lazy Mistral model sync (pure-bash mtime check, avoids Python startup)",
+        "    if command -v vibe-model-sync >/dev/null 2>&1; then",
+        "        local _mc=$HOME/.vibe/mistral-models.txt",
+        '        if [ ! -f "$_mc" ] || [ -n "$(find "$_mc" -mmin +1440 2>/dev/null)" ]; then',
+        "            vibe-model-sync >/dev/null 2>&1 || true",
+        "        fi",
+        "    fi",
+    ]
+
+
+def _vibe_capture_fn(provider: AgentProvider, session_path: str | None) -> list[str]:
+    """Emit bash lines for Vibe post-run session capture helper."""
+    if not (provider.name == "vibe" and session_path):
+        return []
+    return [
+        "    _terok_capture_vibe_session() {",
+        '        python3 -c "',
+        "import json, os, glob",
+        "files = sorted(glob.glob(os.path.expanduser('~/.vibe/logs/session/session_*/meta.json')),",
+        "               key=os.path.getmtime, reverse=True)",
+        "if files:",
+        "    with open(files[0]) as f:",
+        "        sid = json.load(f).get('session_id', '')",
+        "    if sid:",
+        "        print(sid)",
+        f'" > {session_path} 2>/dev/null || true',
+        "    }",
+    ]
+
+
+def _extra_args_expansion(provider: AgentProvider, session_path: str | None) -> str:
+    """Build the extra-args shell expansions between the binary and ``"$@"``."""
+    parts: list[str] = []
+    if provider.auto_approve_flags:
+        parts.append('"${_approve_args[@]}"')
+    if session_path and provider.resume_flag:
+        parts.append('"${_resume_args[@]}"')
+    if provider.name == "codex":
+        parts.append('"${_instr_args[@]}"')
+    return (" " + " ".join(parts)) if parts else ""
+
+
+def _wrap_invocation(cmd: str, provider: AgentProvider, session_path: str | None) -> str:
+    """Wrap a shell invocation with the stale-session fallback when resume is active."""
+    if session_path and provider.resume_flag:
+        return f"_terok_resume_or_fresh {session_path} {provider.resume_flag} {cmd}"
+    return cmd
+
+
+_RESUME_FALLBACK_FN = """\
+# WORKAROUND: stale-session guard (timing-based heuristic).
+#
+# When a user starts an agent, exits immediately (no real interaction),
+# and re-runs, the captured session ID points to a conversation that was
+# never persisted.  The agent then fails with "No conversation found".
+#
+# This is a best-effort mitigation, not a proper fix: we assume that
+# any non-zero exit within 2 seconds of launch is a stale-session error
+# and retry without --resume.  This heuristic can misfire (e.g. a fast
+# config error would also trigger a retry), but the retry is harmless —
+# it just runs without resume, which is the correct fallback anyway.
+#
+# A proper fix would validate the session ID against the agent's storage
+# before injecting --resume, but that requires agent-specific probes
+# that don't exist yet.
+_terok_resume_or_fresh() {
+    local _session_file="$1" _resume_flag="$2"; shift 2
+    local _start; _start=$(date +%s)
+    "$@"; local _rc=$?
+    local _elapsed=$(( $(date +%s) - _start ))
+    if [ $_rc -ne 0 ] && [ $_elapsed -lt 2 ] && [ -s "$_session_file" ]; then
+        echo "terok: session not found (stale?), retrying without resume" >&2
+        rm -f "$_session_file"
+        local _retry=() _skip=false
+        for _a in "$@"; do
+            if $_skip; then _skip=false; continue; fi
+            if [ "$_a" = "$_resume_flag" ]; then _skip=true; continue; fi
+            _retry+=("$_a")
+        done
+        "${_retry[@]}"; _rc=$?
+    fi
+    return $_rc
+}
+"""
+
+
+def _generate_generic_wrapper(provider: AgentProvider) -> str:
+    """Generate a shell wrapper for non-Claude providers.
+
+    Sets git identity env vars and wraps the binary with optional timeout
+    support (``--terok-timeout``), matching the Claude wrapper's interface.
+
+    Session resume logic (for providers with ``session_file``):
+
+    - An OpenCode plugin (or post-run parse for Vibe) captures the session
+      ID to ``/home/dev/.terok/<session_file>``.
+    - Resume args (``--session <id>`` or ``--resume <id>``) are injected
+      only in headless mode (``--terok-timeout`` present) or on bare
+      interactive launch (no user args).
+    - When the user passes their own arguments, passthrough is transparent
+      -- no resume args are injected.
+    """
+    author_name = shlex.quote(provider.git_author_name)
+    author_email = shlex.quote(provider.git_author_email)
+    binary = provider.binary
+    session_path = f"/home/dev/.terok/{provider.session_file}" if provider.session_file else None
+    extra = _extra_args_expansion(provider, session_path)
+
+    lines = [
+        "# Generated by terok",
+        f"{binary}() {{",
+        '    local _timeout=""',
+        "    # Extract terok-specific flags (must come before agent flags)",
+        "    while [[ $# -gt 0 ]]; do",
+        '        case "$1" in',
+        '            --terok-timeout) _timeout="$2"; shift 2 ;;',
+        "            *) break ;;",
+        "        esac",
+        "    done",
+        "    [ -r /usr/local/share/terok/terok-env-git-identity.sh ] && \\",
+        "        . /usr/local/share/terok/terok-env-git-identity.sh",
+    ]
+
+    lines.extend(_vibe_model_sync_block(provider))
+    lines.extend(_auto_approve_block(provider))
+    lines.extend(_opencode_plugin_block(provider))
+    lines.extend(_session_resume_block(provider, session_path))
+    lines.extend(_codex_instr_block(provider))
+    lines.extend(_vibe_capture_fn(provider, session_path))
+
+    headless_cmd = _wrap_invocation(
+        f'timeout "$_timeout" {binary}{extra} "$@"', provider, session_path
+    )
+    interactive_cmd = _wrap_invocation(f'command {binary}{extra} "$@"', provider, session_path)
+
+    # Headless mode (with timeout)
+    lines.append('    if [ -n "$_timeout" ]; then')
+    lines.append("        (")
+    lines.append(f"            _terok_apply_git_identity {author_name} {author_email}")
+    if session_path:
+        lines.append(f"            export TEROK_SESSION_FILE={session_path}")
+    lines.append(f"        {headless_cmd}")
+    if provider.name == "vibe" and session_path:
+        lines.append("        local _rc=$?; _terok_capture_vibe_session; return $_rc")
+    lines.append("        )")
+
+    # Interactive mode (no timeout)
+    lines.append("    else")
+    lines.append("        (")
+    lines.append(f"            _terok_apply_git_identity {author_name} {author_email}")
+    if session_path:
+        lines.append(f"            export TEROK_SESSION_FILE={session_path}")
+    lines.append(f"        {interactive_cmd}")
+    if provider.name == "vibe" and session_path:
+        lines.append("        local _rc=$?; _terok_capture_vibe_session; return $_rc")
+    lines.append("        )")
+    lines.append("    fi")
+    lines.append("}")
+
+    return "\n".join(lines) + "\n"

--- a/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_agent/resources/templates/l1.agent-cli.Dockerfile.template
@@ -64,9 +64,8 @@ RUN chmod +x /etc/profile.d/terok-env.sh; \
     else \
       printf '# terok environment (PATH, git identity, agent wrappers)\n. /etc/profile.d/terok-env.sh\n' > /etc/bash.bashrc; \
     fi; \
-    # Interactive-only: help banner and model sync (login shells only)
-    printf '\n# Help banner (interactive login only)\nif [ -t 1 ] && [ -z "$_TEROK_BANNER_SHOWN" ]; then\n  export _TEROK_BANNER_SHOWN=1\n  _TEROK_LOGIN=1 hilfe --kurz 2>/dev/null || true\nfi\n' >> /etc/bash.bashrc; \
-    printf '\n# Mistral model sync (interactive login only)\nif [ -t 1 ] && [ -z "$_MISTRAL_MODEL_SYNC_RUN" ]; then\n  export _MISTRAL_MODEL_SYNC_RUN=1\n  if command -v vibe-model-sync >/dev/null 2>&1; then\n    vibe-model-sync >/dev/null 2>&1 || true\n  fi\nfi\n' >> /etc/bash.bashrc
+    # Interactive-only: help banner (login shells only)
+    printf '\n# Help banner (interactive login only)\nif [ -t 1 ] && [ -z "$_TEROK_BANNER_SHOWN" ]; then\n  export _TEROK_BANNER_SHOWN=1\n  _TEROK_LOGIN=1 hilfe --kurz 2>/dev/null || true\nfi\n' >> /etc/bash.bashrc
 
 # Symlink for per-task agent wrappers (resolved at runtime via mount).
 RUN mkdir -p /usr/local/share/terok && \

--- a/src/terok_agent/roster/loader.py
+++ b/src/terok_agent/roster/loader.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from terok_sandbox import SandboxConfig
 
     from terok_agent.credentials.auth import AuthProvider
-    from terok_agent.provider.headless import HeadlessProvider, OpenCodeProviderConfig
+    from terok_agent.provider.providers import AgentProvider, OpenCodeProviderConfig
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -137,7 +137,7 @@ class AgentRoster:
     Provides the same query API as the legacy hardcoded dicts.
     """
 
-    _providers: dict[str, HeadlessProvider] = field(default_factory=dict)
+    _providers: dict[str, AgentProvider] = field(default_factory=dict)
     _auth_providers: dict[str, AuthProvider] = field(default_factory=dict)
     _proxy_routes: dict[str, CredentialProxyRoute] = field(default_factory=dict)
     _sidecar_specs: dict[str, SidecarSpec] = field(default_factory=dict)
@@ -148,7 +148,7 @@ class AgentRoster:
     # ── Properties ──
 
     @property
-    def providers(self) -> dict[str, HeadlessProvider]:
+    def providers(self) -> dict[str, AgentProvider]:
         """All headless agent providers (``kind: agent`` only)."""
         return dict(self._providers)
 
@@ -188,20 +188,15 @@ class AgentRoster:
 
     # ── Keyed lookups ──
 
-    def get_provider(
-        self, name: str | None, *, default_agent: str | None = None
-    ) -> HeadlessProvider:
-        """Resolve a provider name to a ``HeadlessProvider``.
+    def get_provider(self, name: str | None, *, default_agent: str | None = None) -> AgentProvider:
+        """Resolve a provider name to an ``AgentProvider``.
 
         Falls back to *default_agent*, then ``"claude"``.
         Raises ``SystemExit`` if the resolved name is unknown.
         """
-        resolved = name or default_agent or "claude"
-        provider = self._providers.get(resolved)
-        if provider is None:
-            valid = ", ".join(sorted(self._providers))
-            raise SystemExit(f"Unknown headless provider {resolved!r}. Valid providers: {valid}")
-        return provider
+        from terok_agent.provider.providers import get_provider
+
+        return get_provider(name, default_agent=default_agent)
 
     def get_auth_provider(self, name: str) -> AuthProvider:
         """Look up an auth provider by name.
@@ -301,7 +296,7 @@ def load_roster() -> AgentRoster:
         else:
             raw[name] = user_data
 
-    providers: dict[str, HeadlessProvider] = {}
+    providers: dict[str, AgentProvider] = {}
     auth_providers: dict[str, AuthProvider] = {}
     proxy_routes: dict[str, CredentialProxyRoute] = {}
     sidecar_specs: dict[str, SidecarSpec] = {}
@@ -316,11 +311,11 @@ def load_roster() -> AgentRoster:
         if kind != "runtime":
             all_names.append(name)
 
-        # Agent kinds (native, opencode, bridge) get a HeadlessProvider;
+        # Agent kinds (native, opencode, bridge) get a AgentProvider;
         # tools and runtime entries only contribute auth/mounts.
         if kind not in ("tool", "runtime"):
             agent_names.append(name)
-            providers[name] = _to_headless_provider(name, data)
+            providers[name] = _to_agent_provider(name, data)
 
         # Auth: explicit auth section, or auto-derived from opencode config
         auth_prov = _to_auth_provider(name, data)
@@ -477,7 +472,7 @@ def _load_user_agents() -> dict[str, dict]:
 
 def _to_opencode_config(data: dict) -> OpenCodeProviderConfig:
     """Deserialize the ``opencode:`` YAML section."""
-    from terok_agent.provider.headless import OpenCodeProviderConfig
+    from terok_agent.provider.providers import OpenCodeProviderConfig
 
     return OpenCodeProviderConfig(
         display_name=data["display_name"],
@@ -490,9 +485,9 @@ def _to_opencode_config(data: dict) -> OpenCodeProviderConfig:
     )
 
 
-def _to_headless_provider(name: str, data: dict) -> HeadlessProvider:
-    """Deserialize a full agent YAML dict into a ``HeadlessProvider``."""
-    from terok_agent.provider.headless import HeadlessProvider
+def _to_agent_provider(name: str, data: dict) -> AgentProvider:
+    """Deserialize a full agent YAML dict into an ``AgentProvider``."""
+    from terok_agent.provider.providers import AgentProvider
 
     hl = data.get("headless", {})
     aa = data.get("auto_approve", {})
@@ -503,7 +498,7 @@ def _to_headless_provider(name: str, data: dict) -> HeadlessProvider:
     oc_data = data.get("opencode")
     oc = _to_opencode_config(oc_data) if oc_data else None
 
-    return HeadlessProvider(
+    return AgentProvider(
         name=name,
         label=data.get("label", name),
         binary=data.get("binary", name),

--- a/src/terok_agent/roster/loader.py
+++ b/src/terok_agent/roster/loader.py
@@ -194,9 +194,9 @@ class AgentRoster:
         Falls back to *default_agent*, then ``"claude"``.
         Raises ``SystemExit`` if the resolved name is unknown.
         """
-        from terok_agent.provider.providers import get_provider
+        from terok_agent.provider.providers import resolve_provider
 
-        return get_provider(name, default_agent=default_agent)
+        return resolve_provider(self._providers, name, default_agent=default_agent)
 
     def get_auth_provider(self, name: str) -> AuthProvider:
         """Look up an auth provider by name.

--- a/tach.toml
+++ b/tach.toml
@@ -53,7 +53,7 @@ depends_on = [
     "terok_agent._util",
     "terok_agent.credentials.auth",
     "terok_agent.roster.config_stack",
-    "terok_agent.provider.headless",
+    "terok_agent.provider.providers",
 ]
 
 # Roster package waypoint (re-exports from loader)
@@ -70,11 +70,24 @@ depends_on = [
 path = "terok_agent.provider.config"
 depends_on = []
 
-# Headless provider registry + dispatch
+# Agent provider definitions + registry
+[[modules]]
+path = "terok_agent.provider.providers"
+depends_on = []
+
+# Shell wrapper generation
+[[modules]]
+path = "terok_agent.provider.wrappers"
+depends_on = [
+    "terok_agent.provider.providers",
+]
+
+# Headless command construction + config resolution
 [[modules]]
 path = "terok_agent.provider.headless"
 depends_on = [
     "terok_agent.provider.config",
+    "terok_agent.provider.providers",
 ]
 
 # Instruction resolution
@@ -89,7 +102,8 @@ depends_on = [
 path = "terok_agent.provider.agents"
 depends_on = [
     "terok_agent._util",
-    "terok_agent.provider.headless",
+    "terok_agent.provider.providers",
+    "terok_agent.provider.wrappers",
 ]
 
 # ── container/ — container lifecycle ────────────────────────────────
@@ -195,6 +209,7 @@ depends_on = [
     "terok_agent.provider.config",
     "terok_agent.provider.headless",
     "terok_agent.provider.instructions",
+    "terok_agent.provider.providers",
     "terok_agent.roster",
     "terok_agent.roster.config_stack",
 ]

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -20,7 +20,7 @@ from terok_agent.provider.agents import (
     parse_md_agent,
     prepare_agent_config_dir,
 )
-from terok_agent.provider.headless import WrapperConfig
+from terok_agent.provider.wrappers import WrapperConfig
 from tests.constants import (
     CONTAINER_CLAUDE_MEMORY_OVERRIDE,
     CONTAINER_CLAUDE_SESSION_PATH,

--- a/tests/unit/test_headless_providers.py
+++ b/tests/unit/test_headless_providers.py
@@ -10,14 +10,18 @@ import pytest
 from terok_agent.provider.agents import _generate_claude_wrapper
 from terok_agent.provider.config import resolve_provider_value
 from terok_agent.provider.headless import (
-    HEADLESS_PROVIDERS,
-    PROVIDER_NAMES,
     apply_provider_config,
     build_headless_command,
+)
+from terok_agent.provider.providers import (
+    AGENT_PROVIDERS,
+    PROVIDER_NAMES,
     collect_all_auto_approve_env,
+    get_provider,
+)
+from terok_agent.provider.wrappers import (
     generate_agent_wrapper,
     generate_all_wrappers,
-    get_provider,
 )
 from tests.constants import CONTAINER_TEROK_DIR
 
@@ -30,7 +34,7 @@ def _provider_wrapper(
     """Generate a wrapper for a provider under test."""
     kwargs = {"claude_wrapper_fn": _generate_claude_wrapper} if name == "claude" else {}
     return generate_agent_wrapper(
-        HEADLESS_PROVIDERS[name],
+        AGENT_PROVIDERS[name],
         has_agents=has_agents,
         **kwargs,
     )
@@ -44,22 +48,22 @@ def _all_wrappers(*, has_agents: bool = False) -> str:
     )
 
 
-class TestHeadlessProviderRegistry:
-    """Tests for the HEADLESS_PROVIDERS registry."""
+class TestAgentProviderRegistry:
+    """Tests for the AGENT_PROVIDERS registry."""
 
     def test_all_seven_providers_exist(self) -> None:
         """Registry contains exactly the seven expected providers."""
         expected = {"claude", "codex", "copilot", "vibe", "blablador", "opencode", "kisski"}
-        assert set(HEADLESS_PROVIDERS.keys()) == expected
+        assert set(AGENT_PROVIDERS.keys()) == expected
 
     def test_provider_names_tuple(self) -> None:
         """PROVIDER_NAMES is a tuple matching registry keys."""
         assert isinstance(PROVIDER_NAMES, tuple)
-        assert set(PROVIDER_NAMES) == set(HEADLESS_PROVIDERS.keys())
+        assert set(PROVIDER_NAMES) == set(AGENT_PROVIDERS.keys())
 
     def test_providers_are_frozen(self) -> None:
-        """HeadlessProvider instances are immutable."""
-        provider = HEADLESS_PROVIDERS["claude"]
+        """AgentProvider instances are immutable."""
+        provider = AGENT_PROVIDERS["claude"]
         with pytest.raises(FrozenInstanceError):
             provider.name = "changed"  # type: ignore[misc]
 
@@ -94,7 +98,7 @@ class TestBuildHeadlessCommand:
 
     def test_all_commands_start_with_init(self) -> None:
         """All provider commands start with init-ssh-and-repo.sh."""
-        for _name, p in HEADLESS_PROVIDERS.items():
+        for _name, p in AGENT_PROVIDERS.items():
             cmd = build_headless_command(p, timeout=1800)
             assert cmd.startswith("init-ssh-and-repo.sh")
 
@@ -110,13 +114,13 @@ class TestGenerateAgentWrapper:
 
     def test_claude_wrapper_requires_fn(self) -> None:
         """Claude provider without claude_wrapper_fn raises ValueError."""
-        p = HEADLESS_PROVIDERS["claude"]
+        p = AGENT_PROVIDERS["claude"]
         with pytest.raises(ValueError):
             generate_agent_wrapper(p, has_agents=False)
 
     def test_generic_wrapper_has_timeout_support(self) -> None:
         """All non-Claude wrappers support --terok-timeout."""
-        for name in HEADLESS_PROVIDERS:
+        for name in AGENT_PROVIDERS:
             if name == "claude":
                 continue
             wrapper = _provider_wrapper(name)
@@ -125,10 +129,24 @@ class TestGenerateAgentWrapper:
     def test_session_resume_uses_explicit_id(self) -> None:
         """Providers with session_file use --session/--resume with explicit ID."""
         for name in ("vibe", "opencode", "blablador", "kisski"):
-            p = HEADLESS_PROVIDERS[name]
+            p = AGENT_PROVIDERS[name]
             wrapper = _provider_wrapper(name)
             assert p.resume_flag in wrapper, f"{name} missing resume flag"
             assert f"cat {CONTAINER_TEROK_DIR}/{p.session_file}" in wrapper
+
+    def test_vibe_wrapper_has_lazy_model_sync(self) -> None:
+        """Vibe wrapper includes lazy Mistral model sync with mtime check."""
+        wrapper = _provider_wrapper("vibe")
+        assert "vibe-model-sync" in wrapper
+        assert "mmin +1440" in wrapper
+
+    def test_non_vibe_wrappers_lack_model_sync(self) -> None:
+        """Only vibe gets the model sync block."""
+        for name in AGENT_PROVIDERS:
+            if name in ("claude", "vibe"):
+                continue
+            wrapper = _provider_wrapper(name)
+            assert "vibe-model-sync" not in wrapper, f"{name} should not have model sync"
 
 
 class TestResolveProviderValue:
@@ -161,19 +179,19 @@ class TestApplyProviderConfig:
 
     def test_model_from_config(self) -> None:
         """Model value is read from config when no CLI override."""
-        p = HEADLESS_PROVIDERS["claude"]
+        p = AGENT_PROVIDERS["claude"]
         pcfg = apply_provider_config(p, {"model": "opus"})
         assert pcfg.model == "opus"
 
     def test_timeout_default(self) -> None:
         """Missing timeout defaults to 1800."""
-        p = HEADLESS_PROVIDERS["claude"]
+        p = AGENT_PROVIDERS["claude"]
         pcfg = apply_provider_config(p, {})
         assert pcfg.timeout == 1800
 
     def test_max_turns_unsupported_injects_prompt(self) -> None:
         """Provider without max_turns_flag gets prompt injection + warning."""
-        p = HEADLESS_PROVIDERS["codex"]
+        p = AGENT_PROVIDERS["codex"]
         pcfg = apply_provider_config(p, {"max_turns": 30})
         assert pcfg.max_turns is None
         assert "30 steps" in pcfg.prompt_extra
@@ -185,7 +203,7 @@ class TestGenerateAllWrappers:
     def test_all_providers_in_output(self) -> None:
         """Output contains wrapper functions for all providers."""
         wrapper = _all_wrappers()
-        for name, p in HEADLESS_PROVIDERS.items():
+        for name, p in AGENT_PROVIDERS.items():
             assert f"{p.binary}()" in wrapper, f"Missing wrapper for {name}"
 
     def test_all_wrappers_valid_bash_syntax(self) -> None:

--- a/tests/unit/test_headless_providers.py
+++ b/tests/unit/test_headless_providers.py
@@ -143,7 +143,7 @@ class TestGenerateAgentWrapper:
     def test_non_vibe_wrappers_lack_model_sync(self) -> None:
         """Only vibe gets the model sync block."""
         for name in AGENT_PROVIDERS:
-            if name in ("claude", "vibe"):
+            if name == "vibe":
                 continue
             wrapper = _provider_wrapper(name)
             assert "vibe-model-sync" not in wrapper, f"{name} should not have model sync"

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -11,15 +11,15 @@ from unittest.mock import patch
 import pytest
 
 from terok_agent.credentials.auth import AuthProvider
-from terok_agent.provider.headless import HeadlessProvider
+from terok_agent.provider.providers import AgentProvider
 from terok_agent.roster import (
     SidecarSpec,
     load_roster,
 )
 from terok_agent.roster.loader import (
     _load_bundled_agents,
+    _to_agent_provider,
     _to_auth_provider,
-    _to_headless_provider,
     _to_sidecar_spec,
 )
 
@@ -91,13 +91,13 @@ class TestLoadBundledAgents:
 
 
 class TestDeserializeProvider:
-    """Verify YAML → HeadlessProvider conversion."""
+    """Verify YAML → AgentProvider conversion."""
 
     def test_claude_full_fidelity(self) -> None:
         agents = _load_bundled_agents()
-        p = _to_headless_provider("claude", agents["claude"])
+        p = _to_agent_provider("claude", agents["claude"])
 
-        assert isinstance(p, HeadlessProvider)
+        assert isinstance(p, AgentProvider)
         assert p.name == "claude"
         assert p.label == "Claude"
         assert p.binary == "claude"
@@ -123,7 +123,7 @@ class TestDeserializeProvider:
 
     def test_codex_subcommand_and_flags(self) -> None:
         agents = _load_bundled_agents()
-        p = _to_headless_provider("codex", agents["codex"])
+        p = _to_agent_provider("codex", agents["codex"])
 
         assert p.headless_subcommand == "exec"
         assert p.prompt_flag == ""
@@ -132,7 +132,7 @@ class TestDeserializeProvider:
 
     def test_blablador_opencode_config(self) -> None:
         agents = _load_bundled_agents()
-        p = _to_headless_provider("blablador", agents["blablador"])
+        p = _to_agent_provider("blablador", agents["blablador"])
 
         assert p.opencode_config is not None
         assert p.opencode_config.display_name == "Helmholtz Blablador"
@@ -141,7 +141,7 @@ class TestDeserializeProvider:
 
     def test_vibe_session_support(self) -> None:
         agents = _load_bundled_agents()
-        p = _to_headless_provider("vibe", agents["vibe"])
+        p = _to_agent_provider("vibe", agents["vibe"])
 
         assert p.supports_session_resume is True
         assert p.resume_flag == "--resume"
@@ -151,7 +151,7 @@ class TestDeserializeProvider:
 
     def test_defaults_for_omitted_fields(self) -> None:
         """Omitted optional fields get sensible defaults."""
-        p = _to_headless_provider("minimal", {"label": "Test", "binary": "test"})
+        p = _to_agent_provider("minimal", {"label": "Test", "binary": "test"})
 
         assert p.headless_subcommand is None
         assert p.auto_approve_env == {}
@@ -310,7 +310,7 @@ class TestLoadRegistry:
 
     def test_get_provider_unknown_exits(self) -> None:
         reg = load_roster()
-        with pytest.raises(SystemExit, match="Unknown headless provider"):
+        with pytest.raises(SystemExit, match="Unknown provider"):
             reg.get_provider("nonexistent")
 
     def test_get_auth_provider_unknown_exits(self) -> None:
@@ -448,11 +448,11 @@ class TestRegistryBehavior:
     """Verify the registry produces well-formed, usable provider dataclasses."""
 
     def test_every_agent_has_valid_headless_provider(self) -> None:
-        """Each agent deserializes into a HeadlessProvider with required fields."""
+        """Each agent deserializes into a AgentProvider with required fields."""
         reg = load_roster()
         for name in reg.agent_names:
             p = reg.get_provider(name)
-            assert isinstance(p, HeadlessProvider)
+            assert isinstance(p, AgentProvider)
             assert p.name == name
             assert p.binary  # non-empty binary
             assert p.label  # non-empty label

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -26,13 +26,13 @@ class TestPackageImport:
         assert isinstance(__version__, str)
         assert len(__version__) > 0
 
-    def test_headless_providers_registry(self) -> None:
-        """HEADLESS_PROVIDERS registry contains expected agents."""
-        from terok_agent import HEADLESS_PROVIDERS
+    def test_agent_providers_registry(self) -> None:
+        """AGENT_PROVIDERS registry contains expected agents."""
+        from terok_agent import AGENT_PROVIDERS
 
-        assert len(HEADLESS_PROVIDERS) >= 7
-        assert "claude" in HEADLESS_PROVIDERS
-        assert "codex" in HEADLESS_PROVIDERS
+        assert len(AGENT_PROVIDERS) >= 7
+        assert "claude" in AGENT_PROVIDERS
+        assert "codex" in AGENT_PROVIDERS
 
     def test_auth_providers_registry(self) -> None:
         """AUTH_PROVIDERS registry contains expected providers."""


### PR DESCRIPTION
## Summary

- **Split `headless.py`** into three focused modules: `providers.py` (AgentProvider registry + lookup), `wrappers.py` (shell wrapper generation), `headless.py` (headless-only command building)
- **Rename** `HeadlessProvider` → `AgentProvider`, `HEADLESS_PROVIDERS` → `AGENT_PROVIDERS` — these describe all modes, not just headless
- **Move `vibe-model-sync`** from bashrc (ran on every login, ~500ms Python startup overhead) to the `vibe()` wrapper with a pure-bash mtime guard — sync only runs when the user invokes vibe and the cache is >24h stale

## Motivation

Two performance issues: TUI project details loading slowly, and container bash prompt taking a long time on login. The model sync move fixes the prompt delay. The split + rename is opportunistic cleanup that surfaced during investigation.

## Test plan

- [x] `make check` passes (lint, tach, tests, docstrings, reuse)
- [x] Verified generated `vibe()` wrapper includes mtime-guarded model sync
- [x] Verified non-vibe wrappers don't include model sync
- [x] bash syntax validation passes for all generated wrappers
- [ ] Manual: login to container, verify prompt appears instantly
- [ ] Manual: run `vibe` in container, verify model sync fires on stale cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal provider system architecture by separating registry management and shell wrapper generation into dedicated modules for improved code structure and maintainability.

* **Bug Fixes**
  * Removed obsolete Mistral model synchronization hook that was automatically triggered during interactive shell startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->