### PR TITLE
refactor(cli): rename `ls` → `list`

### DIFF
--- a/docs/launch-modes.md
+++ b/docs/launch-modes.md
@@ -48,7 +48,7 @@ the list of supported tools.
 ## Managing containers
 
 ```bash
-terok-executor ls              # list running containers
+terok-executor list            # list running containers
 terok-executor stop my-task    # stop a specific container
 ```
 

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -280,7 +280,7 @@ def _handle_build(
         print(f"L1 (sidecar): {tag}")
 
 
-def _handle_ls() -> None:
+def _handle_list() -> None:
     """List running terok-executor containers."""
     from terok_sandbox import get_container_states
 
@@ -463,7 +463,7 @@ BUILD_COMMAND = CommandDef(
     ),
 )
 
-LS_COMMAND = CommandDef(name="ls", help="List running containers", handler=_handle_ls)
+LIST_COMMAND = CommandDef(name="list", help="List running containers", handler=_handle_list)
 
 STOP_COMMAND = CommandDef(
     name="stop",
@@ -493,6 +493,6 @@ COMMANDS: tuple[CommandDef, ...] = (
     AGENTS_COMMAND,
     BUILD_COMMAND,
     SETUP_COMMAND,
-    LS_COMMAND,
+    LIST_COMMAND,
     STOP_COMMAND,
 )


### PR DESCRIPTION
## Summary

Aligns with every other list verb in the ecosystem: `vault list`, `ssh list`, `agents`, and (over in terok) `project list`, `task list`, `image list`.  `ls` was a Unix reflex that looked out of place alongside the rest of the surface.

## Context

In terok-ai/terok#748 I ended up maintaining a ``rename={"ls": "list"}`` translation table on the terok side to paper over this. That was the wrong place — cosmetic sibling naming belongs in the sibling package itself, not as a higher-level translation. The terok-side mechanism was already reverted; this PR is the proper upstream fix.

## Diff shape

- `LS_COMMAND` → `LIST_COMMAND`
- `_handle_ls` → `_handle_list`
- Command name: `"ls"` → `"list"`
- Docs example (`docs/launch-modes.md`) updated

## Test plan

- [x] 633 unit tests pass
- [x] `make lint` clean
- [x] `terok-executor --help` shows `list` in the subcommand listing
- [ ] Users of `terok-executor ls` will need to switch to `list` — breaking change, but early-design policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command reference for container operations.

* **Refactor**
  * Container listing command renamed from `ls` to `list` for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->