### PR TITLE
fix: never inject literal "None" TCP broker env under socket transport

### DIFF
--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -425,7 +425,12 @@ def _inject_vault_tokens(
         db.close()
 
     use_socket = vault_transport == "socket"
-    proxy_base = f"http://host.containers.internal:{port}"
+    # The broker's TCP address — absent under socket transport, where the
+    # broker listens only on the mounted Unix socket and ``port`` is ``None``.
+    # Container-side consumers that need an HTTP endpoint get nothing rather
+    # than the string ``"None"``.
+    tcp_broker = f"host.containers.internal:{port}" if port else None
+    proxy_base = f"http://{tcp_broker}" if tcp_broker else None
     env: dict[str, str] = {}
 
     for name, route in vault_routes.items():
@@ -441,19 +446,19 @@ def _inject_vault_tokens(
 
         if use_socket and route.socket_path and route.socket_env:
             env[route.socket_env] = route.socket_path
-        if route.base_url_env:
+        if route.base_url_env and proxy_base:
             env[route.base_url_env] = proxy_base
 
         # OpenCode base URL override for proxied providers
         provider = roster.providers.get(name)
-        if provider and provider.opencode_config:
+        if provider and provider.opencode_config and proxy_base:
             env[f"TEROK_OC_{name.upper()}_BASE_URL"] = f"{proxy_base}/v1"
         # glab: redirect API to proxy
-        if name == "glab":
-            env["GITLAB_API_HOST"] = f"host.containers.internal:{port}"
+        if name == "glab" and tcp_broker:
+            env["GITLAB_API_HOST"] = tcp_broker
             env["API_PROTOCOL"] = "http"
 
-    if routed:
+    if routed and port:
         env["TEROK_TOKEN_BROKER_PORT"] = str(port)
 
     if ssh_token:

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -503,6 +503,34 @@ class TestVaultTokenInjection:
 
         assert "ANTHROPIC_UNIX_SOCKET" not in result.env
 
+    def test_vault_socket_transport_omits_tcp_broker_env_when_port_none(
+        self, workspace, envs_dir, roster, tmp_path
+    ):
+        """Socket-only deployments have no TCP broker port; the env must reflect that.
+
+        Under socket transport the broker listens only on the mounted Unix socket,
+        and ``get_token_broker_port`` returns ``None``.  The assembled env must
+        omit every TCP-flavoured variable rather than interpolate the literal
+        string ``"None"`` — that string would otherwise leak through as
+        ``TEROK_TOKEN_BROKER_PORT="None"``, trip bridge scripts inside the
+        container, and silently break credential routing.
+        """
+        cfg = _make_vault_db(tmp_path)
+        spec = _spec(workspace, envs_dir, credential_scope="proj", vault_transport="socket")
+        with (
+            patch("terok_sandbox.is_vault_socket_active", return_value=True),
+            patch("terok_sandbox.SandboxConfig", return_value=cfg),
+            patch("terok_sandbox.get_token_broker_port", return_value=None),
+        ):
+            result = assemble_container_env(spec, roster, caller_manages_vault=False)
+
+        assert "TEROK_TOKEN_BROKER_PORT" not in result.env
+        assert "GITLAB_API_HOST" not in result.env
+        # No env value should contain the stringified ``None`` port.
+        assert not any("None" in v for v in result.env.values())
+        # Socket transport is still honoured.
+        assert result.env.get("ANTHROPIC_UNIX_SOCKET") == "/tmp/terok-claude-proxy.sock"
+
     def test_vault_required_raises_when_unreachable(self, workspace, envs_dir, roster):
         """vault_required=True raises SystemExit when vault is not running."""
         spec = _spec(workspace, envs_dir, vault_required=True)


### PR DESCRIPTION
## Summary

Under socket-only vault transport, `get_token_broker_port` returns `None` — the broker listens exclusively on the mounted Unix socket. `assemble_container_env` was unconditionally stringifying that `None` into every TCP-flavoured variable it produced, so `spec.env` ended up with `TEROK_TOKEN_BROKER_PORT="None"`, `GITLAB_API_HOST="host.containers.internal:None"`, and `http://host.containers.internal:None` base URLs for providers that declare a `base_url_env`.

Compute a single optional `tcp_broker` string and gate every TCP env write on it.

## Observed symptom

Inside the container: `echo \$TEROK_PROXY_PORT` → `None` (via the currently-released 0.0.85 naming). The container's `ensure-bridges.sh` sees the variable as non-empty and attempts to socat the gh proxy socket to an impossible TCP target, silently failing and leaving `/tmp/terok-gh-proxy.sock` as a dead listen socket. Every `gh` call then returns `401 Bad credentials`, even though the credential proxy is reachable on the mounted socket.

After the fix: `TEROK_TOKEN_BROKER_PORT` is simply not set; the bridge does not run; `gh` (pointed at `/run/terok/credential-proxy.sock`) works.

## Test plan

- [x] New test `test_vault_socket_transport_omits_tcp_broker_env_when_port_none` asserts no TEROK_TOKEN_BROKER_PORT, no GITLAB_API_HOST, and no env value containing the substring `"None"` — while still honouring the socket-env (`ANTHROPIC_UNIX_SOCKET`).
- [x] `make check` — lint, 65/65 unit tests, tach, security (0 M/H), docstrings (99.3%), REUSE — all green.
- [x] Existing socket-transport and TCP-transport tests still pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable configuration for socket transport mode to prevent spurious "None" string values from appearing in the container environment.
  * Ensured TCP broker and proxy settings are only set when actually available, preventing environment pollution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->