### PR TITLE
fix: skip proxy DB storage for tier 3 exposed Claude OAuth

### DIFF
--- a/src/terok_agent/credentials/auth.py
+++ b/src/terok_agent/credentials/auth.py
@@ -326,6 +326,10 @@ def _capture_credentials(
     Uses the per-provider extractors from :mod:`credential_extractors`.
     If extraction fails (no credential file, malformed), prints a warning
     but does not raise — the auth flow succeeded, the user can retry.
+
+    When *expose_token* is ``True`` for Claude OAuth (tier 3), the credential
+    is **not** stored in the proxy DB — Claude manages its own token lifecycle
+    directly, and proxy-side refresh would invalidate the exposed token.
     """
     from .extractors import extract_credential
 
@@ -350,30 +354,36 @@ def _capture_credentials(
                 print(f"  {f}")
         return
 
-    try:
-        from terok_sandbox import CredentialDB, SandboxConfig
+    is_claude_oauth = provider_name == "claude" and cred_data.get("type") == "oauth"
+    exposed_directly = expose_token and is_claude_oauth
 
-        cfg = SandboxConfig()
-        db = CredentialDB(cfg.proxy_db_path)
+    if exposed_directly:
+        print(f"\nCredentials for {provider_name} bypassing proxy DB (exposed directly)")
+    else:
         try:
-            db.store_credential(credential_set, provider_name, cred_data)
-            print(f"\nCredentials captured for {provider_name} (set: {credential_set})")
-        finally:
-            db.close()
-    except Exception as exc:
-        print(
-            f"\nWarning [auth]: failed to store credentials for {provider_name} "
-            f"in proxy DB: {type(exc).__name__}: {exc}",
-            file=sys.stderr,
-        )
-        print(
-            "The auth flow completed but credentials were not saved to the proxy DB.",
-            file=sys.stderr,
-        )
-        return
+            from terok_sandbox import CredentialDB, SandboxConfig
+
+            cfg = SandboxConfig()
+            db = CredentialDB(cfg.proxy_db_path)
+            try:
+                db.store_credential(credential_set, provider_name, cred_data)
+                print(f"\nCredentials captured for {provider_name} (set: {credential_set})")
+            finally:
+                db.close()
+        except Exception as exc:
+            print(
+                f"\nWarning [auth]: failed to store credentials for {provider_name} "
+                f"in proxy DB: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            print(
+                "The auth flow completed but credentials were not saved to the proxy DB.",
+                file=sys.stderr,
+            )
+            return
 
     # Write .credentials.json — real token (tier 3) or phantom marker (default)
-    if provider_name == "claude" and cred_data.get("type") == "oauth":
+    if is_claude_oauth:
         if mounts_base is None:
             from terok_agent.paths import mounts_dir
 

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -494,8 +494,8 @@ class TestCaptureWithExposeToken:
         out = capsys.readouterr().out
         assert "EXPOSED" in out
 
-    def test_expose_token_still_stores_in_db(self, tmp_path: Path) -> None:
-        """expose_token=True still stores the credential in the proxy DB."""
+    def test_expose_token_skips_proxy_db(self, tmp_path: Path) -> None:
+        """expose_token=True does NOT store in proxy DB — avoids refresh conflict."""
         real_creds = {"claudeAiOauth": {"accessToken": "real-tok"}}
         (tmp_path / ".credentials.json").write_text(json.dumps(real_creds))
 
@@ -512,8 +512,7 @@ class TestCaptureWithExposeToken:
         db = CredentialDB(db_path)
         stored = db.load_credential("default", "claude")
         db.close()
-        assert stored is not None
-        assert stored["access_token"] == "real-tok"
+        assert stored is None
 
 
 class TestStoreApiKey:


### PR DESCRIPTION
## Summary

- When `expose_oauth_token` is active (tier 3), the credential capture step now **bypasses proxy DB storage** entirely
- Previously, the real OAuth token was stored in both the proxy DB and the shared mount — the proxy's refresh loop would then invalidate the mounted token that Claude relies on
- The real `.credentials.json` is still copied to the shared mount as before; only the proxy DB write is skipped

## Test plan

- [x] `test_expose_token_skips_proxy_db` — asserts no credential in proxy DB when `expose_token=True`
- [x] `test_expose_token_copies_real_credentials` — real `.credentials.json` still written to mount
- [x] `test_expose_token_prints_warning` — EXPOSED warning still shown
- [x] `test_expose_token_false_writes_phantom` — tier 2 path unchanged (phantom marker)
- [x] Full `make check` passes (483 tests, lint, REUSE, docstrings, security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Claude OAuth credential handling updated: when token exposure is enabled, credentials are no longer stored in the proxy database to avoid unintended persistence and enhance security.

* **Tests**
  * Unit test updated to reflect new behavior: verifies that exposed Claude OAuth credentials are not stored in the proxy DB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->