### PR TITLE
fix: recognize quay.io/podman/* as rpm family

### DIFF
--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -58,7 +58,7 @@ _DEFAULT_TAG = "ubuntu-24.04"
 # for NVIDIA, where the same repo path ships both Ubuntu (apt) and UBI
 # (dnf) variants and only the tag distinguishes them.
 # "Officially tested" (per AGENTS.md): ubuntu:24.04, fedora:43,
-# quay.io/containers/podman, nvcr.io/nvidia/nvhpc.  Other images in the
+# quay.io/podman/stable, nvcr.io/nvidia/nvhpc.  Other images in the
 # same family path will match but are unsupported.
 _NVIDIA_UBI_TAG_RE: re.Pattern[str] = re.compile(r"ubi\d+", re.IGNORECASE)
 
@@ -74,7 +74,7 @@ def _nvidia_family(tag: str) -> str:
 
 _KNOWN_FAMILIES: tuple[tuple[str, str | Callable[[str], str]], ...] = (
     ("registry.fedoraproject.org/fedora", "rpm"),
-    ("quay.io/containers/podman", "rpm"),
+    ("quay.io/podman", "rpm"),
     ("nvcr.io/nvidia", _nvidia_family),
     ("nvidia", _nvidia_family),
     ("ubuntu", "deb"),

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -604,7 +604,8 @@ class TestDetectFamily:
             ("debian:12", "deb"),
             ("fedora:43", "rpm"),
             ("registry.fedoraproject.org/fedora:43", "rpm"),
-            ("quay.io/containers/podman:latest", "rpm"),
+            ("quay.io/podman/stable:latest", "rpm"),
+            ("quay.io/podman/upstream:latest", "rpm"),
         ],
     )
     def test_known_prefixes(self, base_image: str, expected: str) -> None:
@@ -688,7 +689,7 @@ class TestRenderFamilyAware:
         assert "DEBIAN_FRONTEND" not in content
 
     def test_l0_podman_image_is_rpm(self) -> None:
-        content = render_l0("quay.io/containers/podman:latest")
+        content = render_l0("quay.io/podman/stable:latest")
         assert "dnf install" in content
         assert "apt-get" not in content
 


### PR DESCRIPTION
## Summary

The detect_family allowlist pointed at `quay.io/containers/podman`, but the official image lives at `quay.io/podman/stable` (with siblings `quay.io/podman/upstream`, `testing`, `minimal`, etc. under the same org). Users basing their project on the real image got a BuildError asking for an explicit \`family:\` override, which is avoidable — every image under \`quay.io/podman\` is rpm-based by construction.

## What changed

- \`_KNOWN_FAMILIES\`: prefix broadened to \`quay.io/podman\` (org-level) so \`stable\`, \`upstream\`, and any future sibling tag resolve to rpm without per-tag entries.
- Test parametrisation extended to both \`quay.io/podman/stable:latest\` and \`quay.io/podman/upstream:latest\`; the existing \`test_l0_podman_image_is_rpm\` updated to the correct path.
- Docstring comment updated.

## Test plan

- [x] \`make check\` — lint, 569 tests, tach, security, docstrings, REUSE all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Podman container image detection to recognize stable and upstream image variants, ensuring correct package manager configuration for Podman-derived base containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->