### PR TITLE
feat(roster): Caddy auth-gate for toad's web UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.93"
+version = "0.0.94"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_executor/resources/agents/caddy.yaml
+++ b/src/terok_executor/resources/agents/caddy.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Caddy reverse proxy — runtime ingress that gates web-UI roster entries
+# (toad today, Vibes and others in future) with a per-container token.
+# Not an agent or tool: pulled in via ``install.depends_on: [caddy]``.
+roster_version: 1
+
+kind: runtime
+label: Caddy
+
+install:
+  # Debian 12+ and Fedora 40+ both ship ``caddy`` in their default repos;
+  # no third-party apt source is needed.  The Caddyfile is staged to
+  # /etc/caddy and the token env var ({$TOAD_TOKEN}) is resolved at
+  # ``caddy run`` time by the per-UI supervisor script.
+  run_as_root: |
+    {% if family == "deb" %}
+    RUN set -eux; \
+        apt-get update; \
+        apt-get install -y --no-install-recommends caddy; \
+        rm -rf /var/lib/apt/lists/*
+    {% else %}
+    RUN set -eux; \
+        dnf install -y caddy; \
+        dnf clean all
+    {% endif %}
+    RUN set -eux; \
+        install -m 0644 /tmp/terok-scripts/Caddyfile /etc/caddy/Caddyfile

--- a/src/terok_executor/resources/agents/toad.yaml
+++ b/src/terok_executor/resources/agents/toad.yaml
@@ -9,6 +9,11 @@ kind: runtime
 label: Toad
 binary: toad
 
+# Host-published HTTP port gated by the Caddy sidecar; terok's launch
+# path reads this flag to allocate a port, drop a per-task token, and
+# render click-through links.
+web_ingress: true
+
 mounts:
   - host_dir: _toad-config
     container_path: /home/dev/.config/toad
@@ -18,12 +23,15 @@ install:
   # Toad needs Python ≥3.14; uv installs a standalone interpreter so the
   # system Python stays untouched.  The uv-created symlink is removed so
   # the wrapper at /usr/local/bin/toad takes precedence in PATH.
-  # toad-agents/ ships the bundled ACP launcher TOMLs.
+  # toad-agents/ ships the bundled ACP launcher TOMLs.  terok-toad-entry
+  # is the supervisor launched as the container command — it starts the
+  # Caddy auth gate before exec-ing toad on a loopback port.
+  depends_on: [caddy]
   run_as_root: |
     COPY toad-agents/ /usr/local/share/terok/toad-agents/
     RUN set -eux; \
-        cp /tmp/terok-scripts/toad /usr/local/bin/toad; \
-        chmod +x /usr/local/bin/toad
+        install -m 0755 /tmp/terok-scripts/toad /usr/local/bin/toad; \
+        install -m 0755 /tmp/terok-scripts/terok-toad-entry /usr/local/bin/terok-toad-entry
   run_as_dev: |
     RUN uv tool install batrachian-toad --python 3.14 \
      && rm -f ~/.local/bin/toad

--- a/src/terok_executor/resources/scripts/Caddyfile
+++ b/src/terok_executor/resources/scripts/Caddyfile
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Token-gated HTTP ingress for containerized web UIs (toad, Vibes, ...).
+# Env variables consumed at ``caddy run`` time:
+#   TOAD_TOKEN         — shared secret checked via CEL equality
+#   TOAD_UPSTREAM      — inner host:port the supervisor launched toad on
+#   TOAD_PUBLIC_PORT   — listener port (matches the supervisor's probe)
+{
+	auto_https off
+	admin off
+}
+
+:{$TOAD_PUBLIC_PORT:8080} {
+	# Literal equality via CEL expressions — avoids any regex-metacharacter
+	# risk from interpolated tokens.  Caddy resolves {$TOAD_TOKEN} at config
+	# load time, well before any request hits these matchers.
+	@authed expression `{http.request.cookie.terok_token} == "{$TOAD_TOKEN}"`
+	@seed expression `{http.request.uri.query.token} == "{$TOAD_TOKEN}"`
+
+	handle @authed {
+		reverse_proxy {$TOAD_UPSTREAM}
+	}
+
+	handle @seed {
+		# SameSite=Lax (not Strict): the seed link is frequently clicked
+		# from another origin — e.g. the parent terok-tui served over
+		# textual-serve on a different port — and Strict would withhold
+		# the cookie on the 303's follow-up request, dropping us back to
+		# @seed's own redirect → 401 loop.  Lax still blocks cross-site
+		# POST/subresource leaks.
+		header Set-Cookie "terok_token={$TOAD_TOKEN}; Path=/; HttpOnly; SameSite=Lax"
+		redir {path} 303
+	}
+
+	handle {
+		respond "Unauthorized" 401
+	}
+}

--- a/src/terok_executor/resources/scripts/terok-toad-entry
+++ b/src/terok_executor/resources/scripts/terok-toad-entry
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+#
+# Supervisor wrapper: bootstraps the workspace, starts Caddy as an auth
+# gate on port 8080, launches toad on loopback, waits for both to bind,
+# then signals readiness via the ``TEROK_READY`` marker that terok's
+# host-side readiness check greps for.
+
+set -euo pipefail
+
+TOKEN_FILE="${TOAD_TOKEN_FILE:-/home/dev/.terok/toad.token}"
+PUBLIC_PORT="${TOAD_PUBLIC_PORT:-8080}"
+INTERNAL_PORT="${TOAD_INTERNAL_PORT:-8081}"
+
+if [[ ! -r "$TOKEN_FILE" ]]; then
+    echo "terok-toad-entry: token file $TOKEN_FILE is missing or unreadable" >&2
+    exit 1
+fi
+TOAD_TOKEN="$(tr -d '\r\n' <"$TOKEN_FILE")"
+# Defence in depth against a hand-edited token file: terok mints
+# secrets.token_urlsafe(32) which is urlsafe-base64, but we still
+# reject anything outside [A-Za-z0-9_-] before exporting so stray
+# quotes/semicolons can't leak into the Caddyfile env expansion.
+if [[ -z "$TOAD_TOKEN" ]] || (( ${#TOAD_TOKEN} > 256 )) \
+   || [[ ! "$TOAD_TOKEN" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    echo "terok-toad-entry: token in $TOKEN_FILE is empty or malformed" >&2
+    exit 1
+fi
+TOAD_UPSTREAM="127.0.0.1:${INTERNAL_PORT}"
+# Caddy's listener is ``:{$TOAD_PUBLIC_PORT:8080}``, so it sees the same
+# port our probe below waits for.
+export TOAD_TOKEN TOAD_UPSTREAM TOAD_PUBLIC_PORT
+
+# Workspace bootstrap (git clone/fetch, managed settings) — unchanged
+# from the pre-Caddy launch flow.
+init-ssh-and-repo.sh
+
+caddy run --config /etc/caddy/Caddyfile --adapter caddyfile &
+CADDY_PID=$!
+
+toad --serve -H 127.0.0.1 -p "$INTERNAL_PORT" "$@" &
+TOAD_PID=$!
+
+wait_for_port() {
+    local port="$1" retries=100
+    until (echo >"/dev/tcp/127.0.0.1/${port}") >/dev/null 2>&1; do
+        retries=$((retries - 1))
+        if (( retries <= 0 )); then
+            return 1
+        fi
+        sleep 0.2
+    done
+}
+
+if ! wait_for_port "$PUBLIC_PORT"; then
+    echo "terok-toad-entry: caddy failed to bind :${PUBLIC_PORT}" >&2
+    exit 1
+fi
+if ! wait_for_port "$INTERNAL_PORT"; then
+    echo "terok-toad-entry: toad failed to bind 127.0.0.1:${INTERNAL_PORT}" >&2
+    exit 1
+fi
+
+echo "TEROK_READY"
+
+# Exit when either child dies so a Caddy crash brings the container
+# down rather than leaving toad reachable without the auth gate.
+# ``wait -n`` needs Bash 4.3+; we're on Bash 5 in the images.  The
+# ``if`` block absorbs the non-zero exit under ``set -e``.
+if wait -n "$TOAD_PID" "$CADDY_PID"; then
+    EXIT=0
+else
+    EXIT=$?
+fi
+kill "$TOAD_PID" "$CADDY_PID" 2>/dev/null || true
+wait "$TOAD_PID" 2>/dev/null || true
+wait "$CADDY_PID" 2>/dev/null || true
+exit "$EXIT"

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -196,6 +196,7 @@ class AgentRoster:
     _mounts: tuple[MountDef, ...] = ()
     _agent_names: tuple[str, ...] = ()
     _all_names: tuple[str, ...] = ()
+    _web_ingress: frozenset[str] = frozenset()
 
     # ── Properties ──
 
@@ -238,6 +239,16 @@ class AgentRoster:
     def helps(self) -> dict[str, HelpSpec]:
         """All help blurbs, keyed by roster name (entries without one are absent)."""
         return dict(self._helps)
+
+    @property
+    def web_ingress(self) -> frozenset[str]:
+        """Names of entries that publish a host HTTP port (``web_ingress: true``).
+
+        Consumers (e.g. terok's task launcher) use this to decide whether
+        to allocate a published port and drop a per-task auth token into
+        the container-visible config dir.
+        """
+        return self._web_ingress
 
     # ── Selection ──
 
@@ -432,6 +443,7 @@ def load_roster() -> AgentRoster:
     helps: dict[str, HelpSpec] = {}
     agent_names: list[str] = []
     all_names: list[str] = []
+    web_ingress_names: set[str] = set()
 
     # Collect mounts from all entries — deduplicate by host_dir
     seen_mounts: dict[str, MountDef] = {}
@@ -497,6 +509,15 @@ def load_roster() -> AgentRoster:
         if help_spec is not None:
             helps[name] = help_spec
 
+        raw_web_ingress = data.get("web_ingress", False)
+        if not isinstance(raw_web_ingress, bool):
+            raise ValueError(
+                f"Agent {name!r}: web_ingress must be a boolean, got "
+                f"{type(raw_web_ingress).__name__}"
+            )
+        if raw_web_ingress:
+            web_ingress_names.add(name)
+
     return AgentRoster(
         _providers=providers,
         _auth_providers=auth_providers,
@@ -507,6 +528,7 @@ def load_roster() -> AgentRoster:
         _mounts=tuple(seen_mounts.values()),
         _agent_names=tuple(agent_names),
         _all_names=tuple(all_names),
+        _web_ingress=frozenset(web_ingress_names),
     )
 
 

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -43,6 +43,7 @@ class TestLoadBundledAgents:
     def test_loads_all_bundled_agents(self) -> None:
         agents = _load_bundled_agents()
         expected = {
+            "caddy",
             "claude",
             "coderabbit",
             "codex",
@@ -476,6 +477,25 @@ class TestDeserializeSidecar:
         reg = load_roster()
         with pytest.raises(SystemExit, match="No sidecar config"):
             reg.get_sidecar_spec("nonexistent")
+
+
+class TestWebIngress:
+    """Verify the ``web_ingress`` flag is surfaced via the roster."""
+
+    def test_toad_is_web_ingress(self) -> None:
+        reg = load_roster()
+        assert "toad" in reg.web_ingress
+
+    def test_non_web_agents_absent(self) -> None:
+        reg = load_roster()
+        assert "claude" not in reg.web_ingress
+        assert "caddy" not in reg.web_ingress
+
+    def test_toad_depends_on_caddy(self) -> None:
+        reg = load_roster()
+        # resolve_selection returns the canonical alphabetical tuple.
+        # Asserting the exact set guards against accidental extras creeping in.
+        assert reg.resolve_selection(("toad",)) == ("caddy", "toad")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Install **Caddy** in task-container images as a token-gated reverse proxy in front of `toad`'s web UI. On a shared multi-user host, toad's published port was reachable by every local user — Caddy enforces a per-container token so only the owning user's browser gets through.

## How it works

- **New roster entry** `caddy` (`kind: runtime`) installs the Caddy binary and a shared `Caddyfile`. **`toad` declares** `install.depends_on: [caddy]`, so selecting `toad` transitively pulls Caddy into the L1 image (tag suffix: `…-caddy-…-toad`).
- The Caddyfile listens on `:8080` (the port terok publishes) and gates every request with CEL expression matchers against an env-injected `$TOAD_TOKEN`:
  - first hit with `?token=…` → `Set-Cookie: terok_token=…; HttpOnly` + `303` to the clean path
  - subsequent requests → cookie match → `reverse_proxy 127.0.0.1:8081` to toad
  - anything else → `401`
- A small supervisor `terok-toad-entry` starts Caddy + toad, waits for both to bind, emits `TEROK_READY` on stdout (host-side readiness marker).
- New roster-schema field `web_ingress: true` flags entries that need host-port publishing; surfaced on `AgentRoster.web_ingress` for downstream consumers (future: Vibes).

## Key choices

- **Caddy** over nginx/custom middleware — smallest declarative config, auth primitives built in, env substitution at load.
- **CEL `expression` matchers** over `header_regexp` — literal equality, no regex-metachar risk from an interpolated token.
- **Cookie seeded from `?token=…` query** rather than asserting per-request — textual-serve emits absolute URLs from `public_url` without tokens, so cookie is the only browser-compatible option that keeps WebSocket/static routes authed.
- **Plain HTTP** (no TLS) — target is `localhost`; TLS adds nothing against the local-user threat model.

## Test plan

- [x] `make check` passes (lint, unit, tach, security, docstr-coverage, reuse).
- [x] `TestWebIngress` covers the roster flag + `toad → caddy` transitive resolution; bundled-agents load test updated.
- [ ] Off-CI end-to-end: build L1 with `--agents toad`; `curl 401` without token; `curl 303 + Set-Cookie` with `?token=`; browser flow.

Pairs with the host-side PR in terok-ai/terok (soon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toad supports HTTP web ingress with token‑gated access and managed reverse‑proxy behavior.
  * New supervised entrypoint coordinates proxy and agent startup/shutdown, enforces readiness checks, and fails safely if preconditions aren't met.

* **Infrastructure**
  * Caddy added and configured as the managed ingress proxy.
  * Agent startup ordering updated; roster now tracks which agents expose web ingress.

* **Tests**
  * Unit tests updated to cover web‑ingress behavior, dependency resolution, and bundled agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->