### PR TITLE
feat: push proxy wiring into executor

### DIFF
--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -26,11 +26,13 @@ import logging
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from terok_sandbox import Sharing, VolumeSpec
 
 if TYPE_CHECKING:
+    from terok_sandbox import CredentialDB, SandboxConfig
+
     from terok_executor.roster.loader import AgentRoster
 
 _logger = logging.getLogger(__name__)
@@ -96,7 +98,7 @@ class ContainerEnvSpec:
     credential_scope: str = "standalone"
     """Scope for proxy token creation.  terok passes ``project.id``."""
 
-    proxy_transport: str = "direct"
+    proxy_transport: Literal["direct", "socket"] = "direct"
     """Proxy transport mode: ``"direct"`` (HTTP base URL) or ``"socket"``
     (Unix socket path via :attr:`~CredentialProxyRoute.socket_env`)."""
 
@@ -258,16 +260,8 @@ def assemble_container_env(
         from terok_executor.credentials.proxy_commands import scan_leaked_credentials
 
         leaked = scan_leaked_credentials(mounts_base)
-        if leaked:
-            import sys
-
-            print("WARNING: Real credentials in shared mounts:", file=sys.stderr)
-            for provider, path in leaked:
-                print(f"  {provider}: {path}", file=sys.stderr)
-            print(
-                "Remove these files — containers should only see proxy tokens.",
-                file=sys.stderr,
-            )
+        for provider, path in leaked:
+            _logger.warning("Real credential in shared mount: %s: %s", provider, path)
 
     # 10. Agent config mount
     if spec.agent_config_dir:
@@ -342,7 +336,7 @@ def _inject_proxy_tokens(
     scope: str,
     task_id: str,
     *,
-    proxy_transport: str = "direct",
+    proxy_transport: Literal["direct", "socket"] = "direct",
     proxy_required: bool = False,
 ) -> dict[str, str]:
     """Inject credential proxy phantom tokens if the proxy is running.
@@ -394,9 +388,6 @@ def _inject_proxy_tokens(
         if not routed:
             return {}
 
-        # Load credential types so we can select the right phantom env vars.
-        # OAuth credentials get oauth_phantom_env (e.g. CLAUDE_CODE_OAUTH_TOKEN),
-        # while API keys get phantom_env (e.g. ANTHROPIC_API_KEY).
         credential_types: dict[str, str] = {}
         for name in routed:
             cred = db.load_credential(credential_set, name)
@@ -406,7 +397,6 @@ def _inject_proxy_tokens(
             name: db.create_proxy_token(scope, task_id, credential_set, name) for name in routed
         }
 
-        # SSH agent: create phantom token if scope has valid keys registered
         ssh_token = _load_ssh_agent_token(db, cfg, scope, task_id)
 
         port = get_proxy_port(cfg)
@@ -424,7 +414,6 @@ def _inject_proxy_tokens(
         if name not in routed:
             continue
 
-        # Auth dimension: select phantom env vars by credential type
         is_oauth = credential_types.get(name) == "oauth"
         token_vars = (
             route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
@@ -432,7 +421,6 @@ def _inject_proxy_tokens(
         for env_var in token_vars:
             env[env_var] = tokens[name]
 
-        # Transport dimension: socket path + HTTP base URL
         if use_socket and route.socket_path and route.socket_env:
             env[route.socket_env] = route.socket_path
         if route.base_url_env:
@@ -450,7 +438,6 @@ def _inject_proxy_tokens(
     if routed:
         env["TEROK_PROXY_PORT"] = str(port)
 
-    # SSH agent token (scope-scoped, separate from per-provider tokens)
     if ssh_token:
         env["TEROK_SSH_AGENT_TOKEN"] = ssh_token
         env["TEROK_SSH_AGENT_PORT"] = str(get_ssh_agent_port(cfg))
@@ -473,7 +460,9 @@ def _load_ssh_keys_json(path: Path) -> dict:
         return {}
 
 
-def _load_ssh_agent_token(db, cfg, scope: str, task_id: str) -> str | None:
+def _load_ssh_agent_token(
+    db: CredentialDB, cfg: SandboxConfig, scope: str, task_id: str
+) -> str | None:
     """Create an SSH agent phantom token if *scope* has valid keys registered."""
     ssh_keys = _load_ssh_keys_json(cfg.ssh_keys_json_path)
     ssh_entry = ssh_keys.get(scope)

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -379,29 +379,44 @@ def _inject_proxy_tokens(
         db = CredentialDB(cfg.proxy_db_path)
     except Exception as exc:
         _logger.warning("Credential proxy DB unavailable: %s: %s", type(exc).__name__, exc)
+        if proxy_required:
+            raise SystemExit(
+                f"Credential proxy DB unavailable: {type(exc).__name__}: {exc}\n\n"
+                "Start it with:\n"
+                "  terok credential-proxy install   (systemd socket activation)\n"
+                "  terok credential-proxy start     (manual daemon)"
+            ) from exc
         return {}
 
     try:
         credential_set = "default"
         stored = set(db.list_credentials(credential_set))
         routed = stored & proxy_routes.keys()
-        if not routed:
+
+        # SSH agent token is independent of provider credentials — a project
+        # with SSH keys but no API creds should still get TEROK_SSH_AGENT_*.
+        ssh_token = _load_ssh_agent_token(db, cfg, scope, task_id)
+
+        if not routed and not ssh_token:
             return {}
 
         credential_types: dict[str, str] = {}
+        tokens: dict[str, str] = {}
         for name in routed:
             cred = db.load_credential(credential_set, name)
             credential_types[name] = (cred.get("type") if cred else None) or "api_key"
-
-        tokens = {
-            name: db.create_proxy_token(scope, task_id, credential_set, name) for name in routed
-        }
-
-        ssh_token = _load_ssh_agent_token(db, cfg, scope, task_id)
+            tokens[name] = db.create_proxy_token(scope, task_id, credential_set, name)
 
         port = get_proxy_port(cfg)
     except Exception as exc:
         _logger.warning("Credential proxy token injection failed: %s: %s", type(exc).__name__, exc)
+        if proxy_required:
+            raise SystemExit(
+                f"Credential proxy token injection failed: {type(exc).__name__}: {exc}\n\n"
+                "Start it with:\n"
+                "  terok credential-proxy install   (systemd socket activation)\n"
+                "  terok credential-proxy start     (manual daemon)"
+            ) from exc
         return {}
     finally:
         db.close()
@@ -466,8 +481,16 @@ def _load_ssh_agent_token(
     """Create an SSH agent phantom token if *scope* has valid keys registered."""
     ssh_keys = _load_ssh_keys_json(cfg.ssh_keys_json_path)
     ssh_entry = ssh_keys.get(scope)
-    if isinstance(ssh_entry, list) and any(
-        e.get("private_key") and e.get("public_key") for e in ssh_entry
-    ):
+    if not isinstance(ssh_entry, list):
+        return None
+    for entry in ssh_entry:
+        if not isinstance(entry, dict):
+            _logger.warning(
+                "Malformed entry in ssh-keys.json for scope %r: expected dict, got %s",
+                scope,
+                type(entry).__name__,
+            )
+            return None
+    if any(e.get("private_key") and e.get("public_key") for e in ssh_entry):
         return db.create_proxy_token(scope, task_id, scope, "ssh")
     return None

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -96,6 +96,18 @@ class ContainerEnvSpec:
     credential_scope: str = "standalone"
     """Scope for proxy token creation.  terok passes ``project.id``."""
 
+    proxy_transport: str = "direct"
+    """Proxy transport mode: ``"direct"`` (HTTP base URL) or ``"socket"``
+    (Unix socket path via :attr:`~CredentialProxyRoute.socket_env`)."""
+
+    proxy_required: bool = False
+    """When ``True``, raise ``SystemExit`` if the credential proxy is
+    unreachable.  When ``False`` (default), soft-fail to empty env."""
+
+    scan_leaked_creds: bool = False
+    """When ``True``, scan shared mounts for real credential files and emit
+    warnings.  Standalone mode defaults to off; terok enables this."""
+
     # -- Permissions -------------------------------------------------------
 
     unrestricted: bool = True
@@ -230,7 +242,32 @@ def assemble_container_env(
 
     # 9. Credential proxy
     if not caller_manages_proxy:
-        env.update(_inject_proxy_tokens(roster, spec.credential_scope, spec.task_id))
+        env.update(
+            _inject_proxy_tokens(
+                roster,
+                spec.credential_scope,
+                spec.task_id,
+                proxy_transport=spec.proxy_transport,
+                proxy_required=spec.proxy_required,
+            )
+        )
+
+    # 9b. Leaked credential scan (runs regardless of caller_manages_proxy —
+    #     the shared mounts exist either way)
+    if spec.scan_leaked_creds:
+        from terok_executor.credentials.proxy_commands import scan_leaked_credentials
+
+        leaked = scan_leaked_credentials(mounts_base)
+        if leaked:
+            import sys
+
+            print("WARNING: Real credentials in shared mounts:", file=sys.stderr)
+            for provider, path in leaked:
+                print(f"  {provider}: {path}", file=sys.stderr)
+            print(
+                "Remove these files — containers should only see proxy tokens.",
+                file=sys.stderr,
+            )
 
     # 10. Agent config mount
     if spec.agent_config_dir:
@@ -300,23 +337,47 @@ def _shared_config_mounts(roster: AgentRoster, mounts_base: Path) -> list[Volume
     return specs
 
 
-def _inject_proxy_tokens(roster: AgentRoster, scope: str, task_id: str) -> dict[str, str]:
+def _inject_proxy_tokens(
+    roster: AgentRoster,
+    scope: str,
+    task_id: str,
+    *,
+    proxy_transport: str = "direct",
+    proxy_required: bool = False,
+) -> dict[str, str]:
     """Inject credential proxy phantom tokens if the proxy is running.
 
-    Always soft-fails: returns an empty dict when the proxy is not available.
-    Callers that require the proxy (e.g. terok project mode) should call
-    ``ensure_proxy_reachable()`` **before** invoking the assembly function.
+    Handles three orthogonal concerns:
+
+    - **Auth**: selects ``phantom_env`` vs ``oauth_phantom_env`` based on the
+      stored credential type (Phase 1).
+    - **Transport**: injects ``socket_env``/``socket_path`` when
+      *proxy_transport* is ``"socket"`` (Phase 2).
+    - **SSH agent**: creates a phantom token for the SSH agent proxy when the
+      scope has registered SSH keys (Phase 3).
+
+    When *proxy_required* is ``False`` (standalone default), soft-fails to
+    empty dict.  When ``True`` (terok project mode), raises ``SystemExit``
+    if the proxy is unreachable.
     """
     from terok_sandbox import (
         CredentialDB,
         SandboxConfig,
         get_proxy_port,
+        get_ssh_agent_port,
         is_proxy_running,
         is_proxy_socket_active,
     )
 
     cfg = SandboxConfig()
     if not (is_proxy_socket_active() or is_proxy_running(cfg)):
+        if proxy_required:
+            raise SystemExit(
+                "Credential proxy is not running.\n\n"
+                "Start it with:\n"
+                "  terok credential-proxy install   (systemd socket activation)\n"
+                "  terok credential-proxy start     (manual daemon)"
+            )
         return {}
 
     proxy_routes = roster.proxy_routes
@@ -344,6 +405,10 @@ def _inject_proxy_tokens(roster: AgentRoster, scope: str, task_id: str) -> dict[
         tokens = {
             name: db.create_proxy_token(scope, task_id, credential_set, name) for name in routed
         }
+
+        # SSH agent: create phantom token if scope has valid keys registered
+        ssh_token = _load_ssh_agent_token(db, cfg, scope, task_id)
+
         port = get_proxy_port(cfg)
     except Exception as exc:
         _logger.warning("Credential proxy token injection failed: %s: %s", type(exc).__name__, exc)
@@ -351,20 +416,28 @@ def _inject_proxy_tokens(roster: AgentRoster, scope: str, task_id: str) -> dict[
     finally:
         db.close()
 
+    use_socket = proxy_transport == "socket"
     proxy_base = f"http://host.containers.internal:{port}"
     env: dict[str, str] = {}
 
     for name, route in proxy_routes.items():
         if name not in routed:
             continue
+
+        # Auth dimension: select phantom env vars by credential type
         is_oauth = credential_types.get(name) == "oauth"
         token_vars = (
             route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
         )
         for env_var in token_vars:
             env[env_var] = tokens[name]
+
+        # Transport dimension: socket path + HTTP base URL
+        if use_socket and route.socket_path and route.socket_env:
+            env[route.socket_env] = route.socket_path
         if route.base_url_env:
             env[route.base_url_env] = proxy_base
+
         # OpenCode base URL override for proxied providers
         provider = roster.providers.get(name)
         if provider and provider.opencode_config:
@@ -377,5 +450,35 @@ def _inject_proxy_tokens(roster: AgentRoster, scope: str, task_id: str) -> dict[
     if routed:
         env["TEROK_PROXY_PORT"] = str(port)
 
+    # SSH agent token (scope-scoped, separate from per-provider tokens)
+    if ssh_token:
+        env["TEROK_SSH_AGENT_TOKEN"] = ssh_token
+        env["TEROK_SSH_AGENT_PORT"] = str(get_ssh_agent_port(cfg))
+
     _logger.debug("Credential proxy: injected %d env vars for %s", len(env), routed)
     return env
+
+
+def _load_ssh_keys_json(path: Path) -> dict:
+    """Load the SSH key mapping JSON.  Returns empty dict on failure."""
+    import json
+
+    if not path.is_file():
+        return {}
+    try:
+        result = json.loads(path.read_text(encoding="utf-8"))
+        return result if isinstance(result, dict) else {}
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
+        _logger.warning("Cannot read SSH keys file %s: %s", path, exc)
+        return {}
+
+
+def _load_ssh_agent_token(db, cfg, scope: str, task_id: str) -> str | None:
+    """Create an SSH agent phantom token if *scope* has valid keys registered."""
+    ssh_keys = _load_ssh_keys_json(cfg.ssh_keys_json_path)
+    ssh_entry = ssh_keys.get(scope)
+    if isinstance(ssh_entry, list) and any(
+        e.get("private_key") and e.get("public_key") for e in ssh_entry
+    ):
+        return db.create_proxy_token(scope, task_id, scope, "ssh")
+    return None

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -332,6 +332,15 @@ def _inject_proxy_tokens(roster: AgentRoster, scope: str, task_id: str) -> dict[
         routed = stored & proxy_routes.keys()
         if not routed:
             return {}
+
+        # Load credential types so we can select the right phantom env vars.
+        # OAuth credentials get oauth_phantom_env (e.g. CLAUDE_CODE_OAUTH_TOKEN),
+        # while API keys get phantom_env (e.g. ANTHROPIC_API_KEY).
+        credential_types: dict[str, str] = {}
+        for name in routed:
+            cred = db.load_credential(credential_set, name)
+            credential_types[name] = (cred.get("type") if cred else None) or "api_key"
+
         tokens = {
             name: db.create_proxy_token(scope, task_id, credential_set, name) for name in routed
         }
@@ -348,7 +357,11 @@ def _inject_proxy_tokens(roster: AgentRoster, scope: str, task_id: str) -> dict[
     for name, route in proxy_routes.items():
         if name not in routed:
             continue
-        for env_var in route.phantom_env:
+        is_oauth = credential_types.get(name) == "oauth"
+        token_vars = (
+            route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
+        )
+        for env_var in token_vars:
             env[env_var] = tokens[name]
         if route.base_url_env:
             env[route.base_url_env] = proxy_base

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -377,15 +377,15 @@ def _inject_proxy_tokens(
     proxy_routes = roster.proxy_routes
     try:
         db = CredentialDB(cfg.proxy_db_path)
-    except Exception as exc:
-        _logger.warning("Credential proxy DB unavailable: %s: %s", type(exc).__name__, exc)
+    except Exception:
+        _logger.exception("Credential proxy DB unavailable")
         if proxy_required:
             raise SystemExit(
-                f"Credential proxy DB unavailable: {type(exc).__name__}: {exc}\n\n"
+                "Credential proxy DB unavailable. Check logs for details.\n\n"
                 "Start it with:\n"
                 "  terok credential-proxy install   (systemd socket activation)\n"
                 "  terok credential-proxy start     (manual daemon)"
-            ) from exc
+            ) from None
         return {}
 
     try:
@@ -408,15 +408,15 @@ def _inject_proxy_tokens(
             tokens[name] = db.create_proxy_token(scope, task_id, credential_set, name)
 
         port = get_proxy_port(cfg)
-    except Exception as exc:
-        _logger.warning("Credential proxy token injection failed: %s: %s", type(exc).__name__, exc)
+    except Exception:
+        _logger.exception("Credential proxy token injection failed")
         if proxy_required:
             raise SystemExit(
-                f"Credential proxy token injection failed: {type(exc).__name__}: {exc}\n\n"
+                "Credential proxy token injection failed. Check logs for details.\n\n"
                 "Start it with:\n"
                 "  terok credential-proxy install   (systemd socket activation)\n"
                 "  terok credential-proxy start     (manual daemon)"
-            ) from exc
+            ) from None
         return {}
     finally:
         db.close()

--- a/src/terok_executor/credentials/proxy_commands.py
+++ b/src/terok_executor/credentials/proxy_commands.py
@@ -86,10 +86,16 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
 
     Files injected by :func:`~terok_executor.auth._write_claude_credentials_file`
     are recognised by their dummy ``accessToken`` marker and skipped.
+
+    Symlinks are rejected to prevent a container from tricking the scan into
+    reading arbitrary host files via a crafted symlink in the shared mount.
     """
+    import stat
+
     from terok_executor.roster.loader import get_roster
 
     roster = get_roster()
+    base_resolved = mounts_base.resolve(strict=False)
     leaked: list[tuple[str, Path]] = []
     for name, route in roster.proxy_routes.items():
         if not route.credential_file:
@@ -99,11 +105,14 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
             continue
         try:
             path = mounts_base / auth.host_dir_name / route.credential_file
-            if (
-                path.is_file()
-                and path.stat().st_size > 0
-                and not _is_injected_credentials_file(path)
-            ):
+            # lstat: do not follow symlinks — reject them outright
+            st = path.lstat()
+            if stat.S_ISLNK(st.st_mode) or not stat.S_ISREG(st.st_mode):
+                continue
+            # Ensure resolved path stays within the mounts base
+            if base_resolved not in path.resolve(strict=True).parents:
+                continue
+            if st.st_size > 0 and not _is_injected_credentials_file(path):
                 leaked.append((name, path))
         except (OSError, TypeError):
             continue

--- a/tach.toml
+++ b/tach.toml
@@ -114,6 +114,7 @@ depends_on = []
 [[modules]]
 path = "terok_executor.container.env"
 depends_on = [
+    "terok_executor.credentials.proxy_commands",
     "terok_executor.credentials.proxy_config",
     "terok_executor.paths",
 ]

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -26,6 +26,21 @@ def _find_vol(volumes: tuple[VolumeSpec, ...], container_path: str) -> VolumeSpe
     return next((v for v in volumes if container_path in v.container_path), None)
 
 
+def _make_proxy_db(tmp_path: Path, cred_name: str = "claude", cred_data: dict | None = None):
+    """Create a SandboxConfig + CredentialDB with one stored credential.
+
+    Returns ``(cfg, db)`` — caller should ``db.close()`` when done.
+    """
+    from terok_sandbox import CredentialDB, SandboxConfig
+
+    cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+    cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+    db = CredentialDB(cfg.proxy_db_path)
+    db.store_credential("default", cred_name, cred_data or {"type": "api_key", "key": "sk-test"})
+    db.close()
+    return cfg
+
+
 @pytest.fixture
 def roster():
     """Return the live agent roster (loaded from bundled YAML)."""
@@ -366,14 +381,7 @@ class TestCredentialProxy:
         assert "TEROK_PROXY_PORT" not in result.env
 
     def test_proxy_running_injects_tokens(self, workspace, envs_dir, roster, tmp_path):
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
-
+        cfg = _make_proxy_db(tmp_path)
         spec = _spec(workspace, envs_dir, credential_scope="test-project")
 
         with (
@@ -388,14 +396,7 @@ class TestCredentialProxy:
 
     def test_no_routed_providers_returns_empty(self, workspace, envs_dir, roster, tmp_path):
         """Stored credentials that don't match any proxy route produce no tokens."""
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "nonexistent-provider", {"type": "api_key", "key": "k"})
-        db.close()
-
+        cfg = _make_proxy_db(tmp_path, "nonexistent-provider")
         spec = _spec(workspace, envs_dir)
         with (
             patch("terok_sandbox.is_proxy_socket_active", return_value=True),
@@ -418,14 +419,7 @@ class TestCredentialProxy:
         self, workspace, envs_dir, roster, tmp_path
     ):
         """OAuth credential selects oauth_phantom_env (e.g. CLAUDE_CODE_OAUTH_TOKEN)."""
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "claude", {"type": "oauth", "access_token": "oa-tok"})
-        db.close()
-
+        cfg = _make_proxy_db(tmp_path, cred_data={"type": "oauth", "access_token": "oa-tok"})
         spec = _spec(workspace, envs_dir, credential_scope="test-project")
         with (
             patch("terok_sandbox.is_proxy_socket_active", return_value=True),
@@ -440,14 +434,7 @@ class TestCredentialProxy:
 
     def test_proxy_api_key_falls_back_to_phantom_env(self, workspace, envs_dir, roster, tmp_path):
         """API-key credential uses phantom_env even when oauth_phantom_env exists."""
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-ant-test"})
-        db.close()
-
+        cfg = _make_proxy_db(tmp_path)
         spec = _spec(workspace, envs_dir, credential_scope="test-project")
         with (
             patch("terok_sandbox.is_proxy_socket_active", return_value=True),
@@ -462,14 +449,7 @@ class TestCredentialProxy:
 
     def test_proxy_token_creation_error_returns_empty(self, workspace, envs_dir, roster, tmp_path):
         """Token creation failure returns empty env gracefully."""
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
-
+        cfg = _make_proxy_db(tmp_path)
         spec = _spec(workspace, envs_dir)
 
         with (
@@ -484,14 +464,7 @@ class TestCredentialProxy:
 
     def test_proxy_socket_transport_injects_socket_env(self, workspace, envs_dir, roster, tmp_path):
         """Socket transport injects socket_env and socket_path for routes that declare them."""
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
-
+        cfg = _make_proxy_db(tmp_path)
         spec = _spec(workspace, envs_dir, credential_scope="proj", proxy_transport="socket")
         with (
             patch("terok_sandbox.is_proxy_socket_active", return_value=True),
@@ -505,14 +478,7 @@ class TestCredentialProxy:
 
     def test_proxy_direct_transport_omits_socket_env(self, workspace, envs_dir, roster, tmp_path):
         """Direct transport (default) does not inject socket_env."""
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
-
+        cfg = _make_proxy_db(tmp_path)
         spec = _spec(workspace, envs_dir, credential_scope="proj", proxy_transport="direct")
         with (
             patch("terok_sandbox.is_proxy_socket_active", return_value=True),
@@ -546,16 +512,8 @@ class TestCredentialProxy:
         """SSH agent token injected when scope has valid keys in ssh-keys.json."""
         import json
 
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg = _make_proxy_db(tmp_path)
         cfg.credentials_dir.mkdir(parents=True, exist_ok=True)
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
-
-        # Write ssh-keys.json with a valid key entry for scope "myproj"
         cfg.ssh_keys_json_path.write_text(
             json.dumps(
                 {
@@ -579,14 +537,7 @@ class TestCredentialProxy:
 
     def test_proxy_no_ssh_keys_omits_token(self, workspace, envs_dir, roster, tmp_path):
         """No SSH agent token when ssh-keys.json has no entry for scope."""
-        from terok_sandbox import CredentialDB, SandboxConfig
-
-        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
-        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
-        db = CredentialDB(cfg.proxy_db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
-
+        cfg = _make_proxy_db(tmp_path)
         spec = _spec(workspace, envs_dir, credential_scope="no-keys-project")
         with (
             patch("terok_sandbox.is_proxy_socket_active", return_value=True),
@@ -597,8 +548,8 @@ class TestCredentialProxy:
         assert "TEROK_SSH_AGENT_TOKEN" not in result.env
         assert "TEROK_SSH_AGENT_PORT" not in result.env
 
-    def test_scan_leaked_creds_emits_warning(self, workspace, envs_dir, roster, capsys):
-        """scan_leaked_creds=True prints warnings to stderr for leaked files."""
+    def test_scan_leaked_creds_emits_warning(self, workspace, envs_dir, roster, caplog):
+        """scan_leaked_creds=True logs warnings for leaked files."""
         spec = _spec(workspace, envs_dir, scan_leaked_creds=True)
         with patch(
             "terok_executor.credentials.proxy_commands.scan_leaked_credentials",
@@ -607,9 +558,7 @@ class TestCredentialProxy:
             ],
         ):
             assemble_container_env(spec, roster, caller_manages_proxy=True)
-        captured = capsys.readouterr()
-        assert "Real credentials in shared mounts" in captured.err
-        assert "claude" in captured.err
+        assert any("claude" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -27,9 +27,9 @@ def _find_vol(volumes: tuple[VolumeSpec, ...], container_path: str) -> VolumeSpe
 
 
 def _make_proxy_db(tmp_path: Path, cred_name: str = "claude", cred_data: dict | None = None):
-    """Create a SandboxConfig + CredentialDB with one stored credential.
+    """Return a ``SandboxConfig`` with one credential pre-stored in its ``CredentialDB``.
 
-    Returns ``(cfg, db)`` — caller should ``db.close()`` when done.
+    The DB is created, populated, and closed internally.
     """
     from terok_sandbox import CredentialDB, SandboxConfig
 
@@ -547,6 +547,81 @@ class TestCredentialProxy:
 
         assert "TEROK_SSH_AGENT_TOKEN" not in result.env
         assert "TEROK_SSH_AGENT_PORT" not in result.env
+
+    def test_proxy_ssh_only_no_provider_creds(self, workspace, envs_dir, roster, tmp_path):
+        """SSH agent token injected even when no provider credentials are stored."""
+        import json
+
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg.credentials_dir.mkdir(parents=True, exist_ok=True)
+        # DB exists but has NO provider credentials — only SSH keys
+        CredentialDB(cfg.proxy_db_path).close()
+        cfg.ssh_keys_json_path.write_text(
+            json.dumps(
+                {
+                    "sshonly": [
+                        {"private_key": "/tmp/terok-testing/k", "public_key": "ssh-ed25519 A"}
+                    ]
+                }
+            )
+        )
+
+        spec = _spec(workspace, envs_dir, credential_scope="sshonly")
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+        assert "TEROK_SSH_AGENT_TOKEN" in result.env
+        assert result.env["TEROK_SSH_AGENT_TOKEN"].startswith("terok-p-")
+        # No provider tokens
+        assert "ANTHROPIC_API_KEY" not in result.env
+
+    def test_proxy_required_hard_fails_on_db_error(self, workspace, envs_dir, roster):
+        """proxy_required=True raises SystemExit on CredentialDB construction failure."""
+        spec = _spec(workspace, envs_dir, proxy_required=True)
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.CredentialDB", side_effect=OSError("corrupt")),
+            pytest.raises(SystemExit, match="DB unavailable.*corrupt"),
+        ):
+            assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+    def test_proxy_required_hard_fails_on_token_error(self, workspace, envs_dir, roster, tmp_path):
+        """proxy_required=True raises SystemExit on token creation failure."""
+        cfg = _make_proxy_db(tmp_path)
+        spec = _spec(workspace, envs_dir, proxy_required=True)
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+            patch(
+                "terok_sandbox.CredentialDB.create_proxy_token", side_effect=RuntimeError("boom")
+            ),
+            pytest.raises(SystemExit, match="injection failed.*boom"),
+        ):
+            assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+    def test_proxy_malformed_ssh_entry_warns(self, workspace, envs_dir, roster, tmp_path, caplog):
+        """Non-dict entries in ssh-keys.json trigger a warning, not a crash."""
+        import json
+
+        cfg = _make_proxy_db(tmp_path)
+        cfg.credentials_dir.mkdir(parents=True, exist_ok=True)
+        cfg.ssh_keys_json_path.write_text(json.dumps({"badproj": ["not-a-dict"]}))
+
+        spec = _spec(workspace, envs_dir, credential_scope="badproj")
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+        assert "TEROK_SSH_AGENT_TOKEN" not in result.env
+        assert any("Malformed entry" in r.message for r in caplog.records)
 
     def test_scan_leaked_creds_emits_warning(self, workspace, envs_dir, roster, caplog):
         """scan_leaked_creds=True logs warnings for leaked files."""

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -414,6 +414,52 @@ class TestCredentialProxy:
             result = assemble_container_env(base_spec, roster, caller_manages_proxy=False)
         assert "TEROK_PROXY_PORT" not in result.env
 
+    def test_proxy_oauth_credential_uses_oauth_phantom_env(
+        self, workspace, envs_dir, roster, tmp_path
+    ):
+        """OAuth credential selects oauth_phantom_env (e.g. CLAUDE_CODE_OAUTH_TOKEN)."""
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "claude", {"type": "oauth", "access_token": "oa-tok"})
+        db.close()
+
+        spec = _spec(workspace, envs_dir, credential_scope="test-project")
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in result.env
+        assert result.env["CLAUDE_CODE_OAUTH_TOKEN"].startswith("terok-p-")
+        # API key env var must NOT be set when OAuth credential is stored
+        assert "ANTHROPIC_API_KEY" not in result.env
+
+    def test_proxy_api_key_falls_back_to_phantom_env(self, workspace, envs_dir, roster, tmp_path):
+        """API-key credential uses phantom_env even when oauth_phantom_env exists."""
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-ant-test"})
+        db.close()
+
+        spec = _spec(workspace, envs_dir, credential_scope="test-project")
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+        assert "ANTHROPIC_API_KEY" in result.env
+        assert result.env["ANTHROPIC_API_KEY"].startswith("terok-p-")
+        # OAuth env var must NOT be set for API key credentials
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in result.env
+
     def test_proxy_token_creation_error_returns_empty(self, workspace, envs_dir, roster, tmp_path):
         """Token creation failure returns empty env gracefully."""
         from terok_sandbox import CredentialDB, SandboxConfig

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -482,6 +482,135 @@ class TestCredentialProxy:
             result = assemble_container_env(spec, roster, caller_manages_proxy=False)
         assert "TEROK_PROXY_PORT" not in result.env
 
+    def test_proxy_socket_transport_injects_socket_env(self, workspace, envs_dir, roster, tmp_path):
+        """Socket transport injects socket_env and socket_path for routes that declare them."""
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
+        db.close()
+
+        spec = _spec(workspace, envs_dir, credential_scope="proj", proxy_transport="socket")
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+        # Claude route declares socket_env=ANTHROPIC_UNIX_SOCKET
+        assert "ANTHROPIC_UNIX_SOCKET" in result.env
+        assert result.env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
+
+    def test_proxy_direct_transport_omits_socket_env(self, workspace, envs_dir, roster, tmp_path):
+        """Direct transport (default) does not inject socket_env."""
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
+        db.close()
+
+        spec = _spec(workspace, envs_dir, credential_scope="proj", proxy_transport="direct")
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+        assert "ANTHROPIC_UNIX_SOCKET" not in result.env
+
+    def test_proxy_required_raises_when_unreachable(self, workspace, envs_dir, roster):
+        """proxy_required=True raises SystemExit when proxy is not running."""
+        spec = _spec(workspace, envs_dir, proxy_required=True)
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=False),
+            patch("terok_sandbox.is_proxy_running", return_value=False),
+            pytest.raises(SystemExit, match="Credential proxy is not running"),
+        ):
+            assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+    def test_proxy_not_required_soft_fails(self, workspace, envs_dir, roster):
+        """proxy_required=False (default) returns empty env when proxy is down."""
+        spec = _spec(workspace, envs_dir, proxy_required=False)
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=False),
+            patch("terok_sandbox.is_proxy_running", return_value=False),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
+        assert "TEROK_PROXY_PORT" not in result.env
+
+    def test_proxy_injects_ssh_agent_token(self, workspace, envs_dir, roster, tmp_path):
+        """SSH agent token injected when scope has valid keys in ssh-keys.json."""
+        import json
+
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg.credentials_dir.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
+        db.close()
+
+        # Write ssh-keys.json with a valid key entry for scope "myproj"
+        cfg.ssh_keys_json_path.write_text(
+            json.dumps(
+                {
+                    "myproj": [
+                        {"private_key": "/tmp/terok-testing/k", "public_key": "ssh-ed25519 AAAA"}
+                    ]
+                }
+            )
+        )
+
+        spec = _spec(workspace, envs_dir, credential_scope="myproj")
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+        assert "TEROK_SSH_AGENT_TOKEN" in result.env
+        assert result.env["TEROK_SSH_AGENT_TOKEN"].startswith("terok-p-")
+        assert "TEROK_SSH_AGENT_PORT" in result.env
+
+    def test_proxy_no_ssh_keys_omits_token(self, workspace, envs_dir, roster, tmp_path):
+        """No SSH agent token when ssh-keys.json has no entry for scope."""
+        from terok_sandbox import CredentialDB, SandboxConfig
+
+        cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
+        cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.proxy_db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
+        db.close()
+
+        spec = _spec(workspace, envs_dir, credential_scope="no-keys-project")
+        with (
+            patch("terok_sandbox.is_proxy_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_proxy=False)
+
+        assert "TEROK_SSH_AGENT_TOKEN" not in result.env
+        assert "TEROK_SSH_AGENT_PORT" not in result.env
+
+    def test_scan_leaked_creds_emits_warning(self, workspace, envs_dir, roster, capsys):
+        """scan_leaked_creds=True prints warnings to stderr for leaked files."""
+        spec = _spec(workspace, envs_dir, scan_leaked_creds=True)
+        with patch(
+            "terok_executor.credentials.proxy_commands.scan_leaked_credentials",
+            return_value=[
+                ("claude", Path("/tmp/terok-testing/mounts/_claude-config/.credentials.json"))
+            ],
+        ):
+            assemble_container_env(spec, roster, caller_manages_proxy=True)
+        captured = capsys.readouterr()
+        assert "Real credentials in shared mounts" in captured.err
+        assert "claude" in captured.err
+
 
 # ---------------------------------------------------------------------------
 # Task dir

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -36,7 +36,11 @@ def _make_proxy_db(tmp_path: Path, cred_name: str = "claude", cred_data: dict | 
     cfg = SandboxConfig(state_dir=tmp_path, credentials_dir=tmp_path / "credentials")
     cfg.proxy_db_path.parent.mkdir(parents=True, exist_ok=True)
     db = CredentialDB(cfg.proxy_db_path)
-    db.store_credential("default", cred_name, cred_data or {"type": "api_key", "key": "sk-test"})
+    db.store_credential(
+        "default",
+        cred_name,
+        {"type": "api_key", "key": "sk-test"} if cred_data is None else cred_data,
+    )
     db.close()
     return cfg
 
@@ -370,7 +374,7 @@ class TestCredentialProxy:
 
     def test_caller_manages_proxy_skips_injection(self, base_spec, roster):
         result = assemble_container_env(base_spec, roster, caller_manages_proxy=True)
-        assert "TEROK_PROXY_PORT" not in result.env
+        assert "ANTHROPIC_API_KEY" not in result.env
 
     def test_proxy_not_running_returns_no_tokens(self, base_spec, roster):
         with (
@@ -378,7 +382,7 @@ class TestCredentialProxy:
             patch("terok_sandbox.is_proxy_running", return_value=False),
         ):
             result = assemble_container_env(base_spec, roster, caller_manages_proxy=False)
-        assert "TEROK_PROXY_PORT" not in result.env
+        assert "ANTHROPIC_API_KEY" not in result.env
 
     def test_proxy_running_injects_tokens(self, workspace, envs_dir, roster, tmp_path):
         cfg = _make_proxy_db(tmp_path)
@@ -403,7 +407,6 @@ class TestCredentialProxy:
             patch("terok_sandbox.SandboxConfig", return_value=cfg),
         ):
             result = assemble_container_env(spec, roster, caller_manages_proxy=False)
-        assert "TEROK_PROXY_PORT" not in result.env
         assert "ANTHROPIC_API_KEY" not in result.env
 
     def test_proxy_db_error_returns_empty(self, base_spec, roster):
@@ -413,7 +416,7 @@ class TestCredentialProxy:
             patch("terok_sandbox.CredentialDB", side_effect=OSError("corrupt")),
         ):
             result = assemble_container_env(base_spec, roster, caller_manages_proxy=False)
-        assert "TEROK_PROXY_PORT" not in result.env
+        assert "ANTHROPIC_API_KEY" not in result.env
 
     def test_proxy_oauth_credential_uses_oauth_phantom_env(
         self, workspace, envs_dir, roster, tmp_path
@@ -460,7 +463,7 @@ class TestCredentialProxy:
             ),
         ):
             result = assemble_container_env(spec, roster, caller_manages_proxy=False)
-        assert "TEROK_PROXY_PORT" not in result.env
+        assert "ANTHROPIC_API_KEY" not in result.env
 
     def test_proxy_socket_transport_injects_socket_env(self, workspace, envs_dir, roster, tmp_path):
         """Socket transport injects socket_env and socket_path for routes that declare them."""
@@ -506,7 +509,7 @@ class TestCredentialProxy:
             patch("terok_sandbox.is_proxy_running", return_value=False),
         ):
             result = assemble_container_env(spec, roster, caller_manages_proxy=False)
-        assert "TEROK_PROXY_PORT" not in result.env
+        assert "ANTHROPIC_API_KEY" not in result.env
 
     def test_proxy_injects_ssh_agent_token(self, workspace, envs_dir, roster, tmp_path):
         """SSH agent token injected when scope has valid keys in ssh-keys.json."""
@@ -587,7 +590,7 @@ class TestCredentialProxy:
         with (
             patch("terok_sandbox.is_proxy_socket_active", return_value=True),
             patch("terok_sandbox.CredentialDB", side_effect=OSError("corrupt")),
-            pytest.raises(SystemExit, match="DB unavailable.*corrupt"),
+            pytest.raises(SystemExit, match="DB unavailable.*Check logs"),
         ):
             assemble_container_env(spec, roster, caller_manages_proxy=False)
 
@@ -601,7 +604,7 @@ class TestCredentialProxy:
             patch(
                 "terok_sandbox.CredentialDB.create_proxy_token", side_effect=RuntimeError("boom")
             ),
-            pytest.raises(SystemExit, match="injection failed.*boom"),
+            pytest.raises(SystemExit, match="injection failed.*Check logs"),
         ):
             assemble_container_env(spec, roster, caller_manages_proxy=False)
 


### PR DESCRIPTION
## Summary

Pushes four categories of proxy features from terok's duplicated `_credential_proxy_env_and_volumes()` down into executor's canonical `_inject_proxy_tokens()`:

- **Phase 1 — Credential-type awareness**: loads each credential from the DB, selects `oauth_phantom_env` (e.g. `CLAUDE_CODE_OAUTH_TOKEN`) vs `phantom_env` (e.g. `ANTHROPIC_API_KEY`) based on stored type
- **Phase 2 — Socket transport**: new `proxy_transport` field on `ContainerEnvSpec`; injects `socket_env`/`socket_path` when set to `"socket"`
- **Phase 3 — SSH agent tokens**: loads `ssh-keys.json`, creates `TEROK_SSH_AGENT_TOKEN` + `TEROK_SSH_AGENT_PORT` when scope has valid keys registered
- **Phase 4 — Hard-fail + leaked credential scanning**: new `proxy_required` (raises `SystemExit` if proxy unreachable) and `scan_leaked_creds` (warns about real credential files in shared mounts) fields

All new `ContainerEnvSpec` fields have safe defaults — standalone `AgentRunner._run()` is unchanged. Tracked in terok-ai/terok#688.

## Test plan

- [x] `test_proxy_oauth_credential_uses_oauth_phantom_env` — OAuth → `CLAUDE_CODE_OAUTH_TOKEN`
- [x] `test_proxy_api_key_falls_back_to_phantom_env` — API key → `ANTHROPIC_API_KEY`
- [x] `test_proxy_socket_transport_injects_socket_env` — socket mode → `ANTHROPIC_UNIX_SOCKET`
- [x] `test_proxy_direct_transport_omits_socket_env` — direct mode omits socket vars
- [x] `test_proxy_required_raises_when_unreachable` — hard-fail `SystemExit`
- [x] `test_proxy_not_required_soft_fails` — soft-fail returns empty env
- [x] `test_proxy_injects_ssh_agent_token` — SSH token when keys exist
- [x] `test_proxy_no_ssh_keys_omits_token` — no token when no keys
- [x] `test_scan_leaked_creds_emits_warning` — stderr warning for leaked files
- [x] All existing proxy tests pass (no behavioral change for current workflows)
- [x] `make check` passes (lint, 499 tests, tach, security, docstrings, reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable credential-proxy transport (direct or socket) with socket env injection when used.
  * Option to require proxy reachability — startup aborts when required and unreachable.
  * Per-credential selection between OAuth and API-key environment variables.
  * Optional leaked-credentials scan that can run independently of proxy management.
  * Injects SSH-agent token and port when matching SSH keys are present.

* **Bug Fixes**
  * Hardened leaked-credentials scan against symlink/traversal attacks.

* **Tests**
  * Expanded unit tests covering transports, proxy-required failures, credential-type selection, SSH-agent cases, malformed SSH keys, and leaked-credentials warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->