### PR TITLE
fix: drop `-o pipefail` from glab install snippet

### DIFF
--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -27,12 +27,14 @@ install:
   # extension (/tmp/glab.deb or /tmp/glab.rpm) because dnf5 only
   # recognises local RPM files by their .rpm suffix — any other name
   # is treated as a repo-package query and fails to resolve.
-  # pipefail makes the checksum verification (grep | sed |
-  # sha256sum -c -) hard-fail rather than silently accept an empty grep.
+  # `set -eux` only (no `-o pipefail`): Dockerfile RUN goes through
+  # /bin/sh, which is dash on Ubuntu.  The preceding `grep -q … || exit
+  # 1` already rejects a missing checksum line, so the checksum
+  # pipeline below can never see an empty grep result.
   run_as_root: |
     {% set pkg_ext = "deb" if family == "deb" else "rpm" %}
     {% set pkg_install = "dpkg -i" if family == "deb" else "dnf install -y" %}
-    RUN set -eux -o pipefail; \
+    RUN set -eux; \
         GLAB_VERSION=$(curl --fail -sSL "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest" \
           | jq -r '.tag_name | ltrimstr("v")'); \
         case "$(uname -m)" in \


### PR DESCRIPTION
## Summary

The glab install snippet's RUN used \`set -eux -o pipefail\`. That worked on Fedora (where \`/bin/sh\` is bash) but aborts on Ubuntu L1 builds with:

\`\`\`
/bin/sh: 1: set: Illegal option -o pipefail
\`\`\`

Dash (Ubuntu's \`/bin/sh\`) has no \`pipefail\` option.

## Why pipefail is safe to drop here

pipefail was a defense against the checksum-verification pipeline (\`grep | sed | sha256sum -c -\`) silently accepting an empty grep result.  But the snippet also runs \`grep -q \"  \${PKG_NAME}$\" /tmp/checksums.txt || { echo …; exit 1; }\` **before** the pipeline.  That explicit guard already hard-exits on a missing checksum line, so the pipeline can never see empty input.  The two were belt-and-suspenders.

## Scope

One-line behavioural change (\`set -eux -o pipefail\` → \`set -eux\`) plus an updated comment.  Pairs with terok-ai/terok-executor#174 (selectable agents — introduced this snippet).

## Test plan

- [x] \`make check\` — 584 tests, lint, tach, security, docstrings, REUSE all clean
- [ ] Manual \`terok build --refresh-agents\` on an Ubuntu host (downstream test)
- [x] Fedora host build already works (was never affected — bash is /bin/sh there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified shell configuration flags in the agent installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->