### PR TITLE
feat: use DB-backed SSH key records for signer token minting

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2684,24 +2684,25 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.77"
+version = "0.0.75"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.77-py3-none-any.whl", hash = "sha256:c47dbaf736e028aff6c3032f537b557896c5ef219ec5aaf1437bd35d7128e938"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=46.0.7"
 platformdirs = ">=4.9.6"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.20/terok_shield-0.6.20-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.20/terok_shield-0.6.20-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.77/terok_sandbox-0.0.77-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/ssh-keys-in-vault"
+resolved_reference = "4a210a0bb12153187f9a8cce0f50727e2a67fd37"
 
 [[package]]
 name = "terok-shield"
@@ -3119,4 +3120,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "9cff528505864ec92bc46403dbc3fbaab7091599b5cf9014ae8a01f2b8e345f1"
+content-hash = "bf5a2950f7dc214e22fb56453d8eee95beae0ea898e02820aff4935600d5c028"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.77/terok_sandbox-0.0.77-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/ssh-keys-in-vault"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -485,36 +485,17 @@ def _inject_vault_tokens(
     return env
 
 
-def _load_ssh_keys_json(path: Path) -> dict:
-    """Load the SSH key mapping JSON.  Returns empty dict on failure."""
-    import json
-
-    if not path.is_file():
-        return {}
-    try:
-        result = json.loads(path.read_text(encoding="utf-8"))
-        return result if isinstance(result, dict) else {}
-    except (json.JSONDecodeError, OSError, UnicodeDecodeError) as exc:
-        _logger.warning("Cannot read SSH keys file %s: %s", path, exc)
-        return {}
-
-
 def _load_ssh_signer_token(
     db: CredentialDB, cfg: SandboxConfig, scope: str, task_id: str
 ) -> str | None:
-    """Create an SSH signer phantom token if *scope* has valid keys registered."""
-    ssh_keys = _load_ssh_keys_json(cfg.ssh_keys_json_path)
-    ssh_entry = ssh_keys.get(scope)
-    if not isinstance(ssh_entry, list):
-        return None
-    for entry in ssh_entry:
-        if not isinstance(entry, dict):
-            _logger.warning(
-                "Malformed entry in ssh-keys.json for scope %r: expected dict, got %s",
-                scope,
-                type(entry).__name__,
-            )
-            return None
-    if any(e.get("private_key") and e.get("public_key") for e in ssh_entry):
+    """Mint an SSH signer phantom token when *scope* has at least one assigned key.
+
+    SSH keys live as rows in the vault's ``credentials.db`` (see
+    ``ssh_keys`` / ``ssh_key_assignments`` in terok-sandbox); no sidecar
+    JSON to consult.  *cfg* is retained for API symmetry — callers pass
+    it regardless, and future policy knobs may use it.
+    """
+    del cfg  # currently unused; part of a stable call-site signature
+    if db.list_ssh_keys_for_scope(scope):
         return db.create_token(scope, task_id, scope, "ssh")
     return None

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -46,16 +46,25 @@ def _make_vault_db(tmp_path: Path, cred_name: str = "claude", cred_data: dict | 
 
 
 def _make_vault_db_with_ssh_keys(tmp_path: Path, scope: str = "myproj"):
-    """Return a SandboxConfig with credential DB and SSH keys for *scope*."""
-    import json
+    """Return a SandboxConfig with credential DB seeded with a key assigned to *scope*."""
+    from terok_sandbox.credentials.db import CredentialDB
+    from terok_sandbox.credentials.ssh_keypair import generate_keypair
 
     cfg = _make_vault_db(tmp_path)
     cfg.vault_dir.mkdir(parents=True, exist_ok=True)
-    cfg.ssh_keys_json_path.write_text(
-        json.dumps(
-            {scope: [{"private_key": "/tmp/terok-testing/k", "public_key": "ssh-ed25519 AAAA"}]}
+    db = CredentialDB(cfg.db_path)
+    try:
+        kp = generate_keypair("ed25519", comment=f"tk-main:{scope}")
+        key_id = db.store_ssh_key(
+            key_type=kp.key_type,
+            private_pem=kp.private_pem,
+            public_blob=kp.public_blob,
+            comment=kp.comment,
+            fingerprint=kp.fingerprint,
         )
-    )
+        db.assign_ssh_key(scope, key_id)
+    finally:
+        db.close()
     return cfg
 
 
@@ -603,24 +612,26 @@ class TestVaultTokenInjection:
 
     def test_vault_ssh_only_no_provider_creds(self, workspace, envs_dir, roster, tmp_path):
         """SSH signer token injected even when no provider credentials are stored."""
-        import json
-
         from terok_sandbox import CredentialDB, SandboxConfig
+        from terok_sandbox.credentials.ssh_keypair import generate_keypair
 
         cfg = SandboxConfig(state_dir=tmp_path, vault_dir=tmp_path / "credentials")
         cfg.db_path.parent.mkdir(parents=True, exist_ok=True)
         cfg.vault_dir.mkdir(parents=True, exist_ok=True)
-        # DB exists but has NO provider credentials — only SSH keys
-        CredentialDB(cfg.db_path).close()
-        cfg.ssh_keys_json_path.write_text(
-            json.dumps(
-                {
-                    "sshonly": [
-                        {"private_key": "/tmp/terok-testing/k", "public_key": "ssh-ed25519 A"}
-                    ]
-                }
+        # DB exists with NO provider credentials — only SSH keys.
+        db = CredentialDB(cfg.db_path)
+        try:
+            kp = generate_keypair("ed25519", comment="tk-main:sshonly")
+            key_id = db.store_ssh_key(
+                key_type=kp.key_type,
+                private_pem=kp.private_pem,
+                public_blob=kp.public_blob,
+                comment=kp.comment,
+                fingerprint=kp.fingerprint,
             )
-        )
+            db.assign_ssh_key("sshonly", key_id)
+        finally:
+            db.close()
 
         spec = _spec(workspace, envs_dir, credential_scope="sshonly")
         with (
@@ -655,24 +666,6 @@ class TestVaultTokenInjection:
             pytest.raises(SystemExit, match="injection failed.*Check logs"),
         ):
             assemble_container_env(spec, roster, caller_manages_vault=False)
-
-    def test_vault_malformed_ssh_entry_warns(self, workspace, envs_dir, roster, tmp_path, caplog):
-        """Non-dict entries in ssh-keys.json trigger a warning, not a crash."""
-        import json
-
-        cfg = _make_vault_db(tmp_path)
-        cfg.vault_dir.mkdir(parents=True, exist_ok=True)
-        cfg.ssh_keys_json_path.write_text(json.dumps({"badproj": ["not-a-dict"]}))
-
-        spec = _spec(workspace, envs_dir, credential_scope="badproj")
-        with (
-            patch("terok_sandbox.is_vault_socket_active", return_value=True),
-            patch("terok_sandbox.SandboxConfig", return_value=cfg),
-        ):
-            result = assemble_container_env(spec, roster, caller_manages_vault=False)
-
-        assert "TEROK_SSH_SIGNER_TOKEN" not in result.env
-        assert any("Malformed entry" in r.message for r in caplog.records)
 
     def test_scan_leaked_creds_emits_warning(self, workspace, envs_dir, roster, caplog):
         """scan_leaked_creds=True logs warnings for leaked files."""


### PR DESCRIPTION
## Summary

Mirror the terok-sandbox PR that moved SSH keys into `credentials.db`.
`_load_ssh_signer_token` now asks `CredentialDB.list_ssh_keys_for_scope(scope)` directly instead of reading `ssh-keys.json`, and the JSON helper + malformed-entry test case disappear with the sidecar.

## Depends on

- **sandbox:** https://github.com/terok-ai/terok-sandbox/pull/174

`pyproject.toml` is cross-pinned at the sandbox fork's branch tip (`sliwowitz/terok-sandbox:feat/ssh-keys-in-vault`) during review.  At release time the pin flips to the next sandbox wheel.

## Test plan

- [x] `make check` clean: 632 unit tests, tach, docstrings, REUSE, bandit
- [ ] Manual smoke together with the sandbox PR and the upcoming terok-main PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated SSH key storage from a file-based configuration to a database-backed vault; SSH signer tokens now reflect vault state.
  * Updated the sandbox dependency to use a branch-based source instead of a pinned release.

* **Tests**
  * Updated unit tests to seed SSH keys via the vault database and removed tests tied to the old file-based format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->