### PR TITLE
fix: preserve real credentials.json when expose_oauth_token is active

### DIFF
--- a/src/terok_agent/credentials/auth.py
+++ b/src/terok_agent/credentials/auth.py
@@ -118,8 +118,15 @@ def authenticate(
     *,
     mounts_dir: Path,
     image: str,
+    expose_token: bool = False,
 ) -> None:
     """Run the auth flow for *provider* against *project_id*.
+
+    Args:
+        expose_token: When True, copy the real credential files into
+            the shared mount instead of writing a phantom marker.  Used
+            by tier 3 (``expose_oauth_token``) where containers need
+            the actual token.
 
     Dispatches based on the provider's ``modes`` field:
 
@@ -152,7 +159,9 @@ def authenticate(
             store_api_key(provider, key)
             return
         # choice == "1" or anything else → OAuth
-        _run_auth_container(project_id, info, mounts_dir=mounts_dir, image=image)
+        _run_auth_container(
+            project_id, info, mounts_dir=mounts_dir, image=image, expose_token=expose_token
+        )
 
     elif info.supports_api_key:
         # API key only — fast path, no container
@@ -161,7 +170,9 @@ def authenticate(
 
     else:
         # OAuth only
-        _run_auth_container(project_id, info, mounts_dir=mounts_dir, image=image)
+        _run_auth_container(
+            project_id, info, mounts_dir=mounts_dir, image=image, expose_token=expose_token
+        )
 
 
 def store_api_key(
@@ -207,6 +218,7 @@ def _run_auth_container(
     mounts_dir: Path,
     image: str,
     credential_set: str = "default",
+    expose_token: bool = False,
 ) -> None:
     """Run an auth container, capture credentials to the DB.
 
@@ -274,6 +286,7 @@ def _run_auth_container(
             credential_set,
             mounts_base=mounts_dir,
             auth_provider=provider,
+            expose_token=expose_token,
         )
 
 
@@ -305,6 +318,8 @@ def _capture_credentials(
     credential_set: str,
     mounts_base: Path | None = None,
     auth_provider: AuthProvider | None = None,
+    *,
+    expose_token: bool = False,
 ) -> None:
     """Extract credentials from *auth_dir* and store in the credential DB.
 
@@ -357,22 +372,33 @@ def _capture_credentials(
         )
         return
 
-    # Write static .credentials.json for OAuth subscription mode detection
+    # Write .credentials.json — real token (tier 3) or phantom marker (default)
     if provider_name == "claude" and cred_data.get("type") == "oauth":
         if mounts_base is None:
             from terok_agent.paths import mounts_dir
 
             mounts_base = mounts_dir()
         try:
-            _write_claude_credentials_file(cred_data, mounts_base)
-            print("Subscription metadata written to shared Claude config mount.")
+            if expose_token:
+                _copy_real_credentials(auth_dir, mounts_base)
+                print("Real .credentials.json copied to shared Claude config mount.")
+            else:
+                _write_claude_credentials_file(cred_data, mounts_base)
+                print("Subscription metadata written to shared Claude config mount.")
         except Exception as exc:  # noqa: BLE001
             print(f"Warning: could not write .credentials.json: {exc}")
-        print(
-            "\nNote: Claude OAuth uses a shared credential for all tasks."
-            "\n      API calls are routed through the credential proxy — the real"
-            "\n      token never enters any container."
-        )
+        if expose_token:
+            print(
+                "\nNote: Claude OAuth token is EXPOSED in the shared mount."
+                "\n      Every task container can read the real token."
+                "\n      The credential proxy does NOT protect it."
+            )
+        else:
+            print(
+                "\nNote: Claude OAuth credential is shared across all task containers."
+                "\n      API calls are routed through the credential proxy — the real"
+                "\n      token stays on the host."
+            )
 
     # Apply declarative post-capture state from roster YAML
     if auth_provider and auth_provider.post_capture_state:
@@ -387,6 +413,20 @@ def _capture_credentials(
                 f"Warning: could not apply post_capture_state for {provider_name}: {exc}",
                 file=sys.stderr,
             )
+
+
+def _copy_real_credentials(auth_dir: Path, mounts_base: Path) -> None:
+    """Copy the real ``.credentials.json`` from the auth dir to the shared mount.
+
+    Used by tier 3 (``expose_oauth_token``) — the container needs the actual
+    OAuth token for direct API calls to ``api.anthropic.com``.
+    """
+    src = auth_dir / ".credentials.json"
+    if not src.is_file():
+        raise FileNotFoundError(f"No .credentials.json in {auth_dir}")
+    dest_dir = mounts_base / "_claude-config"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest_dir / ".credentials.json")
 
 
 def _write_claude_credentials_file(cred_data: dict, mounts_base: Path) -> None:

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -13,6 +13,7 @@ from terok_agent.credentials.auth import (
     PHANTOM_CREDENTIALS_MARKER,
     _apply_post_capture_state,
     _capture_credentials,
+    _copy_real_credentials,
     _write_claude_credentials_file,
     store_api_key,
 )
@@ -412,6 +413,107 @@ class TestCaptureWritesCredentialsFile:
             _capture_credentials("codex", tmp_path, "default", mounts_base=mounts)
 
         assert not (mounts / "_claude-config").exists()
+
+
+class TestCopyRealCredentials:
+    """Verify _copy_real_credentials preserves the real token file."""
+
+    def test_copies_real_file(self, tmp_path: Path) -> None:
+        """Real .credentials.json is copied verbatim to the shared mount."""
+        auth_dir = tmp_path / "auth"
+        auth_dir.mkdir()
+        real_creds = {"claudeAiOauth": {"accessToken": "real-token-abc"}}
+        (auth_dir / ".credentials.json").write_text(json.dumps(real_creds))
+
+        mounts = tmp_path / "mounts"
+        _copy_real_credentials(auth_dir, mounts)
+
+        dest = mounts / "_claude-config" / ".credentials.json"
+        assert dest.is_file()
+        assert json.loads(dest.read_text()) == real_creds
+
+    def test_raises_when_file_missing(self, tmp_path: Path) -> None:
+        """Raises FileNotFoundError when auth dir has no .credentials.json."""
+        import pytest
+
+        with pytest.raises(FileNotFoundError):
+            _copy_real_credentials(tmp_path, tmp_path / "mounts")
+
+
+class TestCaptureWithExposeToken:
+    """Verify _capture_credentials with expose_token=True copies the real file."""
+
+    def test_expose_token_copies_real_credentials(self, tmp_path: Path) -> None:
+        """expose_token=True copies the real .credentials.json instead of phantom."""
+        real_creds = {"claudeAiOauth": {"accessToken": "real-oauth-token", "scopes": "all"}}
+        (tmp_path / ".credentials.json").write_text(json.dumps(real_creds))
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        mounts = tmp_path / "mounts"
+        with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
+            mock_cfg_cls.return_value.proxy_db_path = db_path
+            _capture_credentials(
+                "claude", tmp_path, "default", mounts_base=mounts, expose_token=True
+            )
+
+        dest = mounts / "_claude-config" / ".credentials.json"
+        assert dest.is_file()
+        data = json.loads(dest.read_text())
+        # Real token, NOT the phantom marker
+        assert data["claudeAiOauth"]["accessToken"] == "real-oauth-token"
+
+    def test_expose_token_false_writes_phantom(self, tmp_path: Path) -> None:
+        """expose_token=False (default) writes the phantom marker as before."""
+        real_creds = {"claudeAiOauth": {"accessToken": "real-token", "scopes": "all"}}
+        (tmp_path / ".credentials.json").write_text(json.dumps(real_creds))
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        mounts = tmp_path / "mounts"
+        with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
+            mock_cfg_cls.return_value.proxy_db_path = db_path
+            _capture_credentials(
+                "claude", tmp_path, "default", mounts_base=mounts, expose_token=False
+            )
+
+        data = json.loads((mounts / "_claude-config" / ".credentials.json").read_text())
+        assert data["claudeAiOauth"]["accessToken"] == PHANTOM_CREDENTIALS_MARKER
+
+    def test_expose_token_prints_warning(self, tmp_path: Path, capsys) -> None:
+        """expose_token=True prints an EXPOSED warning."""
+        real_creds = {"claudeAiOauth": {"accessToken": "tok"}}
+        (tmp_path / ".credentials.json").write_text(json.dumps(real_creds))
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        mounts = tmp_path / "mounts"
+        with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
+            mock_cfg_cls.return_value.proxy_db_path = db_path
+            _capture_credentials(
+                "claude", tmp_path, "default", mounts_base=mounts, expose_token=True
+            )
+
+        out = capsys.readouterr().out
+        assert "EXPOSED" in out
+
+    def test_expose_token_still_stores_in_db(self, tmp_path: Path) -> None:
+        """expose_token=True still stores the credential in the proxy DB."""
+        real_creds = {"claudeAiOauth": {"accessToken": "real-tok"}}
+        (tmp_path / ".credentials.json").write_text(json.dumps(real_creds))
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        mounts = tmp_path / "mounts"
+        with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
+            mock_cfg_cls.return_value.proxy_db_path = db_path
+            _capture_credentials(
+                "claude", tmp_path, "default", mounts_base=mounts, expose_token=True
+            )
+
+        from terok_sandbox import CredentialDB
+
+        db = CredentialDB(db_path)
+        stored = db.load_credential("default", "claude")
+        db.close()
+        assert stored is not None
+        assert stored["access_token"] == "real-tok"
 
 
 class TestStoreApiKey:


### PR DESCRIPTION
## Summary

- Add `expose_token` parameter to `authenticate()` chain — when tier 3 (`expose_oauth_token`) is active, the real `.credentials.json` from the auth container is copied to the shared mount instead of being overwritten with a phantom marker
- Fix misleading capture message: no longer claims "token never enters any container" — tier-aware messaging instead

## Context

With `expose_oauth_token: true` (terok-ai/terok#671), the real OAuth token must be in `.credentials.json` for Claude Code to use it directly. The old capture code always replaced it with a phantom marker, breaking tier 3.

## Changes

- `authenticate()`, `_run_auth_container()`, `_capture_credentials()`: new `expose_token: bool = False` kwarg
- `_copy_real_credentials()`: copies the real `.credentials.json` from auth temp dir to shared mount
- Tier-aware messages at capture time

## Test plan

- [ ] `make check` passes
- [ ] Auth with `expose_oauth_token: false` → phantom marker written (existing behavior)
- [ ] Auth with `expose_oauth_token: true` → real `.credentials.json` preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude provider authentication now includes an optional parameter to control credential exposure: enable direct token access or maintain proxy-routed protection (default).

* **Tests**
  * Added tests covering credential behavior with and without token exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->