### PR TITLE
feat: interactive preflight checks in `terok-executor run`

### DIFF
--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -94,6 +94,13 @@ def _handle_run(
     shared_mount: str = "/shared",
 ) -> None:
     """Run an agent in a hardened container."""
+    import sys
+
+    from .preflight import run_preflight
+
+    if not run_preflight(agent, interactive=sys.stdin.isatty()):
+        raise SystemExit(1)
+
     from .container.runner import AgentRunner
 
     # Resolve human identity from host git config if requested
@@ -282,6 +289,54 @@ def _handle_stop(*, name: str) -> None:
     print(f"Stopped: {name}")
 
 
+def _handle_setup(*, check: bool = False) -> None:
+    """Check prerequisites and optionally fix them interactively."""
+
+    from .preflight import (
+        check_credentials,
+        check_images,
+        check_podman,
+        check_proxy,
+        check_shield,
+    )
+
+    checks = [
+        ("podman", check_podman()),
+        ("proxy", check_proxy()),
+        ("shield", check_shield()),
+        ("images", check_images("ubuntu:24.04")),
+    ]
+
+    print("\nterok-executor status:\n")
+    all_ok = True
+    for label, result in checks:
+        marker = "ok" if result.ok else ("info" if label == "shield" else "FAIL")
+        print(f"  {result.name:<22} {marker} ({result.message})")
+        if not result.ok and label != "shield":
+            all_ok = False
+
+    # Credential summary for known agent providers
+    from .roster.loader import get_roster
+
+    roster = get_roster()
+    print()
+    for name in sorted(roster.agent_names):
+        cr = check_credentials(name)
+        marker = "ok" if cr.ok else "--"
+        print(f"  {name:<22} {marker}")
+
+    if all_ok:
+        print("\nAll prerequisites met. Run: terok-executor run <agent> <repo>")
+    else:
+        if not check:
+            print("\nFix issues above, or just run: terok-executor run <agent> <repo>")
+            print("The run command will offer to fix missing prerequisites interactively.")
+        else:
+            print("\nSome prerequisites are missing (see above).")
+            raise SystemExit(1)
+    print()
+
+
 # ── Command definitions ──
 
 RUN_COMMAND = CommandDef(
@@ -380,6 +435,19 @@ STOP_COMMAND = CommandDef(
     args=(ArgDef(name="name", help="Container name"),),
 )
 
+SETUP_COMMAND = CommandDef(
+    name="setup",
+    help="Check prerequisites (proxy, images, credentials)",
+    handler=_handle_setup,
+    args=(
+        ArgDef(
+            name="--check",
+            action="store_true",
+            help="Report status and exit non-zero if prerequisites are missing",
+        ),
+    ),
+)
+
 #: All terok-executor commands.
 COMMANDS: tuple[CommandDef, ...] = (
     RUN_COMMAND,
@@ -387,6 +455,7 @@ COMMANDS: tuple[CommandDef, ...] = (
     AUTH_COMMAND,
     AGENTS_COMMAND,
     BUILD_COMMAND,
+    SETUP_COMMAND,
     LS_COMMAND,
     STOP_COMMAND,
 )

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pre-launch prerequisite checks for ``terok-executor run``.
+
+Detects missing infrastructure (podman, credential proxy, agent credentials,
+container images) and — in interactive mode — offers to fix each issue before
+the run starts.  In non-interactive mode, reports all problems and exits.
+
+The :func:`run_preflight` entry point is called from :mod:`commands` before
+:class:`~terok_executor.container.runner.AgentRunner` is created.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome of a single prerequisite check."""
+
+    name: str
+    ok: bool
+    message: str
+
+
+# ── Individual checks ──────────────────────────────────────────────────
+
+
+def check_podman() -> CheckResult:
+    """Verify that podman is installed and responds to ``podman version``."""
+    if not shutil.which("podman"):
+        return CheckResult("podman", False, "not found on PATH")
+    try:
+        subprocess.run(
+            ["podman", "version", "--format", "{{.Client.Version}}"],
+            capture_output=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        return CheckResult("podman", False, f"found but not responding: {exc}")
+    return CheckResult("podman", True, "ok")
+
+
+def check_proxy() -> CheckResult:
+    """Check whether the credential proxy is reachable."""
+    from terok_sandbox import SandboxConfig, is_proxy_running, is_proxy_socket_active
+
+    if is_proxy_socket_active() or is_proxy_running(cfg=SandboxConfig()):
+        return CheckResult("credential proxy", True, "running")
+    return CheckResult("credential proxy", False, "not running")
+
+
+def check_credentials(provider: str) -> CheckResult:
+    """Check whether credentials are stored for *provider*."""
+    from terok_sandbox import CredentialDB, SandboxConfig
+
+    cfg = SandboxConfig()
+    try:
+        db = CredentialDB(cfg.proxy_db_path)
+    except Exception:  # noqa: BLE001
+        return CheckResult(f"{provider} credentials", False, "credential database unavailable")
+    try:
+        cred = db.load_credential("default", provider)
+    finally:
+        db.close()
+    if cred:
+        return CheckResult(f"{provider} credentials", True, "stored")
+    return CheckResult(f"{provider} credentials", False, "not found")
+
+
+def check_images(base_image: str) -> CheckResult:
+    """Check whether L0+L1 container images exist."""
+    from terok_executor.container.build import l1_image_tag
+
+    tag = l1_image_tag(base_image)
+    try:
+        result = subprocess.run(
+            ["podman", "image", "exists", tag],
+            capture_output=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return CheckResult("container images", True, "ready")
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return CheckResult("container images", False, "not built")
+
+
+def check_shield() -> CheckResult:
+    """Check whether shield OCI hooks are installed (informational only)."""
+    from terok_sandbox import check_environment
+
+    ec = check_environment()
+    if ec.health == "ok":
+        return CheckResult("shield", True, "active")
+    return CheckResult("shield", False, "not installed (containers have unrestricted network)")
+
+
+# ── Interactive fixers ─────────────────────────────────────────────────
+
+
+def _confirm(prompt: str) -> bool:
+    """Ask a yes/no question, default yes."""
+    try:
+        answer = input(f"  {prompt} [Y/n] ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return False
+    return answer in ("", "y", "yes")
+
+
+def _fix_proxy() -> bool:
+    """Start the credential proxy, installing systemd units if needed."""
+    from terok_sandbox import (
+        SandboxConfig,
+        install_proxy_systemd,
+        is_proxy_running,
+        is_proxy_systemd_available,
+        start_proxy,
+    )
+
+    from terok_executor.roster.loader import ensure_proxy_routes
+
+    cfg = SandboxConfig()
+    ensure_proxy_routes(cfg=cfg)
+
+    if is_proxy_systemd_available():
+        install_proxy_systemd(cfg=cfg)
+        # systemd socket activation will start on first connection
+        return True
+
+    start_proxy(cfg=cfg)
+    return is_proxy_running(cfg=cfg)
+
+
+def _fix_credentials(provider: str) -> bool:
+    """Run the interactive authentication flow for *provider*."""
+    from terok_executor.container.build import l1_image_tag
+    from terok_executor.credentials.auth import authenticate
+    from terok_executor.paths import mounts_dir
+
+    image = l1_image_tag("ubuntu:24.04")
+    try:
+        authenticate("standalone", provider, mounts_dir=mounts_dir(), image=image)
+    except SystemExit:
+        return False
+
+    # Write proxy config patches for the authenticated provider
+    from terok_executor.credentials.proxy_config import write_proxy_config
+
+    write_proxy_config(provider)
+    return True
+
+
+def _fix_images(base_image: str) -> bool:
+    """Build L0+L1 container images."""
+    from terok_executor.container.build import BuildError, build_base_images
+
+    try:
+        build_base_images(base_image)
+        return True
+    except BuildError as exc:
+        print(f"  Build failed: {exc}", file=sys.stderr)
+        return False
+
+
+# ── Orchestrator ───────────────────────────────────────────────────────
+
+
+def _print_step(step: int, total: int, result: CheckResult) -> None:
+    """Print a preflight check result."""
+    marker = "ok" if result.ok else "FAIL"
+    print(f"  [{step}/{total}] {result.name}... {marker}")
+
+
+def _provider_hints(current_provider: str) -> None:
+    """Print a hint about authenticating additional tools."""
+    from terok_executor.roster.loader import get_roster
+
+    roster = get_roster()
+    others = sorted(name for name in roster.all_names if name != current_provider)
+    if others:
+        print("\n  Hint: authenticate additional tools with: terok-executor auth <name>")
+        print(f"        Available: {', '.join(others)}")
+
+
+def run_preflight(
+    provider: str,
+    *,
+    interactive: bool = True,
+    base_image: str = "ubuntu:24.04",
+) -> bool:
+    """Run all prerequisite checks; fix interactively if possible.
+
+    Returns ``True`` if all checks pass (or were fixed), ``False`` otherwise.
+    """
+    print()
+    total = 4
+    all_ok = True
+
+    # 1. Podman
+    r = check_podman()
+    _print_step(1, total, r)
+    if not r.ok:
+        print("      Install podman first: https://podman.io/docs/installation", file=sys.stderr)
+        return False
+
+    # 2. Credential proxy
+    r = check_proxy()
+    if not r.ok and interactive:
+        print(f"  [{2}/{total}] {r.name}... {r.message}")
+        if _confirm("Start credential proxy?"):
+            fixed = _fix_proxy()
+            r = CheckResult(r.name, fixed, "started" if fixed else "failed to start")
+    _print_step(2, total, r)
+    if not r.ok:
+        print("      Start with: terok-executor proxy start", file=sys.stderr)
+        all_ok = False
+
+    # 3. Credentials for the requested provider
+    r = check_credentials(provider)
+    if not r.ok and interactive:
+        print(f"  [{3}/{total}] {r.name}... {r.message}")
+        if _confirm(f"Authenticate {provider} now?"):
+            fixed = _fix_credentials(provider)
+            r = CheckResult(r.name, fixed, "authenticated" if fixed else "authentication failed")
+    _print_step(3, total, r)
+    if not r.ok:
+        print(f"      Run: terok-executor auth {provider}", file=sys.stderr)
+        all_ok = False
+
+    # 4. Container images
+    r = check_images(base_image)
+    if not r.ok and interactive:
+        print(f"  [{4}/{total}] {r.name}... {r.message}")
+        print("      Building agent images (this may take a few minutes)...")
+        fixed = _fix_images(base_image)
+        r = CheckResult(r.name, fixed, "built" if fixed else "build failed")
+    _print_step(4, total, r)
+    if not r.ok:
+        print("      Run: terok-executor build", file=sys.stderr)
+        all_ok = False
+
+    # Shield check (informational)
+    r = check_shield()
+    if not r.ok:
+        print(f"\n  Note: {r.message}")
+
+    # Hint about other providers
+    if all_ok and interactive:
+        _provider_hints(provider)
+
+    print()
+    return all_ok

--- a/tach.toml
+++ b/tach.toml
@@ -165,6 +165,19 @@ depends_on = [
     "terok_executor.roster.loader",
 ]
 
+# ── Preflight — prerequisite checks ────────────────────────────────
+
+# Pre-launch checks + interactive fixers for `terok-executor run`
+[[modules]]
+path = "terok_executor.preflight"
+depends_on = [
+    "terok_executor.container.build",
+    "terok_executor.credentials.auth",
+    "terok_executor.credentials.proxy_config",
+    "terok_executor.paths",
+    "terok_executor.roster.loader",
+]
+
 # ── CLI surface ────────────────────────────────────────────────────
 
 # Command registry — defines all CLI commands
@@ -176,6 +189,7 @@ depends_on = [
     "terok_executor.credentials.auth",
     "terok_executor.credentials.proxy_config",
     "terok_executor.paths",
+    "terok_executor.preflight",
     "terok_executor.roster.loader",
 ]
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -108,7 +108,10 @@ class TestSharedDirArgs:
         """_handle_run passes shared_dir to runner, omits shared_mount when no dir."""
         from terok_executor.commands import _handle_run
 
-        with patch("terok_executor.container.runner.AgentRunner") as mock_cls:
+        with (
+            patch("terok_executor.preflight.run_preflight", return_value=True),
+            patch("terok_executor.container.runner.AgentRunner") as mock_cls,
+        ):
             mock_runner = mock_cls.return_value
             mock_runner.run_headless.return_value = "terok-executor-test"
             _handle_run(
@@ -126,7 +129,10 @@ class TestSharedDirArgs:
         """_handle_run omits shared_mount from common dict when shared_dir is None."""
         from terok_executor.commands import _handle_run
 
-        with patch("terok_executor.container.runner.AgentRunner") as mock_cls:
+        with (
+            patch("terok_executor.preflight.run_preflight", return_value=True),
+            patch("terok_executor.container.runner.AgentRunner") as mock_cls,
+        ):
             mock_runner = mock_cls.return_value
             mock_runner.run_headless.return_value = "terok-executor-test"
             _handle_run(agent="claude", repo=".", prompt="test")

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the preflight prerequisite checker."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from terok_executor.preflight import (
+    CheckResult,
+    check_credentials,
+    check_images,
+    check_podman,
+    check_proxy,
+    check_shield,
+    run_preflight,
+)
+
+# ── check_podman ─────────────────────────────────────────────────────
+
+
+@patch("terok_executor.preflight.subprocess.run")
+@patch("terok_executor.preflight.shutil.which", return_value="/usr/bin/podman")
+def test_podman_ok(_which: MagicMock, _run: MagicMock) -> None:
+    """Podman found and responds → ok."""
+    assert check_podman().ok is True
+
+
+@patch("terok_executor.preflight.shutil.which", return_value=None)
+def test_podman_missing(_which: MagicMock) -> None:
+    """Podman not on PATH → fail."""
+    r = check_podman()
+    assert r.ok is False
+    assert "not found" in r.message
+
+
+# ── check_proxy ──────────────────────────────────────────────────────
+
+
+@patch("terok_sandbox.is_proxy_running", return_value=True)
+@patch("terok_sandbox.is_proxy_socket_active", return_value=False)
+def test_proxy_running(_sock: MagicMock, _run: MagicMock) -> None:
+    """Proxy daemon running → ok."""
+    assert check_proxy().ok is True
+
+
+@patch("terok_sandbox.is_proxy_running", return_value=False)
+@patch("terok_sandbox.is_proxy_socket_active", return_value=True)
+def test_proxy_socket_active(_sock: MagicMock, _run: MagicMock) -> None:
+    """Proxy systemd socket active → ok."""
+    assert check_proxy().ok is True
+
+
+@patch("terok_sandbox.is_proxy_running", return_value=False)
+@patch("terok_sandbox.is_proxy_socket_active", return_value=False)
+def test_proxy_not_running(_sock: MagicMock, _run: MagicMock) -> None:
+    """Neither running nor socket active → fail."""
+    assert check_proxy().ok is False
+
+
+# ── check_credentials ────────────────────────────────────────────────
+
+
+@patch("terok_sandbox.CredentialDB")
+def test_credentials_found(mock_db_cls: MagicMock) -> None:
+    """Credentials stored → ok."""
+    db = mock_db_cls.return_value
+    db.load_credential.return_value = {"type": "api_key", "value": "sk-test"}
+    assert check_credentials("claude").ok is True
+    db.close.assert_called_once()
+
+
+@patch("terok_sandbox.CredentialDB")
+def test_credentials_missing(mock_db_cls: MagicMock) -> None:
+    """No credentials → fail."""
+    db = mock_db_cls.return_value
+    db.load_credential.return_value = None
+    r = check_credentials("claude")
+    assert r.ok is False
+    assert "not found" in r.message
+    db.close.assert_called_once()
+
+
+@patch("terok_sandbox.CredentialDB", side_effect=Exception("db error"))
+def test_credentials_db_unavailable(_cls: MagicMock) -> None:
+    """DB open fails → fail with message."""
+    r = check_credentials("claude")
+    assert r.ok is False
+    assert "unavailable" in r.message
+
+
+# ── check_images ─────────────────────────────────────────────────────
+
+
+@patch("terok_executor.preflight.subprocess.run")
+def test_images_exist(mock_run: MagicMock) -> None:
+    """Image exists → ok."""
+    mock_run.return_value = MagicMock(returncode=0)
+    assert check_images("ubuntu:24.04").ok is True
+
+
+@patch("terok_executor.preflight.subprocess.run")
+def test_images_missing(mock_run: MagicMock) -> None:
+    """Image doesn't exist → fail."""
+    mock_run.return_value = MagicMock(returncode=1)
+    assert check_images("ubuntu:24.04").ok is False
+
+
+# ── check_shield ─────────────────────────────────────────────────────
+
+
+@patch("terok_sandbox.check_environment")
+def test_shield_ok(mock_env: MagicMock) -> None:
+    """Shield active → ok."""
+    mock_env.return_value = MagicMock(health="ok")
+    assert check_shield().ok is True
+
+
+@patch("terok_sandbox.check_environment")
+def test_shield_missing(mock_env: MagicMock) -> None:
+    """Shield not installed → fail (informational)."""
+    mock_env.return_value = MagicMock(health="setup-needed")
+    r = check_shield()
+    assert r.ok is False
+    assert "unrestricted" in r.message
+
+
+# ── run_preflight ────────────────────────────────────────────────────
+
+
+@patch("terok_executor.preflight.check_shield", return_value=CheckResult("shield", True, "ok"))
+@patch("terok_executor.preflight.check_images", return_value=CheckResult("images", True, "ready"))
+@patch(
+    "terok_executor.preflight.check_credentials",
+    return_value=CheckResult("claude creds", True, "stored"),
+)
+@patch("terok_executor.preflight.check_proxy", return_value=CheckResult("proxy", True, "running"))
+@patch("terok_executor.preflight.check_podman", return_value=CheckResult("podman", True, "ok"))
+def test_preflight_all_ok(
+    _pod: MagicMock,
+    _proxy: MagicMock,
+    _creds: MagicMock,
+    _imgs: MagicMock,
+    _shield: MagicMock,
+) -> None:
+    """All checks pass → returns True."""
+    assert run_preflight("claude", interactive=False) is True
+
+
+@patch("terok_executor.preflight.check_podman", return_value=CheckResult("podman", False, "nope"))
+def test_preflight_no_podman(_pod: MagicMock) -> None:
+    """Podman missing → returns False immediately."""
+    assert run_preflight("claude", interactive=False) is False
+
+
+@patch("terok_executor.preflight.check_shield", return_value=CheckResult("shield", False, "nope"))
+@patch("terok_executor.preflight.check_images", return_value=CheckResult("images", True, "ready"))
+@patch(
+    "terok_executor.preflight.check_credentials",
+    return_value=CheckResult("claude creds", True, "stored"),
+)
+@patch("terok_executor.preflight.check_proxy", return_value=CheckResult("proxy", True, "running"))
+@patch("terok_executor.preflight.check_podman", return_value=CheckResult("podman", True, "ok"))
+def test_preflight_shield_missing_still_ok(
+    _pod: MagicMock,
+    _proxy: MagicMock,
+    _creds: MagicMock,
+    _imgs: MagicMock,
+    _shield: MagicMock,
+) -> None:
+    """Shield missing is informational — doesn't block the run."""
+    assert run_preflight("claude", interactive=False) is True
+
+
+@patch("terok_executor.preflight.check_shield", return_value=CheckResult("shield", True, "ok"))
+@patch("terok_executor.preflight.check_images", return_value=CheckResult("images", True, "ready"))
+@patch(
+    "terok_executor.preflight.check_credentials",
+    return_value=CheckResult("claude creds", False, "not found"),
+)
+@patch("terok_executor.preflight.check_proxy", return_value=CheckResult("proxy", True, "running"))
+@patch("terok_executor.preflight.check_podman", return_value=CheckResult("podman", True, "ok"))
+def test_preflight_creds_missing_non_interactive(
+    _pod: MagicMock,
+    _proxy: MagicMock,
+    _creds: MagicMock,
+    _imgs: MagicMock,
+    _shield: MagicMock,
+) -> None:
+    """Missing credentials in non-interactive mode → returns False."""
+    assert run_preflight("claude", interactive=False) is False
+
+
+@patch("terok_executor.preflight._provider_hints")
+@patch("terok_executor.preflight._fix_credentials", return_value=True)
+@patch("terok_executor.preflight._confirm", return_value=True)
+@patch("terok_executor.preflight.check_shield", return_value=CheckResult("shield", True, "ok"))
+@patch("terok_executor.preflight.check_images", return_value=CheckResult("images", True, "ready"))
+@patch(
+    "terok_executor.preflight.check_credentials",
+    return_value=CheckResult("claude creds", False, "not found"),
+)
+@patch("terok_executor.preflight.check_proxy", return_value=CheckResult("proxy", True, "running"))
+@patch("terok_executor.preflight.check_podman", return_value=CheckResult("podman", True, "ok"))
+def test_preflight_creds_fixed_interactively(
+    _pod: MagicMock,
+    _proxy: MagicMock,
+    _creds: MagicMock,
+    _imgs: MagicMock,
+    _shield: MagicMock,
+    _confirm: MagicMock,
+    _fix: MagicMock,
+    _hints: MagicMock,
+) -> None:
+    """Missing credentials + interactive fix → returns True."""
+    assert run_preflight("claude", interactive=True) is True
+    _fix.assert_called_once_with("claude")


### PR DESCRIPTION
## Summary

- Add `preflight.py` module with prerequisite checks: podman, credential proxy, agent credentials, container images, shield (informational)
- Wire preflight into `_handle_run()` — runs before `AgentRunner` is created
- In interactive mode (TTY): offers to start proxy, authenticate agent, build images
- In non-interactive mode: reports problems with fix hints, exits non-zero
- After successful preflight, hints about other available tools (`terok-executor auth <name>`)
- Add `terok-executor setup` command for explicit status check (`--check` for CI)
- 17 new unit tests for all check functions and orchestrator logic

Closes #168

## Example output (newcomer, first run)

```
  [1/4] podman... ok
  [2/4] credential proxy... not running
        Start credential proxy? [Y/n] y
  [2/4] credential proxy... started
  [3/4] claude credentials... not found
        Authenticate claude now? [Y/n] y
        [interactive auth flow]
  [3/4] claude credentials... authenticated
  [4/4] container images... not built
        Building agent images (this may take a few minutes)...
  [4/4] container images... built

  Hint: authenticate additional tools with: terok-executor auth <name>
        Available: codex, copilot, gh, glab, opencode, vibe

Launching claude on ./myproject...
```

## Test plan

- [ ] 17 new unit tests + 2 existing tests updated for preflight mock
- [ ] `make check` passes (lint, tests, tach, security, docstrings, reuse)
- [ ] Manual: `terok-executor run claude . --interactive` on clean system triggers preflight
- [ ] Manual: `terok-executor setup` reports status
- [ ] Manual: `terok-executor setup --check` exits non-zero when prerequisites missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `setup` command to verify system prerequisites and configuration status.
  * Integrated preflight validation before execution with interactive prompts to resolve missing components (podman, credentials, container images).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->