### PR TITLE
feat: roster-driven selectable agents in L1 image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.83"
+version = "0.0.84"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -89,7 +89,13 @@ from .provider.providers import (
 )
 
 # -- Roster (agent catalog + config resolution) --------------------------------
-from .roster import CredentialProxyRoute, SidecarSpec, ensure_proxy_routes, get_roster
+from .roster import (
+    CredentialProxyRoute,
+    SidecarSpec,
+    ensure_proxy_routes,
+    get_roster,
+    parse_agent_selection,
+)
 
 # -- Storage queries (filesystem footprint measurement) -------------------------
 from .storage import (
@@ -173,6 +179,7 @@ __all__ = [
     # Roster
     "SidecarSpec",
     "get_roster",
+    "parse_agent_selection",
     # Command registry
     "AGENT_COMMANDS",
     "PROXY_COMMANDS",

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -33,7 +33,9 @@ from .commands import COMMANDS as AGENT_COMMANDS, CommandDef
 
 # -- Container (build, env assembly, runner) -----------------------------------
 from .container.build import (
+    AGENTS_LABEL,
     DEFAULT_BASE_IMAGE,
+    INSTALLED_ENV_PATH,
     BuildError,
     ImageSet,
     build_base_images,
@@ -149,7 +151,9 @@ __all__ = [
     "ConfigStack",
     "resolve_provider_value",
     # Build: image construction + resource staging
+    "AGENTS_LABEL",
     "DEFAULT_BASE_IMAGE",
+    "INSTALLED_ENV_PATH",
     "BuildError",
     "ImageSet",
     "build_base_images",

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -248,6 +248,7 @@ def _handle_build(
     *,
     base: str = "ubuntu:24.04",
     family: str | None = None,
+    agents: str = "all",
     rebuild: bool = False,
     full_rebuild: bool = False,
     sidecar: bool = False,
@@ -255,8 +256,14 @@ def _handle_build(
     """Build L0+L1 container images (optionally include sidecar L1)."""
     from .container.build import BuildError, build_base_images, build_sidecar_image
 
+    selection: str | tuple[str, ...] = "all"
+    if agents != "all":
+        selection = tuple(name.strip() for name in agents.split(",") if name.strip())
+
     try:
-        images = build_base_images(base, family=family, rebuild=rebuild, full_rebuild=full_rebuild)
+        images = build_base_images(
+            base, family=family, agents=selection, rebuild=rebuild, full_rebuild=full_rebuild
+        )
     except BuildError as e:
         raise SystemExit(str(e)) from e
     print(f"\nL0: {images.l0}")
@@ -443,6 +450,11 @@ BUILD_COMMAND = CommandDef(
             name="--family",
             default=None,
             help="Override package family for unknown base images (deb or rpm)",
+        ),
+        ArgDef(
+            name="--agents",
+            default="all",
+            help='Comma-separated roster entries to install, or "all" (default).',
         ),
         ArgDef(name="--rebuild", action="store_true", help="Force rebuild (cache bust)"),
         ArgDef(name="--full-rebuild", action="store_true", help="Force --no-cache --pull=always"),

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -255,10 +255,9 @@ def _handle_build(
 ) -> None:
     """Build L0+L1 container images (optionally include sidecar L1)."""
     from .container.build import BuildError, build_base_images, build_sidecar_image
+    from .roster.loader import parse_agent_selection
 
-    selection: str | tuple[str, ...] = "all"
-    if agents != "all":
-        selection = tuple(name.strip() for name in agents.split(",") if name.strip())
+    selection = parse_agent_selection(agents)
 
     try:
         images = build_base_images(

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -264,7 +264,9 @@ def _handle_build(
         images = build_base_images(
             base, family=family, agents=selection, rebuild=rebuild, full_rebuild=full_rebuild
         )
-    except BuildError as e:
+    except (BuildError, ValueError) as e:
+        # ValueError is raised by resolve_selection() for unknown agent names
+        # — surface it as a clean CLI message rather than a traceback.
         raise SystemExit(str(e)) from e
     print(f"\nL0: {images.l0}")
     print(f"L1: {images.l1}")

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -440,7 +440,9 @@ def render_l1(
     installs = roster.installs
 
     root_snippets = [
-        _render_snippet(installs[n].run_as_root, family) for n in selected if installs[n].run_as_root
+        _render_snippet(installs[n].run_as_root, family)
+        for n in selected
+        if installs[n].run_as_root
     ]
     dev_snippets = [
         _render_snippet(installs[n].run_as_dev, family) for n in selected if installs[n].run_as_dev

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -49,8 +49,11 @@ import subprocess
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import lru_cache
 from importlib import resources
 from pathlib import Path
+
+from jinja2 import BaseLoader, Environment
 
 # ── Vocabulary ──
 
@@ -638,6 +641,14 @@ def _base_tag(base_image: str) -> str:
     return tag
 
 
+@lru_cache(maxsize=1)
+def _jinja_env() -> Environment:
+    """Shared stateless Jinja2 environment for all Dockerfile rendering."""
+    return Environment(  # nosec B701 — Dockerfile output, not HTML
+        loader=BaseLoader(), keep_trailing_newline=True, autoescape=False
+    )
+
+
 def _render_template(template_name: str, variables: dict[str, str]) -> str:
     """Render a Jinja2 Dockerfile template from package resources.
 
@@ -645,34 +656,19 @@ def _render_template(template_name: str, variables: dict[str, str]) -> str:
     branch on a ``family`` variable (``deb``/``rpm``); the L1 template
     also iterates over pre-rendered per-agent install snippets.
     """
-    from jinja2 import BaseLoader, Environment
-
     raw = (resources.files("terok_executor") / "resources" / "templates" / template_name).read_text(
         encoding="utf-8"
     )
-    env = Environment(  # nosec B701 — Dockerfile output, not HTML
-        loader=BaseLoader(), keep_trailing_newline=True, autoescape=False
-    )
-    tmpl = env.from_string(raw)
-    return tmpl.render(**variables)
+    return _jinja_env().from_string(raw).render(**variables)
 
 
 def _render_snippet(snippet: str, family: str) -> str:
-    """Render a per-agent install snippet as a Jinja string with *family* in scope.
+    """Render a per-agent install snippet with *family* in Jinja scope.
 
-    Roster install snippets are stored as plain Dockerfile text in each
-    agent YAML.  They may contain ``{% if family == "deb" %}…{% else %}…
-    {% endif %}`` branches so that package-manager-specific commands
-    (apt vs dnf, .deb vs .rpm download) live alongside the rest of the
-    agent's install steps.  Non-family-aware snippets pass through
-    unchanged.
+    Roster install snippets may contain ``{% if family == "deb" %}…{% else %}…
+    {% endif %}`` branches; non-family-aware snippets pass through unchanged.
     """
-    from jinja2 import BaseLoader, Environment
-
-    env = Environment(  # nosec B701 — Dockerfile output, not HTML
-        loader=BaseLoader(), keep_trailing_newline=True, autoescape=False
-    )
-    return env.from_string(snippet).render(family=family)
+    return _jinja_env().from_string(snippet).render(family=family)
 
 
 def _copy_package_tree(package: str, rel_path: str, dest: Path) -> None:

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -571,14 +571,18 @@ def l1_image_tag(base_image: str, agents: tuple[str, ...] | None = None) -> str:
     When *agents* is ``None``, returns the unsuffixed alias
     (e.g. ``terok-l1-cli:ubuntu-24.04``) — the moving handle that always
     points at the most recent build.  When *agents* is a tuple of names,
-    appends a sorted ``+a+b+c`` suffix so multiple selections can coexist
-    in the local image store and stay individually addressable.
+    appends a sorted ``-a-b-c`` suffix (``-`` is the only spec-valid
+    separator that ``_base_tag`` already uses) so multiple selections
+    coexist in the local image store and stay individually addressable.
+    Agent name fragments are passed through the same ``_base_tag``
+    sanitiser to keep the final tag within the OCI tag charset
+    (``[A-Za-z0-9_.-]``).
     """
     base = f"terok-l1-cli:{_base_tag(base_image)}"
     if agents is None:
         return base
-    suffix = "+".join(sorted(agents)) if agents else "empty"
-    return f"{base}+{suffix}"
+    suffix = "-".join(_base_tag(a) for a in sorted(agents)) if agents else "empty"
+    return f"{base}-{suffix}"
 
 
 def l1_sidecar_image_tag(base_image: str) -> str:

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -30,6 +30,13 @@ Usage as a library::
 The L0/L1 templates select between Debian/Ubuntu (``apt``) and Fedora-like
 (``dnf``) package managers via a ``family`` Jinja2 variable resolved by
 :func:`detect_family` from the base image name (or an explicit override).
+
+L1 is roster-driven: each agent's install steps live in its YAML file
+(``install.run_as_root`` / ``install.run_as_dev``), and the L1 template
+loops over the resolved selection.  Build emits an OCI label
+``ai.terok.agents=<csv>``, an in-container manifest
+``/etc/terok/installed.env``, and pre-rendered ``hilfe`` help fragments —
+all derived from the same selection.
 """
 
 from __future__ import annotations
@@ -140,6 +147,7 @@ def build_base_images(
     base_image: str = DEFAULT_BASE_IMAGE,
     *,
     family: str | None = None,
+    agents: str | tuple[str, ...] = "all",
     rebuild: bool = False,
     full_rebuild: bool = False,
     build_dir: Path | None = None,
@@ -155,6 +163,10 @@ def build_base_images(
         base_image: Base OS image (e.g. ``ubuntu:24.04``, ``nvidia/cuda:...``).
         family: Override for the package family (``"deb"`` or ``"rpm"``).
             ``None`` means detect from *base_image* via :func:`detect_family`.
+        agents: Roster entries to install, as the literal string ``"all"``
+            (every entry) or a tuple of names (transitively expanded by
+            ``depends_on``).  Same selection drives the OCI label, the L1
+            tag suffix, the in-container manifest, and the help fragments.
         rebuild: Force rebuild with cache bust (refreshes agent installs).
         full_rebuild: Force rebuild with ``--no-cache --pull=always``.
         build_dir: Build context directory (must be empty or absent).
@@ -165,14 +177,20 @@ def build_base_images(
     Raises:
         BuildError: If podman is missing, the family cannot be resolved,
             or a build step fails.
-        ValueError: If *build_dir* is a file or a non-empty directory.
+        ValueError: If *build_dir* is a file or a non-empty directory,
+            or if *agents* contains unknown roster entries.
     """
+    from terok_executor.roster.loader import get_roster
+
     _validate_build_dir(build_dir)
     _check_podman()
 
     base_image = _normalize_base_image(base_image)
+    selected = get_roster().resolve_selection(agents)
+
     l0_tag = l0_image_tag(base_image)
-    l1_tag = l1_image_tag(base_image)
+    l1_tag = l1_image_tag(base_image, selected)
+    l1_alias = l1_image_tag(base_image)  # unsuffixed "latest" alias
 
     # Skip if both images exist and no forced rebuild — done before
     # detect_family() so cached images for unknown bases (built earlier
@@ -191,6 +209,7 @@ def build_base_images(
 
     try:
         prepare_build_context(context)
+        stage_help_fragments(context / "help.d", selected)
 
         # Single timestamp for both render and build-arg consistency
         cache_bust = str(int(time.time()))
@@ -198,7 +217,7 @@ def build_base_images(
         # Render and write Dockerfiles into the build context
         (context / "L0.Dockerfile").write_text(render_l0(base_image, family=fam))
         (context / "L1.cli.Dockerfile").write_text(
-            render_l1(l0_tag, family=fam, cache_bust=cache_bust)
+            render_l1(l0_tag, family=fam, agents=selected, cache_bust=cache_bust)
         )
 
         ctx = str(context)
@@ -214,11 +233,13 @@ def build_base_images(
         print("$", shlex.join(cmd_l0))
         subprocess.run(cmd_l0, check=True)
 
-        # Build L1 — agent CLI layer (all agent installs, shell env, ACP wrappers)
+        # Build L1 — agent CLI layer (selected agents, shell env, ACP wrappers).
+        # Tagged twice: with the agent-set suffix (addressable, coexists with
+        # other selections) and with the unsuffixed alias (most-recent build).
         cmd_l1 = ["podman", "build", "-f", str(context / "L1.cli.Dockerfile")]
         cmd_l1 += ["--build-arg", f"BASE_IMAGE={l0_tag}"]
         cmd_l1 += ["--build-arg", f"AGENT_CACHE_BUST={cache_bust}"]
-        cmd_l1 += ["-t", l1_tag]
+        cmd_l1 += ["-t", l1_tag, "-t", l1_alias]
         if full_rebuild:
             cmd_l1.append("--no-cache")
         cmd_l1.append(ctx)
@@ -360,19 +381,53 @@ def render_l0(base_image: str = DEFAULT_BASE_IMAGE, *, family: str | None = None
     )
 
 
-def render_l1(l0_image: str, *, family: str, cache_bust: str = "0") -> str:
-    """Render the L1 (agent CLI) Dockerfile.
+def render_l1(
+    l0_image: str,
+    *,
+    family: str,
+    agents: tuple[str, ...] | str = "all",
+    cache_bust: str = "0",
+) -> str:
+    """Render the L1 (agent CLI) Dockerfile for the given agent selection.
 
     *l0_image* is the tag of the L0 image to build on top of.  *family*
     (``"deb"`` or ``"rpm"``) selects the package-manager branch and is
-    required — there is no L0 reference to detect from at this point,
-    so callers must supply the value resolved at the L0 level (typically
-    via :func:`detect_family`).  *cache_bust* invalidates the agent-install
-    layers when changed (typically set to a Unix timestamp).
+    required — there is no L0 reference to detect from at this point, so
+    callers must supply the value resolved at the L0 level (typically via
+    :func:`detect_family`).  Each roster install snippet is itself rendered
+    as a Jinja template with ``family`` in scope, so snippets can carry
+    ``{% if family == "deb" %}…{% else %}…{% endif %}`` branches for
+    package-manager-specific commands.  *agents* is a tuple of
+    already-resolved roster names (or the literal string ``"all"``); the
+    template loops over them and emits each one's install snippets.
+    *cache_bust* invalidates the per-agent install layers when changed
+    (typically set to a Unix timestamp).
     """
+    from terok_executor.roster.loader import get_roster
+
+    roster = get_roster()
+    # resolve_selection is idempotent on already-expanded tuples, so callers
+    # may pass either a raw user selection or a pre-resolved one.
+    selected = roster.resolve_selection(agents)
+    installs = roster.installs
+
+    root_snippets = [
+        _render_snippet(installs[n].run_as_root, family) for n in selected if installs[n].run_as_root
+    ]
+    dev_snippets = [
+        _render_snippet(installs[n].run_as_dev, family) for n in selected if installs[n].run_as_dev
+    ]
+
     return _render_template(
         "l1.agent-cli.Dockerfile.template",
-        {"BASE_IMAGE": l0_image, "AGENT_CACHE_BUST": cache_bust, "family": family},
+        {
+            "BASE_IMAGE": l0_image,
+            "AGENT_CACHE_BUST": cache_bust,
+            "family": family,
+            "install_root_snippets": root_snippets,
+            "install_dev_snippets": dev_snippets,
+            "installed_agents_csv": ",".join(selected),
+        },
     )
 
 
@@ -429,6 +484,38 @@ def stage_toad_agents(dest: Path) -> None:
     _clean_packaging_artifacts(dest)
 
 
+def stage_help_fragments(dest: Path, agents: tuple[str, ...]) -> None:
+    """Render per-section ``hilfe`` help fragments into *dest*.
+
+    Writes one file per section (currently ``agent`` and ``dev_tool``)
+    containing the labels of the selected agents that have a ``help:``
+    section, with backslash escapes (``\\033[...]``) interpreted into
+    real ANSI sequences so that ``hilfe`` only needs to ``cat`` them.
+    Empty sections are omitted entirely; ``hilfe`` skips missing files.
+    """
+    from terok_executor.roster.loader import get_roster
+
+    roster = get_roster()
+    helps = roster.helps
+
+    by_section: dict[str, list[str]] = {}
+    for name in agents:
+        spec = helps.get(name)
+        if spec is None or not spec.label:
+            continue
+        by_section.setdefault(spec.section, []).append(spec.label)
+
+    section_files = {"agent": "agents.txt", "dev_tool": "dev-tools.txt"}
+
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    for section, lines in by_section.items():
+        filename = section_files.get(section, f"{section}.txt")
+        decoded = "".join(bytes(line, "utf-8").decode("unicode_escape") + "\n" for line in lines)
+        (dest / filename).write_text(decoded, encoding="utf-8")
+
+
 def stage_tmux_config(dest: Path) -> None:
     """Stage the container tmux configuration into *dest*.
 
@@ -449,9 +536,20 @@ def l0_image_tag(base_image: str) -> str:
     return f"terok-l0:{_base_tag(base_image)}"
 
 
-def l1_image_tag(base_image: str) -> str:
-    """Return the L1 agent CLI image tag for *base_image*."""
-    return f"terok-l1-cli:{_base_tag(base_image)}"
+def l1_image_tag(base_image: str, agents: tuple[str, ...] | None = None) -> str:
+    """Return the L1 agent CLI image tag for *base_image* and a selection.
+
+    When *agents* is ``None``, returns the unsuffixed alias
+    (e.g. ``terok-l1-cli:ubuntu-24.04``) — the moving handle that always
+    points at the most recent build.  When *agents* is a tuple of names,
+    appends a sorted ``+a+b+c`` suffix so multiple selections can coexist
+    in the local image store and stay individually addressable.
+    """
+    base = f"terok-l1-cli:{_base_tag(base_image)}"
+    if agents is None:
+        return base
+    suffix = "+".join(sorted(agents)) if agents else "empty"
+    return f"{base}+{suffix}"
 
 
 def l1_sidecar_image_tag(base_image: str) -> str:
@@ -510,10 +608,9 @@ def _base_tag(base_image: str) -> str:
 def _render_template(template_name: str, variables: dict[str, str]) -> str:
     """Render a Jinja2 Dockerfile template from package resources.
 
-    Templates live in ``resources/templates/``.  Currently they use
-    Dockerfile ``ARG``/``${VAR}`` syntax (Jinja2 is a pass-through).
-    Future L1 templatisation will use ``{% for agent %}`` loops driven
-    by the YAML agent roster.
+    Templates live in ``resources/templates/``.  The L0/L1 templates
+    branch on a ``family`` variable (``deb``/``rpm``); the L1 template
+    also iterates over pre-rendered per-agent install snippets.
     """
     from jinja2 import BaseLoader, Environment
 
@@ -525,6 +622,24 @@ def _render_template(template_name: str, variables: dict[str, str]) -> str:
     )
     tmpl = env.from_string(raw)
     return tmpl.render(**variables)
+
+
+def _render_snippet(snippet: str, family: str) -> str:
+    """Render a per-agent install snippet as a Jinja string with *family* in scope.
+
+    Roster install snippets are stored as plain Dockerfile text in each
+    agent YAML.  They may contain ``{% if family == "deb" %}…{% else %}…
+    {% endif %}`` branches so that package-manager-specific commands
+    (apt vs dnf, .deb vs .rpm download) live alongside the rest of the
+    agent's install steps.  Non-family-aware snippets pass through
+    unchanged.
+    """
+    from jinja2 import BaseLoader, Environment
+
+    env = Environment(  # nosec B701 — Dockerfile output, not HTML
+        loader=BaseLoader(), keep_trailing_newline=True, autoescape=False
+    )
+    return env.from_string(snippet).render(family=family)
 
 
 def _copy_package_tree(package: str, rel_path: str, dest: Path) -> None:

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -93,6 +93,17 @@ def _decode_label_escapes(text: str) -> str:
 _DEFAULT_TAG = "ubuntu-24.04"
 """Pre-sanitized tag fragment for the default base image."""
 
+_MAX_TAG_LEN = 120
+"""Cap on the tag portion of an OCI image reference.
+
+OCI spec allows 128; the extra headroom absorbs future suffix changes
+without rebuilding history.  Both :func:`_base_tag` (for the L0 tag)
+and :func:`l1_image_tag` (for the L1 base+agents tag) respect this.
+"""
+
+_AGENT_DIGEST_LEN = 12
+"""SHA1-prefix length for the fallback agent-suffix digest."""
+
 # Map of known base-image prefixes to their package family.  Each entry
 # is either a literal ``"deb"``/``"rpm"`` or a tag-aware resolver — used
 # for NVIDIA, where the same repo path ships both Ubuntu (apt) and UBI
@@ -580,12 +591,29 @@ def l1_image_tag(base_image: str, agents: tuple[str, ...] | None = None) -> str:
     Agent name fragments are passed through the same ``_base_tag``
     sanitiser to keep the final tag within the OCI tag charset
     (``[A-Za-z0-9_.-]``).
+
+    The full tag (after ``:``) is bounded by :data:`_MAX_TAG_LEN`.  When
+    the readable ``base-a-b-c`` form would overflow, the agent portion
+    is replaced with a SHA1 digest of the sorted selection — same
+    collision-resistant fallback pattern :func:`_base_tag` uses
+    internally for overlong image names.
     """
-    base = f"terok-l1-cli:{_base_tag(base_image)}"
+    base_tag = _base_tag(base_image)
     if agents is None:
-        return base
-    suffix = "-".join(_base_tag(a) for a in sorted(agents)) if agents else "empty"
-    return f"{base}-{suffix}"
+        return f"terok-l1-cli:{base_tag}"
+    readable_suffix = "-".join(_base_tag(a) for a in sorted(agents)) if agents else "empty"
+    if len(base_tag) + 1 + len(readable_suffix) <= _MAX_TAG_LEN:
+        return f"terok-l1-cli:{base_tag}-{readable_suffix}"
+    suffix = hashlib.sha1(
+        ",".join(sorted(agents)).encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:_AGENT_DIGEST_LEN]
+    # Pathological case: a base already near _MAX_TAG_LEN leaves no room
+    # even for the digest.  Trim base_tag further — same collision-resistant
+    # shape as the digest fallback itself.
+    max_base = _MAX_TAG_LEN - 1 - _AGENT_DIGEST_LEN
+    if len(base_tag) > max_base:
+        base_tag = base_tag[:max_base]
+    return f"terok-l1-cli:{base_tag}-{suffix}"
 
 
 def l1_sidecar_image_tag(base_image: str) -> str:

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -66,6 +66,27 @@ INSTALLED_ENV_PATH = "/etc/terok/installed.env"
 _HELP_SECTION_FILES: dict[str, str] = {"agent": "agents.txt", "dev_tool": "dev-tools.txt"}
 """Maps each :class:`~terok_executor.roster.loader.HelpSection` to its fragment filename."""
 
+_ESCAPE_RE = re.compile(r"\\(?:[0-7]{1,3}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|[nrtbfav\\'\"])")
+"""Backslash escapes recognised in roster ``help.label`` strings.
+
+Matches octal (``\\033``), hex (``\\x1b``), 4-digit Unicode (``\\u1234``),
+and the standard one-letter forms — nothing wider, so the surrounding
+text (which may contain non-ASCII characters) is preserved verbatim.
+"""
+
+
+def _decode_label_escapes(text: str) -> str:
+    """Expand backslash escapes in *text* without disturbing non-ASCII content.
+
+    The straight ``bytes(text, "utf-8").decode("unicode_escape")`` round-trip
+    re-interprets every UTF-8 byte as Latin-1 and mojibakes anything outside
+    ASCII (e.g. ``"ä"`` becomes ``"Ã¤"``).  We only want to expand explicit
+    backslash escapes, so we substitute one match at a time — each match
+    is pure ASCII, making the per-match round-trip safe.
+    """
+    return _ESCAPE_RE.sub(lambda m: m.group().encode("ascii").decode("unicode_escape"), text)
+
+
 _DEFAULT_TAG = "ubuntu-24.04"
 """Pre-sanitized tag fragment for the default base image."""
 
@@ -518,7 +539,7 @@ def stage_help_fragments(dest: Path, agents: tuple[str, ...]) -> None:
         shutil.rmtree(dest)
     dest.mkdir(parents=True, exist_ok=True)
     for section, lines in by_section.items():
-        decoded = "".join(bytes(line, "utf-8").decode("unicode_escape") + "\n" for line in lines)
+        decoded = "".join(_decode_label_escapes(line) + "\n" for line in lines)
         (dest / _HELP_SECTION_FILES[section]).write_text(decoded, encoding="utf-8")
 
 

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -57,6 +57,15 @@ from pathlib import Path
 DEFAULT_BASE_IMAGE = "ubuntu:24.04"
 """Default base OS image when none is specified."""
 
+AGENTS_LABEL = "ai.terok.agents"
+"""OCI label naming the roster entries baked into an L1 image."""
+
+INSTALLED_ENV_PATH = "/etc/terok/installed.env"
+"""In-container env file that scripts source to learn what's installed."""
+
+_HELP_SECTION_FILES: dict[str, str] = {"agent": "agents.txt", "dev_tool": "dev-tools.txt"}
+"""Maps each :class:`~terok_executor.roster.loader.HelpSection` to its fragment filename."""
+
 _DEFAULT_TAG = "ubuntu-24.04"
 """Pre-sanitized tag fragment for the default base image."""
 
@@ -190,7 +199,7 @@ def build_base_images(
 
     l0_tag = l0_image_tag(base_image)
     l1_tag = l1_image_tag(base_image, selected)
-    l1_alias = l1_image_tag(base_image)  # unsuffixed "latest" alias
+    l1_alias = l1_image_tag(base_image)
 
     # Skip if both images exist and no forced rebuild — done before
     # detect_family() so cached images for unknown bases (built earlier
@@ -233,9 +242,9 @@ def build_base_images(
         print("$", shlex.join(cmd_l0))
         subprocess.run(cmd_l0, check=True)
 
-        # Build L1 — agent CLI layer (selected agents, shell env, ACP wrappers).
-        # Tagged twice: with the agent-set suffix (addressable, coexists with
-        # other selections) and with the unsuffixed alias (most-recent build).
+        # The unsuffixed alias lets `terok run` find the latest L1 without
+        # knowing the agent-set suffix; the suffixed tag keeps prior selections
+        # individually addressable.
         cmd_l1 = ["podman", "build", "-f", str(context / "L1.cli.Dockerfile")]
         cmd_l1 += ["--build-arg", f"BASE_IMAGE={l0_tag}"]
         cmd_l1 += ["--build-arg", f"AGENT_CACHE_BUST={cache_bust}"]
@@ -406,8 +415,6 @@ def render_l1(
     from terok_executor.roster.loader import get_roster
 
     roster = get_roster()
-    # resolve_selection is idempotent on already-expanded tuples, so callers
-    # may pass either a raw user selection or a pre-resolved one.
     selected = roster.resolve_selection(agents)
     installs = roster.installs
 
@@ -427,6 +434,8 @@ def render_l1(
             "install_root_snippets": root_snippets,
             "install_dev_snippets": dev_snippets,
             "installed_agents_csv": ",".join(selected),
+            "agents_label": AGENTS_LABEL,
+            "installed_env_path": INSTALLED_ENV_PATH,
         },
     )
 
@@ -505,15 +514,12 @@ def stage_help_fragments(dest: Path, agents: tuple[str, ...]) -> None:
             continue
         by_section.setdefault(spec.section, []).append(spec.label)
 
-    section_files = {"agent": "agents.txt", "dev_tool": "dev-tools.txt"}
-
     if dest.exists():
         shutil.rmtree(dest)
     dest.mkdir(parents=True, exist_ok=True)
     for section, lines in by_section.items():
-        filename = section_files.get(section, f"{section}.txt")
         decoded = "".join(bytes(line, "utf-8").decode("unicode_escape") + "\n" for line in lines)
-        (dest / filename).write_text(decoded, encoding="utf-8")
+        (dest / _HELP_SECTION_FILES[section]).write_text(decoded, encoding="utf-8")
 
 
 def stage_tmux_config(dest: Path) -> None:

--- a/src/terok_executor/resources/agents/blablador.yaml
+++ b/src/terok_executor/resources/agents/blablador.yaml
@@ -47,3 +47,16 @@ opencode:
 
 # OpenCode runtime mounts are defined in opencode.yaml and deduplicated
 # by the registry — no need to repeat them here.
+
+install:
+  # All blablador wrappers are symlinks to the opencode-provider family;
+  # selecting blablador transitively pulls opencode in.
+  depends_on: [opencode]
+  run_as_root: |
+    RUN set -eux; \
+        ln -sf opencode-provider     /usr/local/bin/blablador; \
+        ln -sf opencode-provider-acp /usr/local/bin/blablador-acp; \
+        ln -sf opencode-toad         /usr/local/bin/blablatoad
+
+help:
+  label: '  \033[36mblablador\033[0m  - OpenCode with Helmholtz Blablador'

--- a/src/terok_executor/resources/agents/claude.yaml
+++ b/src/terok_executor/resources/agents/claude.yaml
@@ -67,3 +67,22 @@ auth:
   post_capture_state:               # JSON state merged into auth mount after capture
     .claude.json:
       hasCompletedOnboarding: true
+
+install:
+  # /etc/claude-code is the managed-config directory for per-task permission
+  # mode; init-ssh-and-repo.sh writes here when TEROK_UNRESTRICTED=1.
+  run_as_root: |
+    RUN set -eux; \
+        cp /tmp/terok-scripts/terok-claude-acp /usr/local/bin/terok-claude-acp; \
+        chmod +x /usr/local/bin/terok-claude-acp; \
+        mkdir -p /etc/claude-code && chown dev:dev /etc/claude-code
+  # The claude-agent-acp npm package backs the terok-claude-acp wrapper
+  # (needed for ACP clients like Toad to drive Claude).
+  run_as_dev: |
+    RUN set -eux; \
+        npm install -g @agentclientprotocol/claude-agent-acp; \
+        npm cache clean --force
+    RUN curl -fsSL https://claude.ai/install.sh | bash
+
+help:
+  label: '  \033[36mclaude\033[0m     - Claude Code CLI'

--- a/src/terok_executor/resources/agents/codex.yaml
+++ b/src/terok_executor/resources/agents/codex.yaml
@@ -44,3 +44,17 @@ auth:
     After completing authentication, press Ctrl+C to stop the container.
   extra_run_args: ["-p", "127.0.0.1:1455:1455"]
   api_key_hint: "Get your API key at: https://platform.openai.com/api-keys"
+
+install:
+  run_as_root: |
+    RUN set -eux; \
+        cp /tmp/terok-scripts/terok-codex-acp /usr/local/bin/terok-codex-acp; \
+        cp /tmp/terok-scripts/setup-codex-auth.sh /usr/local/bin/setup-codex-auth.sh; \
+        chmod +x /usr/local/bin/terok-codex-acp /usr/local/bin/setup-codex-auth.sh
+  run_as_dev: |
+    RUN set -eux; \
+        npm install -g @openai/codex; \
+        npm cache clean --force
+
+help:
+  label: '  \033[36mcodex\033[0m      - OpenAI Codex CLI'

--- a/src/terok_executor/resources/agents/copilot.yaml
+++ b/src/terok_executor/resources/agents/copilot.yaml
@@ -22,3 +22,16 @@ session:
 
 capabilities:
   log_format: plain
+
+install:
+  run_as_root: |
+    RUN set -eux; \
+        cp /tmp/terok-scripts/terok-copilot-acp /usr/local/bin/terok-copilot-acp; \
+        chmod +x /usr/local/bin/terok-copilot-acp
+  run_as_dev: |
+    RUN set -eux; \
+        npm install -g @github/copilot; \
+        npm cache clean --force
+
+help:
+  label: '  \033[36mcopilot\033[0m    - GitHub Copilot CLI'

--- a/src/terok_executor/resources/agents/gh.yaml
+++ b/src/terok_executor/resources/agents/gh.yaml
@@ -27,3 +27,16 @@ auth:
     You will be guided through GitHub authentication.
     Recommended: choose 'Login with a web browser' or paste a token.
   api_key_hint: "Paste a GitHub personal access token (https://github.com/settings/tokens)"
+
+install:
+  # The gh apt source is pre-registered in the L1 prelude alongside NodeSource.
+  # Here we only refresh the index and install the package.
+  run_as_root: |
+    RUN set -eux; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends gh; \
+        rm -rf /var/lib/apt/lists/*
+
+help:
+  label: '  \033[36mgh\033[0m         - GitHub CLI'
+  section: dev_tool

--- a/src/terok_executor/resources/agents/gh.yaml
+++ b/src/terok_executor/resources/agents/gh.yaml
@@ -29,13 +29,27 @@ auth:
   api_key_hint: "Paste a GitHub personal access token (https://github.com/settings/tokens)"
 
 install:
-  # The gh apt source is pre-registered in the L1 prelude alongside NodeSource.
-  # Here we only refresh the index and install the package.
+  # Register the official GitHub package source, then install gh.  Both
+  # branches land the same binary in $PATH; the template picks which one
+  # runs based on the resolved family.
   run_as_root: |
+    {% if family == "deb" %}
     RUN set -eux; \
+        mkdir -p /etc/apt/keyrings; \
+        curl -sSL -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+          "https://cli.github.com/packages/githubcli-archive-keyring.gpg"; \
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+          > /etc/apt/sources.list.d/github-cli.list; \
         apt-get update; \
         apt-get install -y --no-install-recommends gh; \
         rm -rf /var/lib/apt/lists/*
+    {% else %}
+    RUN set -eux; \
+        curl -fsSL -o /etc/yum.repos.d/gh-cli.repo \
+          "https://cli.github.com/packages/rpm/gh-cli.repo"; \
+        dnf install -y gh; \
+        dnf clean all
+    {% endif %}
 
 help:
   label: '  \033[36mgh\033[0m         - GitHub CLI'

--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -22,17 +22,23 @@ auth:
   api_key_hint: "Create a personal access token at: https://gitlab.com/-/user_settings/personal_access_tokens"
 
 install:
+  # pipefail is needed because the checksum verification is a pipeline
+  # (grep | sed | sha256sum -c -); without it, an empty grep result would
+  # silently feed sha256sum nothing and exit 0, skipping verification.
   run_as_root: |
-    RUN set -eux; \
-        GLAB_VERSION=$(curl -sSL "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest" \
+    RUN set -eux -o pipefail; \
+        GLAB_VERSION=$(curl --fail -sSL "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest" \
           | jq -r '.tag_name | ltrimstr("v")'); \
         ARCH=$(dpkg --print-architecture); \
         DEB_NAME="glab_${GLAB_VERSION}_linux_${ARCH}.deb"; \
-        curl -sSL -o /tmp/glab.deb \
+        curl --fail -sSL -o /tmp/glab.deb \
           "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/${DEB_NAME}"; \
-        curl -sSL -o /tmp/checksums.txt \
+        curl --fail -sSL -o /tmp/checksums.txt \
           "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/checksums.txt"; \
-        grep "  ${DEB_NAME}$" /tmp/checksums.txt | sed "s|${DEB_NAME}|/tmp/glab.deb|" | sha256sum -c -; \
+        grep -q "  ${DEB_NAME}$" /tmp/checksums.txt \
+          || { echo "no checksum entry for ${DEB_NAME}" >&2; exit 1; }; \
+        grep "  ${DEB_NAME}$" /tmp/checksums.txt \
+          | sed "s|${DEB_NAME}|/tmp/glab.deb|" | sha256sum -c -; \
         dpkg -i /tmp/glab.deb; \
         rm -f /tmp/glab.deb /tmp/checksums.txt
 

--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -20,3 +20,22 @@ auth:
   container_mount: /home/dev/.config/glab-cli
   modes: [api_key]
   api_key_hint: "Create a personal access token at: https://gitlab.com/-/user_settings/personal_access_tokens"
+
+install:
+  run_as_root: |
+    RUN set -eux; \
+        GLAB_VERSION=$(curl -sSL "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest" \
+          | jq -r '.tag_name | ltrimstr("v")'); \
+        ARCH=$(dpkg --print-architecture); \
+        DEB_NAME="glab_${GLAB_VERSION}_linux_${ARCH}.deb"; \
+        curl -sSL -o /tmp/glab.deb \
+          "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/${DEB_NAME}"; \
+        curl -sSL -o /tmp/checksums.txt \
+          "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/checksums.txt"; \
+        grep "  ${DEB_NAME}$" /tmp/checksums.txt | sed "s|${DEB_NAME}|/tmp/glab.deb|" | sha256sum -c -; \
+        dpkg -i /tmp/glab.deb; \
+        rm -f /tmp/glab.deb /tmp/checksums.txt
+
+help:
+  label: '  \033[36mglab\033[0m       - GitLab CLI'
+  section: dev_tool

--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -22,25 +22,31 @@ auth:
   api_key_hint: "Create a personal access token at: https://gitlab.com/-/user_settings/personal_access_tokens"
 
 install:
-  # pipefail is needed because the checksum verification is a pipeline
-  # (grep | sed | sha256sum -c -); without it, an empty grep result would
-  # silently feed sha256sum nothing and exit 0, skipping verification.
+  # Arch detection uses `uname -m` so the snippet works on both deb and
+  # rpm hosts.  pipefail makes the checksum verification (grep | sed |
+  # sha256sum -c -) hard-fail rather than silently accept an empty grep.
   run_as_root: |
+    {% set pkg_ext = "deb" if family == "deb" else "rpm" %}
+    {% set pkg_install = "dpkg -i" if family == "deb" else "dnf install -y" %}
     RUN set -eux -o pipefail; \
         GLAB_VERSION=$(curl --fail -sSL "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest" \
           | jq -r '.tag_name | ltrimstr("v")'); \
-        ARCH=$(dpkg --print-architecture); \
-        DEB_NAME="glab_${GLAB_VERSION}_linux_${ARCH}.deb"; \
-        curl --fail -sSL -o /tmp/glab.deb \
-          "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/${DEB_NAME}"; \
+        case "$(uname -m)" in \
+          x86_64) ARCH=amd64 ;; \
+          aarch64) ARCH=arm64 ;; \
+          *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;; \
+        esac; \
+        PKG_NAME="glab_${GLAB_VERSION}_linux_${ARCH}.{{ pkg_ext }}"; \
+        curl --fail -sSL -o /tmp/glab.pkg \
+          "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/${PKG_NAME}"; \
         curl --fail -sSL -o /tmp/checksums.txt \
           "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/checksums.txt"; \
-        grep -q "  ${DEB_NAME}$" /tmp/checksums.txt \
-          || { echo "no checksum entry for ${DEB_NAME}" >&2; exit 1; }; \
-        grep "  ${DEB_NAME}$" /tmp/checksums.txt \
-          | sed "s|${DEB_NAME}|/tmp/glab.deb|" | sha256sum -c -; \
-        dpkg -i /tmp/glab.deb; \
-        rm -f /tmp/glab.deb /tmp/checksums.txt
+        grep -q "  ${PKG_NAME}$" /tmp/checksums.txt \
+          || { echo "no checksum entry for ${PKG_NAME}" >&2; exit 1; }; \
+        grep "  ${PKG_NAME}$" /tmp/checksums.txt \
+          | sed "s|${PKG_NAME}|/tmp/glab.pkg|" | sha256sum -c -; \
+        {{ pkg_install }} /tmp/glab.pkg; \
+        rm -f /tmp/glab.pkg /tmp/checksums.txt
 
 help:
   label: '  \033[36mglab\033[0m       - GitLab CLI'

--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -23,7 +23,11 @@ auth:
 
 install:
   # Arch detection uses `uname -m` so the snippet works on both deb and
-  # rpm hosts.  pipefail makes the checksum verification (grep | sed |
+  # rpm hosts.  The on-disk filename carries the family-specific
+  # extension (/tmp/glab.deb or /tmp/glab.rpm) because dnf5 only
+  # recognises local RPM files by their .rpm suffix — any other name
+  # is treated as a repo-package query and fails to resolve.
+  # pipefail makes the checksum verification (grep | sed |
   # sha256sum -c -) hard-fail rather than silently accept an empty grep.
   run_as_root: |
     {% set pkg_ext = "deb" if family == "deb" else "rpm" %}
@@ -37,16 +41,16 @@ install:
           *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;; \
         esac; \
         PKG_NAME="glab_${GLAB_VERSION}_linux_${ARCH}.{{ pkg_ext }}"; \
-        curl --fail -sSL -o /tmp/glab.pkg \
+        curl --fail -sSL -o /tmp/glab.{{ pkg_ext }} \
           "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/${PKG_NAME}"; \
         curl --fail -sSL -o /tmp/checksums.txt \
           "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/checksums.txt"; \
         grep -q "  ${PKG_NAME}$" /tmp/checksums.txt \
           || { echo "no checksum entry for ${PKG_NAME}" >&2; exit 1; }; \
         grep "  ${PKG_NAME}$" /tmp/checksums.txt \
-          | sed "s|${PKG_NAME}|/tmp/glab.pkg|" | sha256sum -c -; \
-        {{ pkg_install }} /tmp/glab.pkg; \
-        rm -f /tmp/glab.pkg /tmp/checksums.txt
+          | sed "s|${PKG_NAME}|/tmp/glab.{{ pkg_ext }}|" | sha256sum -c -; \
+        {{ pkg_install }} /tmp/glab.{{ pkg_ext }}; \
+        rm -f /tmp/glab.{{ pkg_ext }} /tmp/checksums.txt
 
 help:
   label: '  \033[36mglab\033[0m       - GitLab CLI'

--- a/src/terok_executor/resources/agents/kisski.yaml
+++ b/src/terok_executor/resources/agents/kisski.yaml
@@ -47,3 +47,14 @@ opencode:
 
 # OpenCode runtime mounts are defined in opencode.yaml and deduplicated
 # by the registry — no need to repeat them here.
+
+install:
+  depends_on: [opencode]
+  run_as_root: |
+    RUN set -eux; \
+        ln -sf opencode-provider     /usr/local/bin/kisski; \
+        ln -sf opencode-provider-acp /usr/local/bin/kisski-acp; \
+        ln -sf opencode-toad         /usr/local/bin/kisskitoad
+
+help:
+  label: '  \033[36mkisski\033[0m     - OpenCode with KISSKI'

--- a/src/terok_executor/resources/agents/opencode.yaml
+++ b/src/terok_executor/resources/agents/opencode.yaml
@@ -41,3 +41,23 @@ mounts:
   - host_dir: _opencode-state
     container_path: /home/dev/.local/state
     label: OpenCode state
+
+install:
+  # opencode-provider/-acp/-toad are wrappers used by both OpenCode itself
+  # and by every kind:opencode agent (blablador, kisski) via symlinks.
+  run_as_root: |
+    RUN set -eux; \
+        cp /tmp/terok-scripts/opencode-provider /usr/local/bin/opencode-provider; \
+        cp /tmp/terok-scripts/opencode-provider-acp /usr/local/bin/opencode-provider-acp; \
+        cp /tmp/terok-scripts/opencode-toad /usr/local/bin/opencode-toad; \
+        cp /tmp/terok-scripts/terok-opencode-acp /usr/local/bin/terok-opencode-acp; \
+        cp /tmp/terok-scripts/opencode-session-plugin.mjs /usr/local/share/terok/; \
+        chmod +x /usr/local/bin/opencode-provider \
+                 /usr/local/bin/opencode-provider-acp \
+                 /usr/local/bin/opencode-toad \
+                 /usr/local/bin/terok-opencode-acp
+  run_as_dev: |
+    RUN curl -fsSL https://opencode.ai/install | bash
+
+help:
+  label: '  \033[36mopencode\033[0m   - OpenCode CLI (\033[2mterok config import-opencode\033[0m)'

--- a/src/terok_executor/resources/agents/sonar.yaml
+++ b/src/terok_executor/resources/agents/sonar.yaml
@@ -27,11 +27,10 @@ install:
   run_as_root: |
     RUN set -eux; \
         SONAR_VERSION="8.0.1.6346"; \
-        ARCH=$(dpkg --print-architecture); \
-        case "$ARCH" in \
-          amd64) SA="linux-x64" ;; \
-          arm64) SA="linux-aarch64" ;; \
-          *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;; \
+        case "$(uname -m)" in \
+          x86_64) SA="linux-x64" ;; \
+          aarch64) SA="linux-aarch64" ;; \
+          *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;; \
         esac; \
         SONAR_ZIP="sonar-scanner-cli-${SONAR_VERSION}-${SA}.zip"; \
         MAVEN_BASE="https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_VERSION}"; \

--- a/src/terok_executor/resources/agents/sonar.yaml
+++ b/src/terok_executor/resources/agents/sonar.yaml
@@ -20,3 +20,30 @@ auth:
   container_mount: /home/dev/.sonar
   modes: [api_key]
   api_key_hint: "Generate a token at https://sonarcloud.io/account/security"
+
+install:
+  # SonarScanner CLI bundles its own JRE; multi-arch (amd64/arm64).
+  # Needs SONAR_TOKEN at runtime.
+  run_as_root: |
+    RUN set -eux; \
+        SONAR_VERSION="8.0.1.6346"; \
+        ARCH=$(dpkg --print-architecture); \
+        case "$ARCH" in \
+          amd64) SA="linux-x64" ;; \
+          arm64) SA="linux-aarch64" ;; \
+          *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;; \
+        esac; \
+        SONAR_ZIP="sonar-scanner-cli-${SONAR_VERSION}-${SA}.zip"; \
+        MAVEN_BASE="https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_VERSION}"; \
+        curl -fsSL -o /tmp/sonar-scanner.zip "${MAVEN_BASE}/${SONAR_ZIP}"; \
+        curl -fsSL -o /tmp/sonar-scanner.zip.sha256 "${MAVEN_BASE}/${SONAR_ZIP}.sha256"; \
+        echo "$(cat /tmp/sonar-scanner.zip.sha256)  /tmp/sonar-scanner.zip" | sha256sum -c -; \
+        unzip -q /tmp/sonar-scanner.zip -d /opt; \
+        mv "/opt/sonar-scanner-${SONAR_VERSION}-${SA}" /opt/sonar-scanner; \
+        ln -s /opt/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner; \
+        rm /tmp/sonar-scanner.zip; \
+        sonar-scanner --version
+
+help:
+  label: '  \033[36msonar-scanner\033[0m - SonarQube/SonarCloud static analysis (needs SONAR_TOKEN)'
+  section: dev_tool

--- a/src/terok_executor/resources/agents/toad.yaml
+++ b/src/terok_executor/resources/agents/toad.yaml
@@ -11,3 +11,20 @@ mounts:
   - host_dir: _toad-config
     container_path: /home/dev/.config/toad
     label: Toad config
+
+install:
+  # Toad needs Python ≥3.14; uv installs a standalone interpreter so the
+  # system Python stays untouched.  The uv-created symlink is removed so
+  # the wrapper at /usr/local/bin/toad takes precedence in PATH.
+  # toad-agents/ ships the bundled ACP launcher TOMLs.
+  run_as_root: |
+    COPY toad-agents/ /usr/local/share/terok/toad-agents/
+    RUN set -eux; \
+        cp /tmp/terok-scripts/toad /usr/local/bin/toad; \
+        chmod +x /usr/local/bin/toad
+  run_as_dev: |
+    RUN uv tool install batrachian-toad --python 3.14 \
+     && rm -f ~/.local/bin/toad
+
+help:
+  label: '  \033[36mtoad\033[0m       - Multi-agent TUI (ACP)'

--- a/src/terok_executor/resources/agents/vibe.yaml
+++ b/src/terok_executor/resources/agents/vibe.yaml
@@ -47,3 +47,18 @@ auth:
   container_mount: /home/dev/.vibe
   modes: [api_key]
   api_key_hint: "Get your API key at: https://console.mistral.ai/api-keys"
+
+install:
+  run_as_root: |
+    RUN set -eux; \
+        cp /tmp/terok-scripts/terok-vibe-acp /usr/local/bin/terok-vibe-acp; \
+        cp /tmp/terok-scripts/vibe-model-sync.sh /usr/local/bin/vibe-model-sync; \
+        cp /tmp/terok-scripts/mistral-model-sync.py /usr/local/bin/mistral-model-sync.py; \
+        chmod +x /usr/local/bin/terok-vibe-acp \
+                 /usr/local/bin/vibe-model-sync \
+                 /usr/local/bin/mistral-model-sync.py; \
+        pipx install mistral-vibe; \
+        pipx inject mistral-vibe mistralai
+
+help:
+  label: '  \033[36mvibe\033[0m       - Mistral Vibe CLI'

--- a/src/terok_executor/resources/scripts/hilfe
+++ b/src/terok_executor/resources/scripts/hilfe
@@ -28,24 +28,20 @@ _terok_permission_mode() {
     fi
 }
 
-_terok_executors() {
-    printf '\n\033[1mAvailable AI agents:\033[0m\n'
-    printf '  \033[36mcodex\033[0m      - OpenAI Codex CLI\n'
-    printf '  \033[36mclaude\033[0m     - Claude Code CLI\n'
-    printf '  \033[36mcopilot\033[0m    - GitHub Copilot CLI\n'
-    printf '  \033[36mvibe\033[0m       - Mistral Vibe CLI\n'
-    printf '  \033[36mblablador\033[0m  - OpenCode with Helmholtz Blablador\n'
-    printf '  \033[36mkisski\033[0m     - OpenCode with KISSKI\n'
-    printf '  \033[36mopencode\033[0m   - OpenCode CLI (\033[2mterok config import-opencode\033[0m)\n'
-    printf '  \033[36mblablatoad\033[0m - Blablador via Toad ACP\n'
-    printf '  \033[36mkisskitoad\033[0m  - KISSKI via Toad ACP\n'
-    printf '  \033[36mtoad\033[0m       - Multi-agent TUI (ACP)\n'
+_terok_help_dir=/usr/local/share/terok/help.d
+
+# Each section's contents are pre-rendered at L1 build time from the
+# roster YAML's `help:` blurbs (see terok_executor/container/build.py
+# stage_help_fragments).  Empty sections produce no file → silently skipped.
+_terok_section() {
+    local title="$1" file="$2"
+    [ -s "${_terok_help_dir}/${file}" ] || return 0
+    printf '\n\033[1m%s\033[0m\n' "$title"
+    cat "${_terok_help_dir}/${file}"
 }
 
-_terok_dev_tools() {
-    printf '\n\033[1mDev tools:\033[0m\n'
-    printf '  \033[36msonar-scanner\033[0m - SonarQube/SonarCloud static analysis (needs SONAR_TOKEN)\n'
-}
+_terok_executors() { _terok_section 'Available AI agents:' agents.txt; }
+_terok_dev_tools() { _terok_section 'Dev tools:'           dev-tools.txt; }
 
 _terok_notes() {
     printf '\n\033[1mterok container notes:\033[0m\n'
@@ -55,7 +51,7 @@ _terok_notes() {
     printf '  - agent CLI commands above are terok wrappers with git/session defaults\n'
     printf '  - \033[36msudo update-all-the-things\033[0m updates system packages and agent installs\n'
     printf '    in this running container only\n'
-    printf '  - host/TUI: \033[36mRebuild from L1 with fresh agents\033[0m / \033[36mterok build --agents <project>\033[0m\n'
+    printf '  - host/TUI: \033[36mRebuild from L1 with fresh agents\033[0m / \033[36mterok build --refresh-agents <project>\033[0m\n'
     printf '    refreshes agent installs for new containers only\n'
     printf '  - host/TUI: \033[36mRebuild from L0 (no cache)\033[0m / \033[36mterok build --full-rebuild <project>\033[0m\n'
     printf '    refreshes the base image + apt packages for new containers only\n'

--- a/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
@@ -36,6 +36,12 @@ RUN set -eux; \
       if getent group "$uid_owner" >/dev/null; then groupmod -n dev "$uid_owner" || true; fi; \
       usermod -l dev "$uid_owner"; \
       usermod -d /home/dev -m dev; \
+      # usermod -l / groupmod -n don't touch /etc/sub{u,g}id; rewrite \
+      # those entries so pre-configured rootless ranges (e.g. the podman \
+      # image's `podman:100000:65536`) keep working under the new name. \
+      for f in /etc/subuid /etc/subgid; do \
+        [ -f "$f" ] && sed -i "s/^${uid_owner}:/dev:/" "$f"; \
+      done; \
     fi; \
     if ! getent group dev >/dev/null; then \
       groupadd dev; \

--- a/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
@@ -6,20 +6,15 @@ ENV {% if family == "deb" %}DEBIAN_FRONTEND=noninteractive \
     {% endif %}PIPX_HOME=/opt/pipx \
     PIPX_BIN_DIR=/usr/local/bin
 
-# === Root operations (stable — cached across agent rebuilds) ===
+# === Static prelude (cached across agent rebuilds) ===
 USER root
 ENV HOME=/root
 
-# All system packages in a single layer.  External package sources (gh CLI,
-# NodeSource for Node 22) are registered first so the system-package install
-# below picks up everything in one transaction.
+# All system packages in a single layer.  NodeSource (Node 22) is the
+# shared external source; per-agent package repos (gh, glab, etc.) are
+# installed by their roster snippets only when selected.
 {% if family == "deb" -%}
 RUN set -eux; \
-    mkdir -p /etc/apt/keyrings; \
-    curl -sSL -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-      "https://cli.github.com/packages/githubcli-archive-keyring.gpg"; \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-      > /etc/apt/sources.list.d/github-cli.list; \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash -; \
     apt-get install -y --no-install-recommends \
             curl ca-certificates gnupg \
@@ -28,8 +23,6 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 {%- else -%}
 RUN set -eux; \
-    curl -fsSL -o /etc/yum.repos.d/gh-cli.repo \
-      "https://cli.github.com/packages/rpm/gh-cli.repo"; \
     curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -; \
     dnf install -y --setopt=install_weak_deps=False \
             curl ca-certificates gnupg2 \
@@ -38,9 +31,9 @@ RUN set -eux; \
     dnf clean all
 {%- endif %}
 
-# Binary tools: yq (YAML processor), ast-grep (structural code search via AST),
-# uv (Python package manager with built-in Python version management — used to
-# install Toad with its own Python 3.14 without touching system Python).
+# Binary tools used across snippets and at runtime: yq (YAML processor),
+# ast-grep (AST search), uv (Python toolchain — Toad uses it; also a useful
+# general dev tool).
 RUN set -eux; \
     case "$(uname -m)" in \
       x86_64) ARCH=amd64 ;; \
@@ -54,23 +47,9 @@ RUN set -eux; \
     pip install --break-system-packages ast-grep-cli; \
     curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
-# Pre-create managed config directories for per-task permission mode.
-# init-ssh-and-repo.sh writes config here when TEROK_UNRESTRICTED=1.
-# Owned by dev so no sudo is needed at runtime.
-RUN mkdir -p /etc/claude-code && chown dev:dev /etc/claude-code
-
 # Shell environment: terok-env.sh is the single source of truth for PATH,
 # git identity helpers, gh/glab wrappers, and per-project agent wrappers.
-# It lives in /etc/profile.d/ and is sourced by all three shell modes:
-#   - Non-interactive (bash -c): via BASH_ENV (set below)
-#   - Interactive:               via /etc/bash.bashrc
-#   - Login:                     via /etc/profile.d/ (directly)
-# The script guards against double-sourcing internally.
-# It sources two helpers from /usr/local/share/terok/:
-#   - terok-env-git-identity.sh  — _terok_apply_git_identity() function
-#   - terok-env-wrappers.sh      — per-task agent CLI wrappers (symlink to mount)
-# The COPY here sets up the wiring; the script is also refreshed below the
-# cache bust point so `terok build --agents` picks up content changes.
+# It lives in /etc/profile.d/ and is sourced by all three shell modes.
 COPY scripts/terok-env.sh /etc/profile.d/terok-env.sh
 RUN chmod +x /etc/profile.d/terok-env.sh; \
     if [ -f /etc/bash.bashrc ]; then \
@@ -87,113 +66,33 @@ RUN mkdir -p /usr/local/share/terok && \
 
 # === Cache bust point ===
 # Changing AGENT_CACHE_BUST invalidates all layers below: terok scripts,
-# agent CLIs (gh, glab, vibe, codex, copilot, claude, opencode, toad),
-# dev tools (sonar-scanner), and ACP adapters.
-# System packages (apt/dnf, nodejs, python, pipx, uv, yq, ast-grep) and
-# shell config are cached above.
+# selected agent installs, and the in-container manifest.  System
+# packages (nodejs, python, pipx, uv, yq, ast-grep) and shell config
+# are cached above.
 ARG AGENT_CACHE_BUST=0
 
-# terok scripts — single COPY + distribute (refreshed on agent rebuild)
+# Stage scripts and the help fragments rendered from the roster.
 COPY scripts/ /tmp/terok-scripts/
-COPY toad-agents/ /usr/local/share/terok/toad-agents/
+COPY help.d/ /usr/local/share/terok/help.d/
+
+# Always-on terok scripts (env helpers, banner, updaters).
 RUN set -eux; \
     cp /tmp/terok-scripts/terok-env-git-identity.sh /usr/local/share/terok/; \
     cp /tmp/terok-scripts/terok-acp-env.sh /usr/local/share/terok/; \
     cp /tmp/terok-scripts/terok-env.sh /etc/profile.d/terok-env.sh; \
-    cp /tmp/terok-scripts/opencode-session-plugin.mjs /usr/local/share/terok/; \
-    cp /tmp/terok-scripts/vibe-model-sync.sh /usr/local/bin/vibe-model-sync; \
-    for f in setup-codex-auth.sh hilfe opencode-provider opencode-provider-acp \
-             opencode-toad toad \
-             terok-claude-acp terok-codex-acp terok-opencode-acp \
-             terok-copilot-acp terok-vibe-acp \
-             mistral-model-sync.py allthethings.sh update-all-the-things; do \
-        cp "/tmp/terok-scripts/$f" "/usr/local/bin/$f"; \
-    done; \
-    chmod +x \
-        /usr/local/share/terok/terok-env-git-identity.sh \
-        /usr/local/share/terok/terok-acp-env.sh \
-        /usr/local/bin/setup-codex-auth.sh \
-        /usr/local/bin/hilfe \
-        /usr/local/bin/opencode-provider \
-        /usr/local/bin/opencode-provider-acp \
-        /usr/local/bin/opencode-toad \
-        /usr/local/bin/toad \
-        /usr/local/bin/terok-claude-acp \
-        /usr/local/bin/terok-codex-acp \
-        /usr/local/bin/terok-opencode-acp \
-        /usr/local/bin/terok-copilot-acp \
-        /usr/local/bin/terok-vibe-acp \
-        /usr/local/bin/vibe-model-sync \
-        /usr/local/bin/mistral-model-sync.py \
-        /usr/local/bin/allthethings.sh \
-        /usr/local/bin/update-all-the-things; \
-    ln -s opencode-provider /usr/local/bin/blablador; \
-    ln -s opencode-provider /usr/local/bin/kisski; \
-    ln -s opencode-provider-acp /usr/local/bin/blablador-acp; \
-    ln -s opencode-provider-acp /usr/local/bin/kisski-acp; \
-    ln -s opencode-toad /usr/local/bin/blablatoad; \
-    ln -s opencode-toad /usr/local/bin/kisskitoad; \
-    rm -rf /tmp/terok-scripts
+    cp /tmp/terok-scripts/hilfe /usr/local/bin/hilfe; \
+    cp /tmp/terok-scripts/allthethings.sh /usr/local/bin/allthethings.sh; \
+    cp /tmp/terok-scripts/update-all-the-things /usr/local/bin/update-all-the-things; \
+    chmod +x /usr/local/share/terok/terok-env-git-identity.sh \
+             /usr/local/share/terok/terok-acp-env.sh \
+             /usr/local/bin/hilfe \
+             /usr/local/bin/allthethings.sh \
+             /usr/local/bin/update-all-the-things
 
-# Root-level agent installs (need pipx — refreshed on agent rebuild)
-RUN set -eux; \
-    pipx install mistral-vibe; \
-    pipx inject mistral-vibe mistralai
-
-# Install GitHub CLI (gh) — repo is pre-registered above the cache
-# bust point; refreshing the package index is needed since earlier
-# layers cleared the cached metadata.
-{% if family == "deb" -%}
-RUN set -eux; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends gh; \
-    rm -rf /var/lib/apt/lists/*
-{%- else -%}
-RUN set -eux; \
-    dnf install -y gh; \
-    dnf clean all
-{%- endif %}
-
-# Install GitLab CLI (glab) from official GitLab releases
-{%- set pkg_ext = "deb" if family == "deb" else "rpm" %}
-{%- set pkg_install = "dpkg -i" if family == "deb" else "dnf install -y" %}
-RUN set -eux; \
-    GLAB_VERSION=$(curl -sSL "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest" \
-      | jq -r '.tag_name | ltrimstr("v")'); \
-    case "$(uname -m)" in \
-      x86_64) ARCH=amd64 ;; \
-      aarch64) ARCH=arm64 ;; \
-      *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;; \
-    esac; \
-    PKG_NAME="glab_${GLAB_VERSION}_linux_${ARCH}.{{ pkg_ext }}"; \
-    curl -sSL -o /tmp/glab.pkg \
-      "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/${PKG_NAME}"; \
-    curl -sSL -o /tmp/checksums.txt \
-      "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/checksums.txt"; \
-    grep "  ${PKG_NAME}$" /tmp/checksums.txt | sed "s|${PKG_NAME}|/tmp/glab.pkg|" | sha256sum -c -; \
-    {{ pkg_install }} /tmp/glab.pkg; \
-    rm -f /tmp/glab.pkg /tmp/checksums.txt
-
-# Install SonarScanner CLI (local static analysis for SonarQube Cloud/Server).
-# Bundles an embedded JRE; multi-arch (amd64/arm64).
-# Needs SONAR_TOKEN at runtime.
-RUN set -eux; \
-    SONAR_VERSION="8.0.1.6346"; \
-    case "$(uname -m)" in \
-      x86_64) SA="linux-x64" ;; \
-      aarch64) SA="linux-aarch64" ;; \
-      *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;; \
-    esac; \
-    SONAR_ZIP="sonar-scanner-cli-${SONAR_VERSION}-${SA}.zip"; \
-    MAVEN_BASE="https://repo1.maven.org/maven2/org/sonarsource/scanner/cli/sonar-scanner-cli/${SONAR_VERSION}"; \
-    curl -fsSL -o /tmp/sonar-scanner.zip "${MAVEN_BASE}/${SONAR_ZIP}"; \
-    curl -fsSL -o /tmp/sonar-scanner.zip.sha256 "${MAVEN_BASE}/${SONAR_ZIP}.sha256"; \
-    echo "$(cat /tmp/sonar-scanner.zip.sha256)  /tmp/sonar-scanner.zip" | sha256sum -c -; \
-    unzip -q /tmp/sonar-scanner.zip -d /opt; \
-    mv "/opt/sonar-scanner-${SONAR_VERSION}-${SA}" /opt/sonar-scanner; \
-    ln -s /opt/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner; \
-    rm /tmp/sonar-scanner.zip; \
-    sonar-scanner --version
+# === Roster-driven installs (root portion) ===
+{% for snippet in install_root_snippets %}
+{{ snippet }}
+{% endfor %}
 
 # === User operations (agent installs) ===
 ENV HOME=/home/dev
@@ -203,21 +102,21 @@ ENV NPM_CONFIG_PREFIX=/home/dev/.npm-packages \
 USER dev
 WORKDIR /home/dev
 
-# Install AI agent CLIs as dev user (single npm call to reduce overhead)
-RUN set -eux; \
-    mkdir -p "$NPM_CONFIG_PREFIX"; \
-    npm config set prefix "$NPM_CONFIG_PREFIX"; \
-    npm install -g @openai/codex @github/copilot @agentclientprotocol/claude-agent-acp; \
-    npm cache clean --force
-RUN curl -fsSL https://claude.ai/install.sh | bash
-RUN curl -fsSL https://opencode.ai/install | bash
+RUN mkdir -p "$NPM_CONFIG_PREFIX" && npm config set prefix "$NPM_CONFIG_PREFIX"
 
-# Toad — universal multi-agent TUI via ACP (requires Python >=3.14)
-# uv downloads a standalone Python 3.14, leaving system Python untouched.
-# The uv-created symlink is removed so the wrapper at /usr/local/bin/toad
-# (which seeds launcher agents) takes precedence in PATH.
-RUN uv tool install batrachian-toad --python 3.14 \
-    && rm -f ~/.local/bin/toad
+# === Roster-driven installs (dev portion) ===
+{% for snippet in install_dev_snippets %}
+{{ snippet }}
+{% endfor %}
+
+# Drop the staged scripts dir and stamp the in-container manifest.
+USER root
+RUN rm -rf /tmp/terok-scripts && \
+    mkdir -p /etc/terok && \
+    printf 'TEROK_INSTALLED_AGENTS=%s\n' '{{ installed_agents_csv }}' > /etc/terok/installed.env
+USER dev
+
+LABEL ai.terok.agents="{{ installed_agents_csv }}"
 
 WORKDIR /workspace
 # No CMD: reuse init-ssh-and-repo.sh from base image

--- a/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
@@ -113,10 +113,10 @@ RUN mkdir -p "$NPM_CONFIG_PREFIX" && npm config set prefix "$NPM_CONFIG_PREFIX"
 USER root
 RUN rm -rf /tmp/terok-scripts && \
     mkdir -p /etc/terok && \
-    printf 'TEROK_INSTALLED_AGENTS=%s\n' '{{ installed_agents_csv }}' > /etc/terok/installed.env
+    printf 'TEROK_INSTALLED_AGENTS=%s\n' '{{ installed_agents_csv }}' > {{ installed_env_path }}
 USER dev
 
-LABEL ai.terok.agents="{{ installed_agents_csv }}"
+LABEL {{ agents_label }}="{{ installed_agents_csv }}"
 
 WORKDIR /workspace
 # No CMD: reuse init-ssh-and-repo.sh from base image

--- a/src/terok_executor/roster/__init__.py
+++ b/src/terok_executor/roster/__init__.py
@@ -15,6 +15,7 @@ from .loader import (
     ensure_proxy_routes,
     get_roster,
     load_roster,
+    parse_agent_selection,
 )
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "ensure_proxy_routes",
     "get_roster",
     "load_roster",
+    "parse_agent_selection",
 ]

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -231,14 +231,20 @@ class AgentRoster:
         """Resolve a user-supplied selection into the full set of roster names to install.
 
         Accepts the literal string ``"all"`` (every roster entry that has an
-        :class:`InstallSpec`) or an iterable of names.  Expands ``depends_on``
+        :class:`InstallSpec`) or a tuple of names.  Expands ``depends_on``
         transitively.  Returns the names sorted alphabetically — the canonical
         order used for the OCI label, the tag suffix, and the in-container
         manifest.
 
-        Raises ``ValueError`` if a requested name is not in the roster.
+        Raises ``ValueError`` if a requested name is not in the roster, or
+        ``TypeError`` if *names* is a string other than ``"all"`` (a bare
+        name like ``"claude"`` would otherwise be iterated into characters).
         """
-        if names == "all":
+        if isinstance(names, str):
+            if names != "all":
+                raise TypeError(
+                    f"Selection must be the literal string 'all' or a tuple of names, got {names!r}"
+                )
             seed = set(self._installs)
         else:
             seed = set(names)

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -112,6 +112,44 @@ class CredentialProxyRoute:
 
 
 @dataclass(frozen=True)
+class InstallSpec:
+    """Roster-driven install snippets emitted into the L1 Dockerfile.
+
+    The build template loops over the resolved selection and concatenates
+    ``run_as_root`` snippets in the root section, ``run_as_dev`` snippets
+    in the dev-user section.  Both fields are raw Dockerfile fragments
+    (``RUN``, ``COPY`` — anything valid at top level after ``USER ...``).
+    ``depends_on`` lists other roster names that must be installed
+    alongside this one (transitively resolved at selection time).
+    """
+
+    depends_on: tuple[str, ...] = ()
+    """Other roster entries this install requires (e.g. ``blablador → opencode``)."""
+
+    run_as_root: str = ""
+    """Dockerfile fragment emitted in the root section of the L1 image."""
+
+    run_as_dev: str = ""
+    """Dockerfile fragment emitted in the dev-user section of the L1 image."""
+
+
+@dataclass(frozen=True)
+class HelpSpec:
+    """One-line entry shown by the in-container ``hilfe`` help banner.
+
+    Build emits a pre-rendered fragment per section (``agent`` or
+    ``dev_tool``) into ``/usr/local/share/terok/help.d/``; ``hilfe``
+    just ``cat``s them — no per-script template logic.
+    """
+
+    label: str = ""
+    """Raw banner line (the agent owns its formatting, including ANSI codes)."""
+
+    section: str = "agent"
+    """Banner section: ``"agent"`` (default) or ``"dev_tool"``."""
+
+
+@dataclass(frozen=True)
 class SidecarSpec:
     """Sidecar container configuration parsed from a ``sidecar:`` YAML section.
 
@@ -141,6 +179,8 @@ class AgentRoster:
     _auth_providers: dict[str, AuthProvider] = field(default_factory=dict)
     _proxy_routes: dict[str, CredentialProxyRoute] = field(default_factory=dict)
     _sidecar_specs: dict[str, SidecarSpec] = field(default_factory=dict)
+    _installs: dict[str, InstallSpec] = field(default_factory=dict)
+    _helps: dict[str, HelpSpec] = field(default_factory=dict)
     _mounts: tuple[MountDef, ...] = ()
     _agent_names: tuple[str, ...] = ()
     _all_names: tuple[str, ...] = ()
@@ -176,6 +216,59 @@ class AgentRoster:
     def all_names(self) -> tuple[str, ...]:
         """Names of all entries (agents + tools)."""
         return self._all_names
+
+    @property
+    def installs(self) -> dict[str, InstallSpec]:
+        """All install specs, keyed by roster name (entries without one are absent)."""
+        return dict(self._installs)
+
+    @property
+    def helps(self) -> dict[str, HelpSpec]:
+        """All help blurbs, keyed by roster name (entries without one are absent)."""
+        return dict(self._helps)
+
+    # ── Selection ──
+
+    def resolve_selection(self, names: str | tuple[str, ...]) -> tuple[str, ...]:
+        """Resolve a user-supplied selection into the full set of roster names to install.
+
+        Accepts the literal string ``"all"`` (every roster entry that has an
+        :class:`InstallSpec`) or an iterable of names.  Expands ``depends_on``
+        transitively.  Returns the names sorted alphabetically — the canonical
+        order used for the OCI label, the tag suffix, and the in-container
+        manifest.
+
+        Raises ``ValueError`` if a requested name is not in the roster.
+        """
+        if names == "all":
+            seed = set(self._installs)
+        else:
+            seed = set(names)
+
+        unknown = seed - set(self._installs)
+        if unknown:
+            avail = ", ".join(sorted(self._installs))
+            raise ValueError(f"Unknown roster entries: {sorted(unknown)!r}. Available: {avail}")
+
+        resolved: set[str] = set()
+        stack = list(seed)
+        while stack:
+            name = stack.pop()
+            if name in resolved:
+                continue
+            resolved.add(name)
+            spec = self._installs.get(name)
+            if spec is None:
+                continue
+            for dep in spec.depends_on:
+                if dep not in self._installs:
+                    raise ValueError(
+                        f"Agent {name!r} declares depends_on {dep!r}, "
+                        f"which has no install: section in the roster"
+                    )
+                if dep not in resolved:
+                    stack.append(dep)
+        return tuple(sorted(resolved))
 
     @property
     def mounts(self) -> tuple[MountDef, ...]:
@@ -300,6 +393,8 @@ def load_roster() -> AgentRoster:
     auth_providers: dict[str, AuthProvider] = {}
     proxy_routes: dict[str, CredentialProxyRoute] = {}
     sidecar_specs: dict[str, SidecarSpec] = {}
+    installs: dict[str, InstallSpec] = {}
+    helps: dict[str, HelpSpec] = {}
     agent_names: list[str] = []
     all_names: list[str] = []
 
@@ -359,11 +454,21 @@ def load_roster() -> AgentRoster:
         if sidecar is not None:
             sidecar_specs[name] = sidecar
 
+        # Install snippets and help blurb (both optional)
+        install = _to_install_spec(name, data)
+        if install is not None:
+            installs[name] = install
+        help_spec = _to_help_spec(name, data)
+        if help_spec is not None:
+            helps[name] = help_spec
+
     return AgentRoster(
         _providers=providers,
         _auth_providers=auth_providers,
         _proxy_routes=proxy_routes,
         _sidecar_specs=sidecar_specs,
+        _installs=installs,
+        _helps=helps,
         _mounts=tuple(seen_mounts.values()),
         _agent_names=tuple(agent_names),
         _all_names=tuple(all_names),
@@ -662,4 +767,39 @@ def _to_sidecar_spec(name: str, data: dict) -> SidecarSpec | None:
     return SidecarSpec(
         tool_name=sc.get("tool_name", name),
         env_map=dict(sc.get("env_map", {})),
+    )
+
+
+def _to_install_spec(name: str, data: dict) -> InstallSpec | None:
+    """Parse the optional ``install:`` YAML section into an :class:`InstallSpec`.
+
+    Both snippet fields and ``depends_on`` are optional individually; the
+    section as a whole is omitted only for entries that need no install
+    work in L1 (typically sidecar tools and runtime kinds with no payload).
+    """
+    inst = data.get("install")
+    if not inst:
+        return None
+    if not isinstance(inst, dict):
+        raise ValueError(f"Agent {name!r}: install must be a mapping, got {type(inst).__name__}")
+    deps = inst.get("depends_on", ())
+    if isinstance(deps, str):
+        deps = (deps,)
+    return InstallSpec(
+        depends_on=tuple(deps),
+        run_as_root=inst.get("run_as_root", "") or "",
+        run_as_dev=inst.get("run_as_dev", "") or "",
+    )
+
+
+def _to_help_spec(name: str, data: dict) -> HelpSpec | None:
+    """Parse the optional ``help:`` YAML section into a :class:`HelpSpec`."""
+    h = data.get("help")
+    if not h:
+        return None
+    if not isinstance(h, dict):
+        raise ValueError(f"Agent {name!r}: help must be a mapping, got {type(h).__name__}")
+    return HelpSpec(
+        label=h.get("label", "") or "",
+        section=h.get("section", "agent") or "agent",
     )

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -23,7 +23,7 @@ import sys
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from terok_sandbox.config_stack import deep_merge
 
@@ -133,20 +133,18 @@ class InstallSpec:
     """Dockerfile fragment emitted in the dev-user section of the L1 image."""
 
 
+HelpSection = Literal["agent", "dev_tool"]
+"""Section in the in-container help banner that an entry belongs to."""
+
+
 @dataclass(frozen=True)
 class HelpSpec:
-    """One-line entry shown by the in-container ``hilfe`` help banner.
-
-    Build emits a pre-rendered fragment per section (``agent`` or
-    ``dev_tool``) into ``/usr/local/share/terok/help.d/``; ``hilfe``
-    just ``cat``s them — no per-script template logic.
-    """
+    """One-line entry shown in the in-container help banner."""
 
     label: str = ""
     """Raw banner line (the agent owns its formatting, including ANSI codes)."""
 
-    section: str = "agent"
-    """Banner section: ``"agent"`` (default) or ``"dev_tool"``."""
+    section: HelpSection = "agent"
 
 
 @dataclass(frozen=True)
@@ -792,6 +790,9 @@ def _to_install_spec(name: str, data: dict) -> InstallSpec | None:
     )
 
 
+_HELP_SECTIONS: frozenset[str] = frozenset({"agent", "dev_tool"})
+
+
 def _to_help_spec(name: str, data: dict) -> HelpSpec | None:
     """Parse the optional ``help:`` YAML section into a :class:`HelpSpec`."""
     h = data.get("help")
@@ -799,7 +800,10 @@ def _to_help_spec(name: str, data: dict) -> HelpSpec | None:
         return None
     if not isinstance(h, dict):
         raise ValueError(f"Agent {name!r}: help must be a mapping, got {type(h).__name__}")
-    return HelpSpec(
-        label=h.get("label", "") or "",
-        section=h.get("section", "agent") or "agent",
-    )
+    section = h.get("section") or "agent"
+    if section not in _HELP_SECTIONS:
+        raise ValueError(
+            f"Agent {name!r}: help.section must be one of "
+            f"{sorted(_HELP_SECTIONS)!r}, got {section!r}"
+        )
+    return HelpSpec(label=h.get("label", "") or "", section=section)

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -23,7 +23,7 @@ import sys
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, get_args
 
 from terok_sandbox.config_stack import deep_merge
 
@@ -135,6 +135,9 @@ class InstallSpec:
 
 HelpSection = Literal["agent", "dev_tool"]
 """Section in the in-container help banner that an entry belongs to."""
+
+HELP_SECTIONS: tuple[HelpSection, ...] = get_args(HelpSection)
+"""All valid :data:`HelpSection` values, as a tuple (single source of truth)."""
 
 
 @dataclass(frozen=True)
@@ -375,6 +378,23 @@ class AgentRoster:
 def get_roster() -> AgentRoster:
     """Return the singleton roster instance (loaded once, cached)."""
     return load_roster()
+
+
+def parse_agent_selection(raw: str) -> str | tuple[str, ...]:
+    """Normalise a user-supplied agent selection string.
+
+    Accepts a comma-list (``"claude,codex"``) or the literal ``"all"``.
+    Whitespace is stripped, empty / whitespace-only entries dropped,
+    and case folded.  Empty or all-whitespace input collapses to
+    ``"all"`` — the same shape :meth:`AgentRoster.resolve_selection`
+    expects.  Unknown names are not checked here; ``resolve_selection``
+    does that.
+    """
+    folded = raw.strip().lower()
+    if folded == "all" or not folded:
+        return "all"
+    names = tuple(n.strip() for n in folded.split(",") if n.strip())
+    return names or "all"
 
 
 def load_roster() -> AgentRoster:
@@ -796,9 +816,6 @@ def _to_install_spec(name: str, data: dict) -> InstallSpec | None:
     )
 
 
-_HELP_SECTIONS: frozenset[str] = frozenset({"agent", "dev_tool"})
-
-
 def _to_help_spec(name: str, data: dict) -> HelpSpec | None:
     """Parse the optional ``help:`` YAML section into a :class:`HelpSpec`."""
     h = data.get("help")
@@ -807,9 +824,8 @@ def _to_help_spec(name: str, data: dict) -> HelpSpec | None:
     if not isinstance(h, dict):
         raise ValueError(f"Agent {name!r}: help must be a mapping, got {type(h).__name__}")
     section = h.get("section") or "agent"
-    if section not in _HELP_SECTIONS:
+    if section not in HELP_SECTIONS:
         raise ValueError(
-            f"Agent {name!r}: help.section must be one of "
-            f"{sorted(_HELP_SECTIONS)!r}, got {section!r}"
+            f"Agent {name!r}: help.section must be one of {list(HELP_SECTIONS)!r}, got {section!r}"
         )
     return HelpSpec(label=h.get("label", "") or "", section=section)

--- a/tach.toml
+++ b/tach.toml
@@ -103,7 +103,9 @@ depends_on = [
 # Build resource staging — standalone
 [[modules]]
 path = "terok_executor.container.build"
-depends_on = []
+depends_on = [
+    "terok_executor.roster.loader",
+]
 
 # Clone-cache workspace seeding — copies cached clone into task workspace
 [[modules]]

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -26,6 +26,7 @@ from terok_executor.container.build import (
     render_l0,
     render_l1,
     render_l1_sidecar,
+    stage_help_fragments,
     stage_scripts,
     stage_tmux_config,
     stage_toad_agents,
@@ -62,6 +63,22 @@ class TestImageNaming:
 
     def test_l1_tag(self) -> None:
         assert l1_image_tag("ubuntu:24.04") == "terok-l1-cli:ubuntu-24.04"
+
+    def test_l1_tag_with_agents(self) -> None:
+        assert (
+            l1_image_tag("ubuntu:24.04", ("claude", "codex"))
+            == "terok-l1-cli:ubuntu-24.04+claude+codex"
+        )
+
+    def test_l1_tag_agents_sorted(self) -> None:
+        # Suffix is canonicalised regardless of input order.
+        assert l1_image_tag("ubuntu:24.04", ("codex", "claude")) == l1_image_tag(
+            "ubuntu:24.04", ("claude", "codex")
+        )
+
+    def test_l1_tag_empty_selection(self) -> None:
+        # Edge case: empty selection still produces a distinct, addressable tag.
+        assert l1_image_tag("ubuntu:24.04", ()) == "terok-l1-cli:ubuntu-24.04+empty"
 
     def test_image_set(self) -> None:
         s = ImageSet(l0="terok-l0:test", l1="terok-l1-cli:test")
@@ -323,6 +340,26 @@ class TestTemplateRendering:
         content = render_l1("terok-l0:nvidia-cuda-12.4", family="deb")
         assert "FROM" in content
 
+    def test_l1_label_lists_selection(self) -> None:
+        content = render_l1("terok-l0:test", agents=("claude", "codex"))
+        assert 'LABEL ai.terok.agents="claude,codex"' in content
+
+    def test_l1_omits_unselected_agents(self) -> None:
+        # Selecting only claude should not pull in vibe's pipx install.
+        content = render_l1("terok-l0:test", agents=("claude",))
+        assert "claude.ai/install" in content
+        assert "pipx install mistral-vibe" not in content
+
+    def test_l1_resolves_transitive_deps(self) -> None:
+        # blablador depends_on opencode → opencode install must appear.
+        content = render_l1("terok-l0:test", agents=("blablador",))
+        assert "opencode.ai/install" in content
+        assert 'LABEL ai.terok.agents="blablador,opencode"' in content
+
+    def test_l1_unknown_agent_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown roster entries"):
+            render_l1("terok-l0:test", agents=("not-a-real-agent",))
+
     def test_l1_sidecar_is_valid_dockerfile(self) -> None:
         content = render_l1_sidecar("terok-l0:test", family="deb")
         assert content.startswith("# syntax=docker")
@@ -477,6 +514,32 @@ class TestStageTmuxConfig:
         dest = tmp_path / "tmux"
         stage_tmux_config(dest)
         assert not (dest / "__init__.py").exists()
+
+
+class TestStageHelpFragments:
+    """Verify per-section help fragment rendering for ``hilfe``."""
+
+    def test_splits_by_section(self, tmp_path: Path) -> None:
+        dest = tmp_path / "help.d"
+        stage_help_fragments(dest, ("claude", "gh"))
+        assert (dest / "agents.txt").is_file()
+        assert (dest / "dev-tools.txt").is_file()
+        assert "claude" in (dest / "agents.txt").read_text()
+        assert "gh" in (dest / "dev-tools.txt").read_text()
+
+    def test_decodes_ansi_escapes(self, tmp_path: Path) -> None:
+        dest = tmp_path / "help.d"
+        stage_help_fragments(dest, ("claude",))
+        # \033 in the YAML must land as the literal ESC byte in the file so
+        # that hilfe just `cat`s and gets coloured output.
+        assert "\x1b[" in (dest / "agents.txt").read_text()
+        assert r"\033[" not in (dest / "agents.txt").read_text()
+
+    def test_omits_empty_sections(self, tmp_path: Path) -> None:
+        # Selecting only an agent (no dev_tool) leaves dev-tools.txt absent.
+        dest = tmp_path / "help.d"
+        stage_help_fragments(dest, ("claude",))
+        assert not (dest / "dev-tools.txt").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -341,24 +341,24 @@ class TestTemplateRendering:
         assert "FROM" in content
 
     def test_l1_label_lists_selection(self) -> None:
-        content = render_l1("terok-l0:test", agents=("claude", "codex"))
+        content = render_l1("terok-l0:test", family="deb", agents=("claude", "codex"))
         assert 'LABEL ai.terok.agents="claude,codex"' in content
 
     def test_l1_omits_unselected_agents(self) -> None:
         # Selecting only claude should not pull in vibe's pipx install.
-        content = render_l1("terok-l0:test", agents=("claude",))
+        content = render_l1("terok-l0:test", family="deb", agents=("claude",))
         assert "claude.ai/install" in content
         assert "pipx install mistral-vibe" not in content
 
     def test_l1_resolves_transitive_deps(self) -> None:
         # blablador depends_on opencode → opencode install must appear.
-        content = render_l1("terok-l0:test", agents=("blablador",))
+        content = render_l1("terok-l0:test", family="deb", agents=("blablador",))
         assert "opencode.ai/install" in content
         assert 'LABEL ai.terok.agents="blablador,opencode"' in content
 
     def test_l1_unknown_agent_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown roster entries"):
-            render_l1("terok-l0:test", agents=("not-a-real-agent",))
+            render_l1("terok-l0:test", family="deb", agents=("not-a-real-agent",))
 
     def test_l1_sidecar_is_valid_dockerfile(self) -> None:
         content = render_l1_sidecar("terok-l0:test", family="deb")
@@ -546,9 +546,7 @@ class TestStageHelpFragments:
         from terok_executor.container.build import _decode_label_escapes
 
         # bytes(s, "utf-8").decode("unicode_escape") would produce 'Ã¤' here.
-        assert _decode_label_escapes(r"\033[36m→ ähnlich\033[0m") == (
-            "\x1b[36m→ ähnlich\x1b[0m"
-        )
+        assert _decode_label_escapes(r"\033[36m→ ähnlich\033[0m") == ("\x1b[36m→ ähnlich\x1b[0m")
 
 
 # ---------------------------------------------------------------------------
@@ -873,7 +871,8 @@ class TestBuildBaseImagesFamily:
             result = build_base_images("rockylinux:9")
 
         assert result.l0.endswith(":rockylinux-9")
-        assert result.l1.endswith(":rockylinux-9")
+        # L1 tag carries the default agent-suffix on top of the base fragment.
+        assert result.l1.startswith("terok-l1-cli:rockylinux-9+")
         mock_detect.assert_not_called()
 
 

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -541,6 +541,15 @@ class TestStageHelpFragments:
         stage_help_fragments(dest, ("claude",))
         assert not (dest / "dev-tools.txt").exists()
 
+    def test_decoder_preserves_non_ascii(self) -> None:
+        """The escape decoder must not mojibake non-ASCII characters."""
+        from terok_executor.container.build import _decode_label_escapes
+
+        # bytes(s, "utf-8").decode("unicode_escape") would produce 'Ã¤' here.
+        assert _decode_label_escapes(r"\033[36m→ ähnlich\033[0m") == (
+            "\x1b[36m→ ähnlich\x1b[0m"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Sidecar image build

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -80,6 +80,46 @@ class TestImageNaming:
         # Edge case: empty selection still produces a distinct, addressable tag.
         assert l1_image_tag("ubuntu:24.04", ()) == "terok-l1-cli:ubuntu-24.04-empty"
 
+    def test_l1_tag_fits_oci_limit_for_worst_realistic_base(self) -> None:
+        # Longest base we currently presets (podman+all-agents) must fit.
+        tag = l1_image_tag(
+            "quay.io/podman/stable:latest",
+            (
+                "blablador",
+                "claude",
+                "codex",
+                "copilot",
+                "gh",
+                "glab",
+                "kisski",
+                "opencode",
+                "sonar",
+                "toad",
+                "vibe",
+            ),
+        )
+        _, _, tag_part = tag.partition(":")
+        assert len(tag_part) <= 128  # OCI spec
+        assert "blablador" in tag  # readable form still won
+
+    def test_l1_tag_digests_when_combined_overflows(self) -> None:
+        # Synthesise a base that by itself is near the cap so the readable
+        # agent suffix would push past the limit; digest takes over.
+        long_base = "registry.example.internal/" + "x" * 100 + ":latest"
+        tag = l1_image_tag(long_base, ("claude", "codex", "gh"))
+        _, _, tag_part = tag.partition(":")
+        assert len(tag_part) <= 128
+        # Agent suffix replaced by a 12-char hex digest — no readable names.
+        assert "claude" not in tag and "codex" not in tag
+
+    def test_l1_tag_digest_is_stable_and_selection_sensitive(self) -> None:
+        long_base = "registry.example.internal/" + "x" * 100 + ":latest"
+        a = l1_image_tag(long_base, ("claude", "codex"))
+        b = l1_image_tag(long_base, ("codex", "claude"))  # same set, reordered
+        c = l1_image_tag(long_base, ("claude", "gh"))  # different set
+        assert a == b
+        assert a != c
+
     def test_image_set(self) -> None:
         s = ImageSet(l0="terok-l0:test", l1="terok-l1-cli:test")
         assert s.l0 == "terok-l0:test"

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -784,7 +784,7 @@ class TestRenderFamilyAware:
         assert "deb.nodesource.com/setup_22.x" in content
         assert "/etc/apt/keyrings/githubcli" in content
         assert "glab_${GLAB_VERSION}_linux_${ARCH}.deb" in content
-        assert "dpkg -i /tmp/glab.pkg" in content
+        assert "dpkg -i /tmp/glab.deb" in content
 
     def test_l1_rpm_uses_dnf_and_rpm_repos(self) -> None:
         content = render_l1("terok-l0:test", family="rpm")
@@ -792,7 +792,9 @@ class TestRenderFamilyAware:
         assert "rpm.nodesource.com/setup_22.x" in content
         assert "/etc/yum.repos.d/gh-cli.repo" in content
         assert "glab_${GLAB_VERSION}_linux_${ARCH}.rpm" in content
-        assert "dnf install -y /tmp/glab.pkg" in content
+        # Filename must carry .rpm extension — dnf5 refuses local installs
+        # of files named anything else (treats them as repo queries).
+        assert "dnf install -y /tmp/glab.rpm" in content
         assert "apt-get" not in content
         assert "dpkg" not in content
 

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -67,7 +67,7 @@ class TestImageNaming:
     def test_l1_tag_with_agents(self) -> None:
         assert (
             l1_image_tag("ubuntu:24.04", ("claude", "codex"))
-            == "terok-l1-cli:ubuntu-24.04+claude+codex"
+            == "terok-l1-cli:ubuntu-24.04-claude-codex"
         )
 
     def test_l1_tag_agents_sorted(self) -> None:
@@ -78,7 +78,7 @@ class TestImageNaming:
 
     def test_l1_tag_empty_selection(self) -> None:
         # Edge case: empty selection still produces a distinct, addressable tag.
-        assert l1_image_tag("ubuntu:24.04", ()) == "terok-l1-cli:ubuntu-24.04+empty"
+        assert l1_image_tag("ubuntu:24.04", ()) == "terok-l1-cli:ubuntu-24.04-empty"
 
     def test_image_set(self) -> None:
         s = ImageSet(l0="terok-l0:test", l1="terok-l1-cli:test")
@@ -359,6 +359,13 @@ class TestTemplateRendering:
     def test_l1_unknown_agent_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown roster entries"):
             render_l1("terok-l0:test", family="deb", agents=("not-a-real-agent",))
+
+    def test_l1_bare_string_selection_rejected(self) -> None:
+        # A bare agent name passed as a string would otherwise be iterated
+        # into characters ({'c','l','a','u','d','e'}) — the guard catches
+        # that misuse instead of raising a confusing ValueError.
+        with pytest.raises(TypeError, match="'all' or a tuple"):
+            render_l1("terok-l0:test", family="deb", agents="claude")
 
     def test_l1_sidecar_is_valid_dockerfile(self) -> None:
         content = render_l1_sidecar("terok-l0:test", family="deb")
@@ -872,7 +879,7 @@ class TestBuildBaseImagesFamily:
 
         assert result.l0.endswith(":rockylinux-9")
         # L1 tag carries the default agent-suffix on top of the base fragment.
-        assert result.l1.startswith("terok-l1-cli:rockylinux-9+")
+        assert result.l1.startswith("terok-l1-cli:rockylinux-9-")
         mock_detect.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- Each roster YAML now declares its own L1 install snippet (`install.run_as_root`, `install.run_as_dev`, `install.depends_on`) and a hilfe help blurb (`help.label`, `help.section`). The L1 Dockerfile template loops over the resolved selection, so only the agents the user picks are baked into the image.
- A single selection drives four artifacts at build time: the **OCI label** `ai.terok.agents=<csv>` (host-side detection), the in-container manifest `/etc/terok/installed.env`, pre-rendered hilfe fragments under `/usr/local/share/terok/help.d/`, and a **suffixed image tag** `terok-l1-cli:<base>+a+b+c` (the unsuffixed alias is also written for "most recent build").
- `depends_on` is transitively expanded: picking `blablador` or `kisski` automatically pulls in `opencode`.
- New CLI flag: `terok-executor build --agents claude,codex` (or the default `--agents all`).
- `hilfe` is no longer hand-curated — it just `cat`s the rendered fragments. Any future "needs to know what's installed" surface can read `/etc/terok/installed.env` or the help.d directory without per-script template logic.

Public API stays compatible: `build_base_images(..., agents="all")` is the default, so existing callers (terok, preflight, runner) keep working unchanged. The unsuffixed `terok-l1-cli:<base>` tag is always written too, so `_image_exists()` checks behave the same.

terok-side wiring (consume the label, expose `--agents` on `terok setup`, filter providers in CLI/TUI/auth) lands in a follow-up PR on `terok-ai/terok` against the tip of this branch.

## Test plan

- [x] `make test-unit` — 534 passed (10 new tests for selection / label / tag suffix / help fragments / dep resolution)
- [x] `make lint` — clean
- [x] `make tach` — boundary updated to allow `container.build → roster.loader`
- [x] `make reuse` — clean
- [ ] Manual `terok-executor build --agents claude,codex` on a podman-equipped machine (deferred to local test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --agents option to choose which agents are included during image builds (comma-separated, default "all"); builds, image tags, labels and an in-image installed-agents manifest reflect the chosen set and produce per-selection artifacts.

* **Bug Fixes**
  * CLI now shows clean exit messages for build failures and invalid agent selections instead of tracebacks.

* **Chores**
  * Added install and help metadata for many agents to enable selective installs.

* **Documentation**
  * Help output now loads staged per-section help fragments at runtime.

* **Tests**
  * Added tests for agent selection, tagging, rendering, and staged help behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->