### PR TITLE
feat: version markers — roster_version + TEROK_CONTAINER_PROTOCOL

### DIFF
--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -33,6 +33,16 @@ from terok_sandbox import Sharing, VolumeSpec
 _CONTAINER_RUNTIME_DIR = "/run/terok"
 """Container-side mount point — must match :data:`terok_sandbox.CONTAINER_RUNTIME_DIR`."""
 
+CONTAINER_PROTOCOL = 1
+"""Version of the host↔container env/script contract.
+
+Emitted to every container as ``TEROK_CONTAINER_PROTOCOL``.  In-container
+scripts (``terok-env.sh`` and friends) read it to adapt to the version
+the host is shipping.  Bumped on breaking changes to the env-var or
+script-interface contract between host and container, not on every
+release.  Old containers on protocol N keep running; new containers get
+protocol N+1 and carry the matching host-side code."""
+
 if TYPE_CHECKING:
     from terok_sandbox import CredentialDB, SandboxConfig
 
@@ -202,6 +212,7 @@ def assemble_container_env(
     env["TASK_ID"] = spec.task_id
     env["REPO_ROOT"] = "/workspace"
     env["GIT_RESET_MODE"] = "none"
+    env["TEROK_CONTAINER_PROTOCOL"] = str(CONTAINER_PROTOCOL)
     env["CLAUDE_CONFIG_DIR"] = "/home/dev/.claude"
 
     # 2. OpenCode provider env

--- a/src/terok_executor/resources/agents/blablador.yaml
+++ b/src/terok_executor/resources/agents/blablador.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: opencode
 label: Blablador
 binary: blablador

--- a/src/terok_executor/resources/agents/claude.yaml
+++ b/src/terok_executor/resources/agents/claude.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: native
 label: Claude
 binary: claude

--- a/src/terok_executor/resources/agents/coderabbit.yaml
+++ b/src/terok_executor/resources/agents/coderabbit.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: tool
 label: CodeRabbit
 binary: coderabbit

--- a/src/terok_executor/resources/agents/codex.yaml
+++ b/src/terok_executor/resources/agents/codex.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: native
 label: Codex
 binary: codex

--- a/src/terok_executor/resources/agents/copilot.yaml
+++ b/src/terok_executor/resources/agents/copilot.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: native
 label: GitHub Copilot
 binary: copilot

--- a/src/terok_executor/resources/agents/gh.yaml
+++ b/src/terok_executor/resources/agents/gh.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: tool
 label: GitHub CLI
 binary: gh

--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: tool
 label: GitLab CLI
 binary: glab

--- a/src/terok_executor/resources/agents/kisski.yaml
+++ b/src/terok_executor/resources/agents/kisski.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: opencode
 label: KISSKI
 binary: kisski

--- a/src/terok_executor/resources/agents/opencode.yaml
+++ b/src/terok_executor/resources/agents/opencode.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: bridge
 label: OpenCode
 binary: opencode

--- a/src/terok_executor/resources/agents/sonar.yaml
+++ b/src/terok_executor/resources/agents/sonar.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: tool
 label: SonarCloud
 binary: sonar-scanner

--- a/src/terok_executor/resources/agents/toad.yaml
+++ b/src/terok_executor/resources/agents/toad.yaml
@@ -3,6 +3,8 @@
 
 # Toad multi-agent TUI — shared config dir for theme and launcher state.
 # Not an agent or tool — a runtime component installed in L1.
+roster_version: 1
+
 kind: runtime
 label: Toad
 binary: toad

--- a/src/terok_executor/resources/agents/vibe.yaml
+++ b/src/terok_executor/resources/agents/vibe.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
+roster_version: 1
+
 kind: native
 label: Mistral Vibe
 binary: vibe

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -39,6 +39,17 @@ if TYPE_CHECKING:
 
 _USER_AGENTS_DIR_NAME = "agents"
 
+ROSTER_VERSION = 1
+"""Schema version of the agent-roster YAML format.
+
+Bundled agent YAMLs and user override files declare a top-level
+``roster_version: 1`` that matches this constant.  A file with no
+``roster_version`` is treated as version 1 (forward-compat for existing
+user overrides written before the marker existed).  A file declaring a
+future version is still loaded but the loader logs a warning — the host
+and container may be on incompatible contracts.  Bumped only on breaking
+changes to the roster schema, never per release."""
+
 
 # ── Domain model ──────────────────────────────────────────────────────────
 
@@ -569,8 +580,7 @@ def _load_bundled_agents() -> dict[str, dict]:
                 file=sys.stderr,
             )
             continue
-        if data:
-            agents[name] = data
+        _add_agent(agents, name, data, source=f"bundled {name}.yaml")
     return agents
 
 
@@ -591,9 +601,60 @@ def _load_user_agents() -> dict[str, dict]:
                 file=sys.stderr,
             )
             continue
-        if data:
-            agents[name] = data
+        _add_agent(agents, name, data, source=str(path))
     return agents
+
+
+def _add_agent(agents: dict[str, dict], name: str, data: dict | None, *, source: str) -> None:
+    """Validate, strip version metadata, and add an agent entry if it has content.
+
+    Files that turn out to be pure metadata (e.g. only ``roster_version``)
+    are skipped — they contribute no agent definition and would otherwise
+    land as an empty dict downstream and surprise the deserializer.
+    """
+    if not data:
+        return
+    _check_roster_version(name, data, source=source)
+    if not data:
+        # Purely metadata file (only ``roster_version`` was present).
+        print(
+            f"Info [roster]: skipping metadata-only file ({source}) — "
+            f"no agent definition to register for {name!r}.",
+            file=sys.stderr,
+        )
+        return
+    agents[name] = data
+
+
+def _check_roster_version(name: str, data: dict, *, source: str) -> None:
+    """Strip the ``roster_version`` marker and warn only on a *future* version.
+
+    Missing or older versions still load silently — existing user overrides
+    written before the marker existed must keep working, and older-but-still-
+    understood roster files are the backward-compat path.  A declared
+    version strictly greater than :data:`ROSTER_VERSION` prints a warning,
+    because the host may not speak every field the file uses.
+    """
+    declared = data.pop("roster_version", None)
+    if declared is None:
+        return
+    try:
+        declared_int = int(declared)
+    except (TypeError, ValueError):
+        print(
+            f"Warning [roster]: {source} declares roster_version={declared!r}, "
+            f"which is not a valid integer version; treating as current.",
+            file=sys.stderr,
+        )
+        return
+    if declared_int > ROSTER_VERSION:
+        print(
+            f"Warning [roster]: {source} declares roster_version={declared_int}, "
+            f"but this terok-executor speaks version {ROSTER_VERSION}.  "
+            f"Some fields in {name!r} may be ignored; upgrade terok-executor "
+            f"or adjust the file.",
+            file=sys.stderr,
+        )
 
 
 # ── Deserialization ───────────────────────────────────────────────────────

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -131,6 +131,14 @@ class TestBaseEnv:
         result = assemble_container_env(base_spec, roster, caller_manages_vault=True)
         assert isinstance(result, ContainerEnvResult)
 
+    def test_container_protocol_marker(self, base_spec, roster):
+        """Every container receives the host↔container contract version so
+        in-container scripts can adapt on an update without guessing."""
+        from terok_executor.container.env import CONTAINER_PROTOCOL
+
+        result = assemble_container_env(base_spec, roster, caller_manages_vault=True)
+        assert result.env["TEROK_CONTAINER_PROTOCOL"] == str(CONTAINER_PROTOCOL)
+
 
 # ---------------------------------------------------------------------------
 # Git identity

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -85,6 +85,116 @@ class TestLoadBundledAgents:
             assert "container_mount" in auth, f"tool {name}: missing auth.container_mount"
 
 
+class TestRosterVersion:
+    """Roster-schema versioning lets in-container contracts evolve without
+    silently breaking existing user overrides."""
+
+    def test_every_bundled_yaml_declares_version(self) -> None:
+        """Every shipped YAML declares ``roster_version: 1`` so the file
+        is self-describing — readers (including sessions that pull raw
+        YAML without the loader) know which contract it targets."""
+        import importlib.resources
+
+        from terok_executor.roster.loader import ROSTER_VERSION, _load_yaml
+
+        pkg = importlib.resources.files("terok_executor.resources.agents")
+        missing = []
+        for item in pkg.iterdir():
+            if not hasattr(item, "name") or not item.name.endswith(".yaml"):
+                continue
+            data = _load_yaml(item.read_text(encoding="utf-8"))
+            if data.get("roster_version") != ROSTER_VERSION:
+                missing.append(item.name)
+        assert not missing, f"bundled YAMLs lacking roster_version={ROSTER_VERSION}: {missing}"
+
+    def test_loader_accepts_current_version(self, capsys) -> None:
+        """Version matching ``ROSTER_VERSION`` loads silently."""
+        from terok_executor.roster.loader import ROSTER_VERSION, _check_roster_version
+
+        _check_roster_version("x", {"roster_version": ROSTER_VERSION}, source="test")
+        assert capsys.readouterr().err == ""
+
+    def test_loader_accepts_missing_version(self, capsys) -> None:
+        """Missing version is treated as the current version — existing
+        user overrides written before the marker existed must keep working."""
+        from terok_executor.roster.loader import _check_roster_version
+
+        _check_roster_version("x", {"kind": "native"}, source="test")
+        assert capsys.readouterr().err == ""
+
+    def test_loader_accepts_older_version_silently(self, capsys) -> None:
+        """A declared version *older* than the current loader is the
+        backward-compat path — the loader knows how to read it, no warning."""
+        from terok_executor.roster.loader import _check_roster_version
+
+        _check_roster_version("x", {"roster_version": 0}, source="old.yaml")
+        assert capsys.readouterr().err == ""
+
+    def test_loader_warns_on_future_version(self, capsys) -> None:
+        """A future version still loads but surfaces a warning — the host
+        may not speak every field in the file."""
+        from terok_executor.roster.loader import _check_roster_version
+
+        _check_roster_version("x", {"roster_version": 99}, source="user.yaml")
+        stderr = capsys.readouterr().err
+        assert "roster_version=99" in stderr
+        assert "user.yaml" in stderr
+
+    def test_loader_warns_on_non_integer_version(self, capsys) -> None:
+        """A non-integer version is malformed metadata; warn and treat
+        as current so the file still loads."""
+        from terok_executor.roster.loader import _check_roster_version
+
+        _check_roster_version("x", {"roster_version": "one-point-oh"}, source="weird.yaml")
+        stderr = capsys.readouterr().err
+        assert "not a valid integer" in stderr
+
+    def test_loader_strips_version_from_data(self) -> None:
+        """``roster_version`` is metadata, not a field the deserializer
+        should see — removed from the dict before it flows downstream."""
+        from terok_executor.roster.loader import _check_roster_version
+
+        data = {"roster_version": 1, "kind": "native"}
+        _check_roster_version("x", data, source="test")
+        assert "roster_version" not in data
+
+    def test_metadata_only_file_is_skipped(self, capsys) -> None:
+        """A YAML containing only ``roster_version`` has no agent to
+        register — don't add an empty dict to the roster that would
+        later confuse the deserializer."""
+        from terok_executor.roster.loader import _add_agent
+
+        agents: dict[str, dict] = {}
+        _add_agent(agents, "meta_only", {"roster_version": 1}, source="meta.yaml")
+        assert agents == {}
+        assert "metadata-only" in capsys.readouterr().err
+
+    def test_add_agent_preserves_real_content(self) -> None:
+        """Non-empty agent definitions land in the map with their version
+        marker stripped out."""
+        from terok_executor.roster.loader import _add_agent
+
+        agents: dict[str, dict] = {}
+        _add_agent(
+            agents,
+            "claude",
+            {"roster_version": 1, "kind": "native", "label": "Claude"},
+            source="test.yaml",
+        )
+        assert "claude" in agents
+        assert "roster_version" not in agents["claude"]
+        assert agents["claude"]["label"] == "Claude"
+
+    def test_add_agent_ignores_empty_input(self) -> None:
+        """Empty or ``None`` data (parse error / blank file) is a no-op."""
+        from terok_executor.roster.loader import _add_agent
+
+        agents: dict[str, dict] = {}
+        _add_agent(agents, "empty", None, source="blank.yaml")
+        _add_agent(agents, "also_empty", {}, source="blank2.yaml")
+        assert agents == {}
+
+
 # ---------------------------------------------------------------------------
 # Deserialization
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two forward-compat version markers for deployment so host and container can evolve across updates without silently breaking existing containers or user overrides.

- **`TEROK_CONTAINER_PROTOCOL=1`** — set in every container's env by `assemble_container_env()`. In-container scripts (`terok-env.sh` etc.) can branch on this once we ever need a breaking host↔container contract change. New constant `CONTAINER_PROTOCOL` lives in `container/env.py` and is bumped only on breaking contract changes, not per release.
- **`roster_version: 1`** — declared at the top of every bundled agent YAML. New constant `ROSTER_VERSION` in `roster/loader.py` matches. The loader strips the marker before deserialization (metadata, not a schema field), treats missing as current (existing user overrides keep working), and warns on future versions without failing.

Covers gates H4 (roster_version) and H5 (TEROK_CONTAINER_PROTOCOL) from the stability memo. H6 (OCI hook format-version check) was already shipped via shield's `_read_installed_hook_version` / `stale-hooks` health flag.

## Test plan

- [x] `make lint` — clean
- [x] `make tach` — clean
- [x] `make docstrings` — 99.3%
- [x] `poetry run pytest tests/unit/test_roster.py tests/unit/test_env_builder.py -q` — 116 passed; 5 new tests (`TestRosterVersion`) plus `TestBaseEnv::test_container_protocol_marker`
- [x] `make check` — full suite clean including REUSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container environments now include an explicit protocol marker for host↔container coordination.
  * Agent resource manifests now include an explicit roster_version field for clearer versioning.

* **Behavioral Changes**
  * Loader validates roster_version, silently accepts current/older versions, and warns for future/invalid versions.

* **Tests**
  * Unit tests added covering protocol marker, roster_version handling, and related warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->