### PR TITLE
fix: apply shared_config_patch on every task start

### DIFF
--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -61,6 +61,7 @@ from .credentials.auth import (
 )
 from .credentials.extractors import extract_credential
 from .credentials.proxy_commands import PROXY_COMMANDS, scan_leaked_credentials
+from .credentials.proxy_config import ConfigPatchError
 
 # -- Doctor + paths ------------------------------------------------------------
 from .doctor import agent_doctor_checks
@@ -172,6 +173,7 @@ __all__ = [
     "CommandDef",
     "mounts_dir",
     "scan_leaked_credentials",
+    "ConfigPatchError",
     # Doctor (container health checks)
     "CheckVerdict",
     "DoctorCheck",

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -210,6 +210,12 @@ def assemble_container_env(
     mounts_base = spec.envs_dir or _mounts_dir()
     volumes += _shared_config_mounts(roster, mounts_base)
 
+    # 8b. Re-apply proxy config patches (idempotent — ensures shared mount
+    #     dirs contain correct proxy URLs even after state wipe).
+    from terok_executor.credentials.proxy_config import apply_shared_config_patches
+
+    apply_shared_config_patches(roster, mounts_base)
+
     # 9. Credential proxy
     if not proxy_bypass:
         env.update(_inject_proxy_tokens(roster, spec.credential_scope, spec.task_id))

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -212,6 +212,13 @@ def assemble_container_env(
 
     # 8b. Re-apply proxy config patches (idempotent — ensures shared mount
     #     dirs contain correct proxy URLs even after state wipe).
+    #
+    #     NOT gated by proxy_bypass: that flag only skips phantom-token
+    #     injection here because the caller (terok) injects richer tokens
+    #     itself — the credential proxy is still in use and agents still
+    #     need their config files rewritten to route through it.  Providers
+    #     whose credential is exposed directly (Claude OAuth tier 3) are
+    #     safe because they have no shared_config_patch in the roster.
     from terok_executor.credentials.proxy_config import apply_shared_config_patches
 
     apply_shared_config_patches(roster, mounts_base)

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -155,7 +155,7 @@ def assemble_container_env(
     spec: ContainerEnvSpec,
     roster: AgentRoster,
     *,
-    proxy_bypass: bool = False,
+    caller_manages_proxy: bool = False,
 ) -> ContainerEnvResult:
     """Assemble container environment variables and volume mounts.
 
@@ -166,7 +166,12 @@ def assemble_container_env(
     Args:
         spec: What the caller wants — all host↔container contract fields.
         roster: Agent roster for shared mounts, proxy routes, provider identity.
-        proxy_bypass: Skip credential proxy entirely (terok's explicit opt-out).
+        caller_manages_proxy: When ``True``, skip phantom-token injection
+            here — the caller injects richer proxy tokens itself (e.g.
+            terok's per-provider OAuth tiers, socket transport, SSH agent).
+            Shared config patches (``api_base`` rewrites) still run because
+            the credential proxy **is** in use; only token injection is
+            delegated.
 
     Returns:
         Assembled env dict, volume tuple, and resolved task_dir.
@@ -213,18 +218,18 @@ def assemble_container_env(
     # 8b. Re-apply proxy config patches (idempotent — ensures shared mount
     #     dirs contain correct proxy URLs even after state wipe).
     #
-    #     NOT gated by proxy_bypass: that flag only skips phantom-token
-    #     injection here because the caller (terok) injects richer tokens
-    #     itself — the credential proxy is still in use and agents still
-    #     need their config files rewritten to route through it.  Providers
-    #     whose credential is exposed directly (Claude OAuth tier 3) are
-    #     safe because they have no shared_config_patch in the roster.
+    #     NOT gated by caller_manages_proxy: that flag only skips
+    #     phantom-token injection here because the caller (terok) injects
+    #     richer tokens itself — the credential proxy is still in use and
+    #     agents still need their config files rewritten to route through
+    #     it.  Providers whose credential is exposed directly (Claude OAuth
+    #     tier 3) are safe because they have no shared_config_patch.
     from terok_executor.credentials.proxy_config import apply_shared_config_patches
 
     apply_shared_config_patches(roster, mounts_base)
 
     # 9. Credential proxy
-    if not proxy_bypass:
+    if not caller_manages_proxy:
         env.update(_inject_proxy_tokens(roster, spec.credential_scope, spec.task_id))
 
     # 10. Agent config mount

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -43,7 +43,7 @@ class AuthProvider:
     """Human-readable display name (e.g. ``"Codex"``)."""
 
     host_dir_name: str
-    """Directory name under ``mounts_dir()`` (e.g. ``"_codex-config"``)."""
+    """Single-segment directory name under ``mounts_dir()`` (e.g. ``"_codex-config"``)."""
 
     container_mount: str
     """Mount point inside the container (e.g. ``"/home/dev/.codex"``)."""
@@ -70,6 +70,14 @@ class AuthProvider:
     mount directory.  Example: ``{".claude.json": {"hasCompletedOnboarding": true}}``
     marks Claude Code onboarding as complete so the first-run wizard is skipped.
     """
+
+    def __post_init__(self) -> None:
+        """Validate fields that become filesystem paths."""
+        p = Path(self.host_dir_name)
+        if p.is_absolute() or ".." in p.parts or len(p.parts) != 1:
+            raise ValueError(
+                f"host_dir_name must be a single directory segment, got {self.host_dir_name!r}"
+            )
 
     @property
     def supports_oauth(self) -> bool:

--- a/src/terok_executor/credentials/proxy_config.py
+++ b/src/terok_executor/credentials/proxy_config.py
@@ -65,23 +65,6 @@ def write_proxy_config(provider_name: str) -> None:
     print(f"Proxy config written to {config_path}")
 
 
-def _safe_config_path(shared_dir: Path, filename: str) -> Path:
-    """Resolve *filename* inside *shared_dir*, rejecting traversal attempts.
-
-    Raises :class:`ConfigPatchError` if the resolved path escapes the
-    intended directory (absolute paths, ``..`` components, symlinks).
-    """
-    rel = Path(filename)
-    if rel.is_absolute() or ".." in rel.parts:
-        raise ConfigPatchError(f"invalid patch file path: {filename!r}")
-
-    target = (shared_dir / rel).resolve(strict=False)
-    base = shared_dir.resolve(strict=True)
-    if base not in target.parents and target != base:
-        raise ConfigPatchError(f"patch target {target} escapes shared dir {base}")
-    return target
-
-
 def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
     """Re-apply every ``shared_config_patch`` for the whole roster.
 
@@ -106,13 +89,11 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
             continue
 
         patch = route.shared_config_patch
-        shared_dir = mounts_base / auth_info.host_dir_name
-        # Directory was already created by _shared_config_mounts(); ensure anyway.
-        shared_dir.mkdir(parents=True, exist_ok=True)
-
-        config_path = _safe_config_path(shared_dir, patch["file"])
-
         try:
+            shared_dir = mounts_base / auth_info.host_dir_name
+            shared_dir.mkdir(parents=True, exist_ok=True)
+            config_path = _safe_config_path(shared_dir, patch["file"])
+
             if "yaml_set" in patch:
                 _apply_yaml_patch(config_path, patch, proxy_url)
             elif "toml_table" in patch:
@@ -122,8 +103,28 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
             raise
         except Exception as exc:
             raise ConfigPatchError(
-                f"Failed to apply proxy config patch for {name} at {config_path}"
+                f"Failed to apply proxy config patch for {name} (file={patch.get('file')!r})"
             ) from exc
+
+
+# ── Private helpers ──────────────────────────────────────────────────────
+
+
+def _safe_config_path(shared_dir: Path, filename: str) -> Path:
+    """Resolve *filename* inside *shared_dir*, rejecting traversal attempts.
+
+    Raises :class:`ConfigPatchError` if the resolved path escapes the
+    intended directory (absolute paths, ``..`` components, symlinks).
+    """
+    rel = Path(filename)
+    if rel.is_absolute() or ".." in rel.parts:
+        raise ConfigPatchError(f"invalid patch file path: {filename!r}")
+
+    target = (shared_dir / rel).resolve(strict=False)
+    base = shared_dir.resolve(strict=True)
+    if base not in target.parents and target != base:
+        raise ConfigPatchError(f"patch target {target} escapes shared dir {base}")
+    return target
 
 
 def _apply_toml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:

--- a/src/terok_executor/credentials/proxy_config.py
+++ b/src/terok_executor/credentials/proxy_config.py
@@ -22,6 +22,10 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
+class ConfigPatchError(RuntimeError):
+    """Raised when a shared config patch fails and the task must not start."""
+
+
 def write_proxy_config(provider_name: str) -> None:
     """Apply ``shared_config_patch`` from the YAML roster after auth.
 
@@ -50,8 +54,8 @@ def write_proxy_config(provider_name: str) -> None:
 
     patch = route.shared_config_patch
     shared_dir = mounts_dir() / auth_info.host_dir_name
-    config_path = shared_dir / patch["file"]
     shared_dir.mkdir(parents=True, exist_ok=True)
+    config_path = _safe_config_path(shared_dir, patch["file"])
 
     if "yaml_set" in patch:
         _apply_yaml_patch(config_path, patch, proxy_url)
@@ -61,12 +65,32 @@ def write_proxy_config(provider_name: str) -> None:
     print(f"Proxy config written to {config_path}")
 
 
+def _safe_config_path(shared_dir: Path, filename: str) -> Path:
+    """Resolve *filename* inside *shared_dir*, rejecting traversal attempts.
+
+    Raises :class:`ConfigPatchError` if the resolved path escapes the
+    intended directory (absolute paths, ``..`` components, symlinks).
+    """
+    rel = Path(filename)
+    if rel.is_absolute() or ".." in rel.parts:
+        raise ConfigPatchError(f"invalid patch file path: {filename!r}")
+
+    target = (shared_dir / rel).resolve(strict=False)
+    base = shared_dir.resolve(strict=True)
+    if base not in target.parents and target != base:
+        raise ConfigPatchError(f"patch target {target} escapes shared dir {base}")
+    return target
+
+
 def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
     """Re-apply every ``shared_config_patch`` for the whole roster.
 
     Called during task start so that shared mount directories (which may
     have been recreated empty) always contain the correct proxy URLs.
     Idempotent: safe to call on every launch.
+
+    Raises :class:`ConfigPatchError` on failure — callers must not start
+    the container if proxy routing cannot be established.
     """
     from terok_sandbox import SandboxConfig, get_proxy_port
 
@@ -83,9 +107,10 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
 
         patch = route.shared_config_patch
         shared_dir = mounts_base / auth_info.host_dir_name
-        config_path = shared_dir / patch["file"]
         # Directory was already created by _shared_config_mounts(); ensure anyway.
         shared_dir.mkdir(parents=True, exist_ok=True)
+
+        config_path = _safe_config_path(shared_dir, patch["file"])
 
         try:
             if "yaml_set" in patch:
@@ -93,8 +118,12 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
             elif "toml_table" in patch:
                 _apply_toml_patch(config_path, patch, proxy_url)
             _logger.debug("Applied config patch for %s → %s", name, config_path)
-        except Exception:
-            _logger.warning("Failed to apply config patch for %s", name, exc_info=True)
+        except ConfigPatchError:
+            raise
+        except Exception as exc:
+            raise ConfigPatchError(
+                f"Failed to apply proxy config patch for {name} at {config_path}"
+            ) from exc
 
 
 def _apply_toml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:

--- a/src/terok_executor/credentials/proxy_config.py
+++ b/src/terok_executor/credentials/proxy_config.py
@@ -3,15 +3,23 @@
 
 """Patches provider config files to route API traffic through the credential proxy.
 
-Applies ``shared_config_patch`` from the YAML roster after authentication.
-Writes proxy URLs (not secrets) to provider config files so that agents
-route API traffic through the credential proxy.
+Applies ``shared_config_patch`` from the YAML roster after authentication
+and — crucially — on every task start.  Writes proxy URLs (not secrets) to
+provider config files so that agents route API traffic through the
+credential proxy instead of hitting upstream directly with phantom tokens.
 """
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from terok_executor.roster.loader import AgentRoster
+
+_logger = logging.getLogger(__name__)
 
 
 def write_proxy_config(provider_name: str) -> None:
@@ -51,6 +59,42 @@ def write_proxy_config(provider_name: str) -> None:
         _apply_toml_patch(config_path, patch, proxy_url)
 
     print(f"Proxy config written to {config_path}")
+
+
+def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
+    """Re-apply every ``shared_config_patch`` for the whole roster.
+
+    Called during task start so that shared mount directories (which may
+    have been recreated empty) always contain the correct proxy URLs.
+    Idempotent: safe to call on every launch.
+    """
+    from terok_sandbox import SandboxConfig, get_proxy_port
+
+    cfg = SandboxConfig()
+    port = get_proxy_port(cfg)
+    proxy_url = f"http://host.containers.internal:{port}"
+
+    for name, route in roster.proxy_routes.items():
+        if not route.shared_config_patch:
+            continue
+        auth_info = roster.auth_providers.get(name)
+        if not auth_info:
+            continue
+
+        patch = route.shared_config_patch
+        shared_dir = mounts_base / auth_info.host_dir_name
+        config_path = shared_dir / patch["file"]
+        # Directory was already created by _shared_config_mounts(); ensure anyway.
+        shared_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            if "yaml_set" in patch:
+                _apply_yaml_patch(config_path, patch, proxy_url)
+            elif "toml_table" in patch:
+                _apply_toml_patch(config_path, patch, proxy_url)
+            _logger.debug("Applied config patch for %s → %s", name, config_path)
+        except Exception:
+            _logger.warning("Failed to apply config patch for %s", name, exc_info=True)
 
 
 def _apply_toml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:

--- a/tach.toml
+++ b/tach.toml
@@ -203,6 +203,7 @@ depends_on = [
     "terok_executor.credentials.auth",
     "terok_executor.credentials.extractors",
     "terok_executor.credentials.proxy_commands",
+    "terok_executor.credentials.proxy_config",
     "terok_executor.doctor",
     "terok_executor.paths",
     "terok_executor.provider.agents",

--- a/tach.toml
+++ b/tach.toml
@@ -114,6 +114,7 @@ depends_on = []
 [[modules]]
 path = "terok_executor.container.env"
 depends_on = [
+    "terok_executor.credentials.proxy_config",
     "terok_executor.paths",
 ]
 

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -328,11 +328,12 @@ class TestCaptureAppliesPostCaptureState:
         provider = AuthProvider(
             name="claude",
             label="Claude",
-            host_dir_name="../../escape",  # will trigger path traversal guard
+            host_dir_name="_claude-config",
             container_mount="/home/dev/.claude",
             command=["claude"],
             banner_hint="",
             modes=("api_key",),
+            # Target file is a directory — write will fail
             post_capture_state={".claude.json": {"hasCompletedOnboarding": True}},
         )
 
@@ -340,6 +341,10 @@ class TestCaptureAppliesPostCaptureState:
         (tmp_path / ".credentials.json").write_text(json.dumps(cred))
 
         mounts = tmp_path / "mounts"
+        # Pre-create the target as a directory so the JSON write fails
+        blocker = mounts / "_claude-config" / ".claude.json"
+        blocker.mkdir(parents=True)
+
         db_path = tmp_path / "proxy" / "credentials.db"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.proxy_db_path = db_path

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -79,23 +79,23 @@ class TestBaseEnv:
     """Verify base environment variables are always set."""
 
     def test_task_id(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert result.env["TASK_ID"] == "test-123"
 
     def test_repo_root(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert result.env["REPO_ROOT"] == "/workspace"
 
     def test_git_reset_mode(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert result.env["GIT_RESET_MODE"] == "none"
 
     def test_claude_config_dir(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert result.env["CLAUDE_CONFIG_DIR"] == "/home/dev/.claude"
 
     def test_returns_frozen_result(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert isinstance(result, ContainerEnvResult)
 
 
@@ -109,7 +109,7 @@ class TestGitIdentity:
 
     def test_identity_from_roster_provider(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir)
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.env["GIT_AUTHOR_NAME"] == "Claude"
         assert result.env["GIT_AUTHOR_EMAIL"] == "noreply@anthropic.com"
         assert result.env["GIT_COMMITTER_NAME"] == "Claude"
@@ -123,7 +123,7 @@ class TestGitIdentity:
             git_committer_name="AI Committer",
             git_committer_email="ai@example.com",
         )
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.env["GIT_AUTHOR_NAME"] == "Human Author"
         assert result.env["GIT_AUTHOR_EMAIL"] == "human@example.com"
         assert result.env["GIT_COMMITTER_NAME"] == "AI Committer"
@@ -131,13 +131,13 @@ class TestGitIdentity:
 
     def test_committer_defaults_to_author(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir, git_author_name="Custom", git_author_email="custom@t.com")
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.env["GIT_COMMITTER_NAME"] == "Custom"
         assert result.env["GIT_COMMITTER_EMAIL"] == "custom@t.com"
 
     def test_unknown_provider_uses_fallback(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir, provider_name="nonexistent")
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.env["GIT_AUTHOR_NAME"] == "AI Agent"
 
 
@@ -150,7 +150,7 @@ class TestAuthorship:
     """Verify authorship mode and human identity env vars."""
 
     def test_defaults(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert result.env["TEROK_GIT_AUTHORSHIP"] == "agent"
         assert result.env["HUMAN_GIT_NAME"] == "Nobody"
         assert result.env["HUMAN_GIT_EMAIL"] == "nobody@localhost"
@@ -163,7 +163,7 @@ class TestAuthorship:
             human_name="Jane Doe",
             human_email="jane@example.com",
         )
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.env["TEROK_GIT_AUTHORSHIP"] == "agent-human"
         assert result.env["HUMAN_GIT_NAME"] == "Jane Doe"
         assert result.env["HUMAN_GIT_EMAIL"] == "jane@example.com"
@@ -179,7 +179,7 @@ class TestRepoSetup:
 
     def test_code_repo(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir, code_repo="http://gate@host:9418/repo")
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.env["CODE_REPO"] == "http://gate@host:9418/repo"
 
     def test_clone_from(self, workspace, envs_dir, roster):
@@ -189,21 +189,21 @@ class TestRepoSetup:
             clone_from="http://gate@host:9418/mirror",
             code_repo="https://github.com/user/repo",
         )
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.env["CLONE_FROM"] == "http://gate@host:9418/mirror"
         assert result.env["CODE_REPO"] == "https://github.com/user/repo"
 
     def test_branch(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir, branch="feat/my-branch")
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.env["GIT_BRANCH"] == "feat/my-branch"
 
     def test_no_branch_omits_key(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert "GIT_BRANCH" not in result.env
 
     def test_no_code_repo_omits_key(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert "CODE_REPO" not in result.env
 
 
@@ -216,7 +216,7 @@ class TestWorkspaceVolume:
     """Verify workspace volume mount."""
 
     def test_workspace_mounted_with_exclusive_label(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         ws = _find_vol(result.volumes, "/workspace")
         assert ws is not None
         assert ws.host_path == base_spec.workspace_host_path
@@ -233,7 +233,7 @@ class TestSharedConfigMounts:
 
     def test_claude_config_mounted(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir)
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         claude = _find_vol(result.volumes, "/home/dev/.claude")
         assert claude is not None
         assert "_claude-config" in str(claude.host_path)
@@ -241,13 +241,13 @@ class TestSharedConfigMounts:
 
     def test_shared_mounts_use_lowercase_z(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir)
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         shared = [v for v in result.volumes if v.sharing == "shared"]
         assert len(shared) > 0
 
     def test_host_dirs_created(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir)
-        assemble_container_env(spec, roster, proxy_bypass=True)
+        assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert (envs_dir / "_claude-config").is_dir()
 
 
@@ -263,14 +263,14 @@ class TestAgentConfigMount:
         cfg_dir = tmp_path / "agent-config"
         cfg_dir.mkdir()
         spec = _spec(workspace, envs_dir, agent_config_dir=cfg_dir)
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         vol = _find_vol(result.volumes, "/home/dev/.terok")
         assert vol is not None
         assert vol.host_path == cfg_dir
         assert vol.sharing == "private"
 
     def test_no_agent_config_when_none(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert _find_vol(result.volumes, "/home/dev/.terok") is None
 
 
@@ -284,12 +284,12 @@ class TestUnrestrictedMode:
 
     def test_unrestricted_sets_env(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir, unrestricted=True)
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.env["TEROK_UNRESTRICTED"] == "1"
 
     def test_restricted_omits_env(self, workspace, envs_dir, roster):
         spec = _spec(workspace, envs_dir, unrestricted=False)
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert "TEROK_UNRESTRICTED" not in result.env
 
 
@@ -304,7 +304,7 @@ class TestSharedTaskDir:
     def test_shared_dir_mounted_when_set(self, workspace, envs_dir, roster, tmp_path):
         shared = tmp_path / "shared"
         spec = _spec(workspace, envs_dir, shared_dir=shared)
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         vol = _find_vol(result.volumes, "/shared")
         assert vol is not None and vol.host_path == shared and vol.sharing == "shared"
         assert result.env["TEROK_SHARED_DIR"] == "/shared"
@@ -312,7 +312,7 @@ class TestSharedTaskDir:
     def test_shared_dir_custom_mount(self, workspace, envs_dir, roster, tmp_path):
         shared = tmp_path / "data"
         spec = _spec(workspace, envs_dir, shared_dir=shared, shared_mount="/data/ipc")
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         vol = _find_vol(result.volumes, "/data/ipc")
         assert vol is not None and vol.host_path == shared
         assert result.env["TEROK_SHARED_DIR"] == "/data/ipc"
@@ -320,11 +320,11 @@ class TestSharedTaskDir:
     def test_shared_dir_created(self, workspace, envs_dir, roster, tmp_path):
         shared = tmp_path / "new-shared"
         spec = _spec(workspace, envs_dir, shared_dir=shared)
-        assemble_container_env(spec, roster, proxy_bypass=True)
+        assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert shared.is_dir()
 
     def test_no_shared_dir_by_default(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert "TEROK_SHARED_DIR" not in result.env
         assert _find_vol(result.volumes, "/shared") is None
 
@@ -340,7 +340,7 @@ class TestExtraVolumes:
     def test_extra_volumes_appended(self, workspace, envs_dir, roster):
         extra = VolumeSpec(Path("/host/ssh"), "/home/dev/.ssh")
         spec = _spec(workspace, envs_dir, extra_volumes=(extra,))
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         vol = _find_vol(result.volumes, "/home/dev/.ssh")
         assert vol is not None and vol.host_path == Path("/host/ssh")
 
@@ -353,8 +353,8 @@ class TestExtraVolumes:
 class TestCredentialProxy:
     """Verify credential proxy token injection."""
 
-    def test_proxy_bypass_skips_injection(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+    def test_caller_manages_proxy_skips_injection(self, base_spec, roster):
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert "TEROK_PROXY_PORT" not in result.env
 
     def test_proxy_not_running_returns_no_tokens(self, base_spec, roster):
@@ -362,7 +362,7 @@ class TestCredentialProxy:
             patch("terok_sandbox.is_proxy_socket_active", return_value=False),
             patch("terok_sandbox.is_proxy_running", return_value=False),
         ):
-            result = assemble_container_env(base_spec, roster, proxy_bypass=False)
+            result = assemble_container_env(base_spec, roster, caller_manages_proxy=False)
         assert "TEROK_PROXY_PORT" not in result.env
 
     def test_proxy_running_injects_tokens(self, workspace, envs_dir, roster, tmp_path):
@@ -381,7 +381,7 @@ class TestCredentialProxy:
             patch("terok_sandbox.is_proxy_running", return_value=True),
             patch("terok_sandbox.SandboxConfig", return_value=cfg),
         ):
-            result = assemble_container_env(spec, roster, proxy_bypass=False)
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
 
         assert "ANTHROPIC_API_KEY" in result.env
         assert result.env["ANTHROPIC_API_KEY"].startswith("terok-p-")
@@ -401,7 +401,7 @@ class TestCredentialProxy:
             patch("terok_sandbox.is_proxy_socket_active", return_value=True),
             patch("terok_sandbox.SandboxConfig", return_value=cfg),
         ):
-            result = assemble_container_env(spec, roster, proxy_bypass=False)
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
         assert "TEROK_PROXY_PORT" not in result.env
         assert "ANTHROPIC_API_KEY" not in result.env
 
@@ -411,7 +411,7 @@ class TestCredentialProxy:
             patch("terok_sandbox.is_proxy_socket_active", return_value=True),
             patch("terok_sandbox.CredentialDB", side_effect=OSError("corrupt")),
         ):
-            result = assemble_container_env(base_spec, roster, proxy_bypass=False)
+            result = assemble_container_env(base_spec, roster, caller_manages_proxy=False)
         assert "TEROK_PROXY_PORT" not in result.env
 
     def test_proxy_token_creation_error_returns_empty(self, workspace, envs_dir, roster, tmp_path):
@@ -433,7 +433,7 @@ class TestCredentialProxy:
                 "terok_sandbox.CredentialDB.create_proxy_token", side_effect=RuntimeError("boom")
             ),
         ):
-            result = assemble_container_env(spec, roster, proxy_bypass=False)
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
         assert "TEROK_PROXY_PORT" not in result.env
 
 
@@ -449,11 +449,11 @@ class TestTaskDir:
         td = tmp_path / "my-task"
         td.mkdir()
         spec = _spec(workspace, envs_dir, task_dir=td)
-        result = assemble_container_env(spec, roster, proxy_bypass=True)
+        result = assemble_container_env(spec, roster, caller_manages_proxy=True)
         assert result.task_dir == td
 
     def test_auto_creates_temp_dir(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         assert result.task_dir.exists()
         assert "terok-executor-test-123" in str(result.task_dir)
 
@@ -467,7 +467,7 @@ class TestOpenCodeEnv:
     """Verify OpenCode provider env vars from roster."""
 
     def test_opencode_vars_present(self, base_spec, roster):
-        result = assemble_container_env(base_spec, roster, proxy_bypass=True)
+        result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
         oc_vars = [k for k in result.env if k.startswith("TEROK_OC_")]
         assert len(oc_vars) > 0
 
@@ -526,13 +526,13 @@ class TestSharedConfigPatches:
         assert "host.containers.internal:18731" in mistral["api_base"]
 
     def test_assemble_env_calls_patches_with_and_without_bypass(self, workspace, envs_dir, roster):
-        """assemble_container_env must invoke patches regardless of proxy_bypass."""
+        """assemble_container_env must invoke patches regardless of caller_manages_proxy."""
         for bypass in (True, False):
             with patch(
                 "terok_executor.credentials.proxy_config.apply_shared_config_patches"
             ) as m_patches:
                 assemble_container_env(
-                    spec=_spec(workspace, envs_dir), roster=roster, proxy_bypass=bypass
+                    spec=_spec(workspace, envs_dir), roster=roster, caller_manages_proxy=bypass
                 )
 
             m_patches.assert_called_once_with(roster, envs_dir)
@@ -560,6 +560,56 @@ class TestSharedConfigPatches:
         providers = data.get("providers", [])
         mistral_entries = [p for p in providers if p.get("name") == "mistral"]
         assert len(mistral_entries) == 1, "idempotent: must have exactly one mistral entry"
+
+
+class TestConfigPatchSecurity:
+    """Security constraints on proxy config patching."""
+
+    def test_path_traversal_rejected(self, tmp_path):
+        """Patch file paths with '..' must be rejected."""
+        from terok_executor.credentials.proxy_config import ConfigPatchError, _safe_config_path
+
+        shared = tmp_path / "mount"
+        shared.mkdir()
+        with pytest.raises(ConfigPatchError, match="invalid patch file path"):
+            _safe_config_path(shared, "../../../etc/passwd")
+
+    def test_absolute_path_rejected(self, tmp_path):
+        """Absolute patch file paths must be rejected."""
+        from terok_executor.credentials.proxy_config import ConfigPatchError, _safe_config_path
+
+        shared = tmp_path / "mount"
+        shared.mkdir()
+        with pytest.raises(ConfigPatchError, match="invalid patch file path"):
+            _safe_config_path(shared, "/etc/passwd")
+
+    def test_safe_relative_path_accepted(self, tmp_path):
+        """A plain filename stays within the shared dir."""
+        from terok_executor.credentials.proxy_config import _safe_config_path
+
+        shared = tmp_path / "mount"
+        shared.mkdir()
+        result = _safe_config_path(shared, "config.toml")
+        assert result == (shared / "config.toml").resolve()
+
+    def test_patch_failure_raises_not_swallows(self, roster, tmp_path):
+        """Patch errors must propagate as ConfigPatchError, not be silently logged."""
+        from terok_executor.credentials.proxy_config import (
+            ConfigPatchError,
+            apply_shared_config_patches,
+        )
+
+        vibe_dir = tmp_path / "_vibe-config"
+        vibe_dir.mkdir()
+        # Make the config path a directory so write_bytes fails
+        (vibe_dir / "config.toml").mkdir()
+
+        with (
+            patch("terok_sandbox.SandboxConfig"),
+            patch("terok_sandbox.get_proxy_port", return_value=18731),
+            pytest.raises(ConfigPatchError, match="Failed to apply"),
+        ):
+            apply_shared_config_patches(roster, tmp_path)
 
 
 class TestSharedConfigMountsUnit:

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -501,7 +501,7 @@ class TestSharedConfigPatches:
     """Verify proxy config patches are applied during env assembly."""
 
     def test_apply_patches_writes_toml(self, roster, tmp_path):
-        """Config patches in the roster should produce patched TOML files."""
+        """Config patches in the roster must produce patched TOML files."""
         from terok_executor.credentials.proxy_config import apply_shared_config_patches
 
         # Create the host mount dir that _shared_config_mounts would create.
@@ -515,27 +515,30 @@ class TestSharedConfigPatches:
             apply_shared_config_patches(roster, tmp_path)
 
         config_path = vibe_dir / "config.toml"
-        if config_path.exists():
-            import tomllib
+        assert config_path.exists(), "apply_shared_config_patches must create config.toml"
 
-            data = tomllib.loads(config_path.read_text())
-            providers = data.get("providers", [])
-            mistral = next((p for p in providers if p.get("name") == "mistral"), None)
-            assert mistral is not None
-            assert "host.containers.internal:18731" in mistral["api_base"]
+        import tomllib
 
-    def test_assemble_env_calls_patches(self, workspace, envs_dir, roster):
-        """assemble_container_env must invoke apply_shared_config_patches."""
-        spec = _spec(workspace, envs_dir)
-        with patch(
-            "terok_executor.credentials.proxy_config.apply_shared_config_patches"
-        ) as m_patches:
-            assemble_container_env(spec, roster, proxy_bypass=True)
+        data = tomllib.loads(config_path.read_text())
+        providers = data.get("providers", [])
+        mistral = next((p for p in providers if p.get("name") == "mistral"), None)
+        assert mistral is not None, "config.toml must contain a mistral provider entry"
+        assert "host.containers.internal:18731" in mistral["api_base"]
 
-        m_patches.assert_called_once_with(roster, envs_dir)
+    def test_assemble_env_calls_patches_with_and_without_bypass(self, workspace, envs_dir, roster):
+        """assemble_container_env must invoke patches regardless of proxy_bypass."""
+        for bypass in (True, False):
+            with patch(
+                "terok_executor.credentials.proxy_config.apply_shared_config_patches"
+            ) as m_patches:
+                assemble_container_env(
+                    spec=_spec(workspace, envs_dir), roster=roster, proxy_bypass=bypass
+                )
+
+            m_patches.assert_called_once_with(roster, envs_dir)
 
     def test_patches_idempotent(self, roster, tmp_path):
-        """Calling apply_shared_config_patches twice doesn't corrupt the file."""
+        """Calling apply_shared_config_patches twice must not duplicate entries."""
         from terok_executor.credentials.proxy_config import apply_shared_config_patches
 
         vibe_dir = tmp_path / "_vibe-config"
@@ -549,14 +552,14 @@ class TestSharedConfigPatches:
             apply_shared_config_patches(roster, tmp_path)
 
         config_path = vibe_dir / "config.toml"
-        if config_path.exists():
-            import tomllib
+        assert config_path.exists(), "config.toml must exist after double apply"
 
-            data = tomllib.loads(config_path.read_text())
-            providers = data.get("providers", [])
-            # Should have exactly one mistral entry, not duplicated.
-            mistral_entries = [p for p in providers if p.get("name") == "mistral"]
-            assert len(mistral_entries) == 1
+        import tomllib
+
+        data = tomllib.loads(config_path.read_text())
+        providers = data.get("providers", [])
+        mistral_entries = [p for p in providers if p.get("name") == "mistral"]
+        assert len(mistral_entries) == 1, "idempotent: must have exactly one mistral entry"
 
 
 class TestSharedConfigMountsUnit:

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -497,6 +497,68 @@ class TestResolveGitIdentityUnit:
 # ---------------------------------------------------------------------------
 
 
+class TestSharedConfigPatches:
+    """Verify proxy config patches are applied during env assembly."""
+
+    def test_apply_patches_writes_toml(self, roster, tmp_path):
+        """Config patches in the roster should produce patched TOML files."""
+        from terok_executor.credentials.proxy_config import apply_shared_config_patches
+
+        # Create the host mount dir that _shared_config_mounts would create.
+        vibe_dir = tmp_path / "_vibe-config"
+        vibe_dir.mkdir()
+
+        with (
+            patch("terok_sandbox.SandboxConfig"),
+            patch("terok_sandbox.get_proxy_port", return_value=18731),
+        ):
+            apply_shared_config_patches(roster, tmp_path)
+
+        config_path = vibe_dir / "config.toml"
+        if config_path.exists():
+            import tomllib
+
+            data = tomllib.loads(config_path.read_text())
+            providers = data.get("providers", [])
+            mistral = next((p for p in providers if p.get("name") == "mistral"), None)
+            assert mistral is not None
+            assert "host.containers.internal:18731" in mistral["api_base"]
+
+    def test_assemble_env_calls_patches(self, workspace, envs_dir, roster):
+        """assemble_container_env must invoke apply_shared_config_patches."""
+        spec = _spec(workspace, envs_dir)
+        with patch(
+            "terok_executor.credentials.proxy_config.apply_shared_config_patches"
+        ) as m_patches:
+            assemble_container_env(spec, roster, proxy_bypass=True)
+
+        m_patches.assert_called_once_with(roster, envs_dir)
+
+    def test_patches_idempotent(self, roster, tmp_path):
+        """Calling apply_shared_config_patches twice doesn't corrupt the file."""
+        from terok_executor.credentials.proxy_config import apply_shared_config_patches
+
+        vibe_dir = tmp_path / "_vibe-config"
+        vibe_dir.mkdir()
+
+        with (
+            patch("terok_sandbox.SandboxConfig"),
+            patch("terok_sandbox.get_proxy_port", return_value=18731),
+        ):
+            apply_shared_config_patches(roster, tmp_path)
+            apply_shared_config_patches(roster, tmp_path)
+
+        config_path = vibe_dir / "config.toml"
+        if config_path.exists():
+            import tomllib
+
+            data = tomllib.loads(config_path.read_text())
+            providers = data.get("providers", [])
+            # Should have exactly one mistral entry, not duplicated.
+            mistral_entries = [p for p in providers if p.get("name") == "mistral"]
+            assert len(mistral_entries) == 1
+
+
 class TestSharedConfigMountsUnit:
     """Unit tests for the internal shared mount builder."""
 


### PR DESCRIPTION
## Summary

- `write_proxy_config()` was only called during `terok auth`, not during task start
- After deleting state or on a fresh machine, shared mount dirs were recreated empty — provider config patches (e.g. Vibe's `api_base` → proxy URL) were never re-applied
- The agent sent phantom tokens directly to upstream APIs (Mistral), which rejected them as invalid
- Add `apply_shared_config_patches(roster, mounts_base)` that idempotently iterates all roster routes and re-applies patches
- Call it from `assemble_container_env()` right after creating shared mount directories

## Test plan

- [x] `test_apply_patches_writes_toml` — verifies TOML patch creates correct proxy URL
- [x] `test_assemble_env_calls_patches` — verifies env assembly invokes the patch function
- [x] `test_patches_idempotent` — verifies double application doesn't duplicate entries
- [x] Full suite passes (486 tests)
- [x] `make check` passes (lint + test + tach + docstrings + security + reuse)
- [ ] Manual: after `terok auth vibe proj` + state wipe + `terok task start`, verify `~/.vibe/config.toml` has proxy URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared proxy configuration patches are now applied on every task start.
  * Env assembly gains a new caller_manages_proxy option controlling proxy token injection.
  * Configuration patch error type is publicly exposed.

* **Bug Fixes / Security**
  * Safer config-path handling to block absolute paths and path traversal.
  * Failures during patching now surface as explicit errors.
  * Auth provider host-dir validation tightened to reject unsafe names.

* **Tests**
  * Added tests for patching behavior, idempotency, path-safety, and error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->