### PR TITLE
feat: unify vault addressing so gh/claude reach /run/terok/vault.sock directly

### DIFF
--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -207,9 +207,9 @@ def _handle_auth(*, agent: str, api_key: str | None = None) -> None:
         authenticate("standalone", agent, mounts_dir=mounts_dir(), image=image)
 
     # Write vault URLs to shared config files (e.g. Vibe config.toml, gh config.yml)
-    from .credentials.vault_config import write_proxy_config
+    from .credentials.vault_config import write_vault_config
 
-    write_proxy_config(agent)
+    write_vault_config(agent)
 
 
 def _handle_agents(*, show_all: bool = False) -> None:

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -243,8 +243,8 @@ def assemble_container_env(
     mounts_base = spec.envs_dir or _mounts_dir()
     volumes += _shared_config_mounts(roster, mounts_base)
 
-    # 8b. Re-apply proxy config patches (idempotent — ensures shared mount
-    #     dirs contain correct proxy URLs even after state wipe).
+    # 8b. Re-apply vault config patches (idempotent — ensures shared mount
+    #     dirs contain correct vault addresses even after state wipe).
     #
     #     NOT gated by caller_manages_vault: that flag only skips
     #     phantom-token injection here because the caller (terok) injects
@@ -359,8 +359,8 @@ def _inject_vault_tokens(
 
     - **Auth**: selects ``phantom_env`` vs ``oauth_phantom_env`` based on the
       stored credential type (Phase 1).
-    - **Transport**: injects ``socket_env``/``socket_path`` when
-      *vault_transport* is ``"socket"`` (Phase 2).
+    - **Transport**: resolves the shared vault address and writes it into
+      every route's ``socket_env`` / ``base_url_env`` (Phase 2).
     - **SSH signer**: creates a phantom token for the SSH signer when the
       scope has registered SSH keys (Phase 3).
 
@@ -436,12 +436,16 @@ def _inject_vault_tokens(
         db.close()
 
     use_socket = vault_transport == "socket"
-    # The broker's TCP address — absent under socket transport, where the
-    # broker listens only on the mounted Unix socket and ``port`` is ``None``.
-    # Container-side consumers that need an HTTP endpoint get nothing rather
-    # than the string ``"None"``.
-    tcp_broker = f"host.containers.internal:{port}" if port else None
-    proxy_base = f"http://{tcp_broker}" if tcp_broker else None
+    # Resolve the single container-side vault address used by every
+    # socket/URL injection below.  Socket mode points at the mounted host
+    # socket + a loopback HTTP bridge; TCP mode points at the broker's TCP
+    # endpoint + a socat-fronted Unix socket.  Agents don't decide per-route
+    # any more — addressing is centralised.
+    from terok_executor.credentials.vault_config import resolve_vault_location
+    from terok_executor.vault_addr import LOOPBACK_VAULT_PORT, VAULT_LOOPBACK_PORT_ENV
+
+    location = resolve_vault_location()
+    host_tcp = f"host.containers.internal:{port}" if port else None
     env: dict[str, str] = {}
 
     for name, route in vault_routes.items():
@@ -455,22 +459,26 @@ def _inject_vault_tokens(
         for env_var in token_vars:
             env[env_var] = tokens[name]
 
-        if use_socket and route.socket_path and route.socket_env:
-            env[route.socket_env] = route.socket_path
-        if route.base_url_env and proxy_base:
-            env[route.base_url_env] = proxy_base
+        if route.socket_env:
+            env[route.socket_env] = location.socket
+        if route.base_url_env:
+            env[route.base_url_env] = location.url
 
-        # OpenCode base URL override for proxied providers
+        # OpenCode base URL override for proxied providers.
         provider = roster.providers.get(name)
-        if provider and provider.opencode_config and proxy_base:
-            env[f"TEROK_OC_{name.upper()}_BASE_URL"] = f"{proxy_base}/v1"
-        # glab: redirect API to proxy
-        if name == "glab" and tcp_broker:
-            env["GITLAB_API_HOST"] = tcp_broker
+        if provider and provider.opencode_config:
+            env[f"TEROK_OC_{name.upper()}_BASE_URL"] = f"{location.url}/v1"
+        # glab uses its own host+protocol split; in socket mode it rides the
+        # same in-container loopback bridge as every other HTTP-only client.
+        if name == "glab":
             env["API_PROTOCOL"] = "http"
+            env["GITLAB_API_HOST"] = host_tcp if host_tcp else f"localhost:{LOOPBACK_VAULT_PORT}"
 
-    if routed and port:
-        env["TEROK_TOKEN_BROKER_PORT"] = str(port)
+    if routed:
+        if port:
+            env["TEROK_TOKEN_BROKER_PORT"] = str(port)
+        if use_socket:
+            env[VAULT_LOOPBACK_PORT_ENV] = str(LOOPBACK_VAULT_PORT)
 
     if ssh_token:
         env["TEROK_SSH_SIGNER_TOKEN"] = ssh_token

--- a/src/terok_executor/credentials/vault_config.py
+++ b/src/terok_executor/credentials/vault_config.py
@@ -4,9 +4,18 @@
 """Patches provider config files to route API traffic through the vault.
 
 Applies ``shared_config_patch`` from the YAML roster after authentication
-and — crucially — on every task start.  Writes vault URLs (not secrets) to
-provider config files so that agents route API traffic through the
+and — crucially — on every task start.  Writes vault URLs / socket paths
+(not secrets) to provider config files so agents route traffic through the
 vault instead of hitting upstream directly with phantom tokens.
+
+Two template tokens are substituted into patch values:
+
+- ``{vault_url}``    — HTTP URL the container should reach the vault on.
+- ``{vault_socket}`` — filesystem path of a Unix socket the container can
+  connect to for the vault.
+
+The concrete values are mode-dependent (socket vs TCP transport) and
+resolved centrally — agent YAMLs only need to reference the tokens.
 """
 
 from __future__ import annotations
@@ -15,6 +24,7 @@ import errno
 import logging
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,12 +38,32 @@ class ConfigPatchError(RuntimeError):
     """Raised when a shared config patch fails and the task must not start."""
 
 
-def write_proxy_config(provider_name: str) -> None:
+@dataclass(frozen=True, slots=True)
+class VaultLocation:
+    """Container-side addresses of the vault in both transports.
+
+    One or both fields are set depending on the active transport:
+
+    - Socket mode: *socket* points at the mounted host socket; *url* points
+      at the in-container TCP→UNIX loopback bridge for HTTP-only clients.
+    - TCP mode: *url* points at ``host.containers.internal:<broker_port>``;
+      *socket* points at a local socat bridge that forwards to the same
+      broker over TCP (for clients that can only speak HTTP-over-UNIX).
+    """
+
+    url: str
+    """Base URL an in-container HTTP client should use (always non-empty)."""
+
+    socket: str
+    """Filesystem path for a Unix-socket-speaking HTTP client."""
+
+
+def write_vault_config(provider_name: str) -> None:
     """Apply ``shared_config_patch`` from the YAML roster after auth.
 
     Patches a TOML or YAML config file in the provider's shared config dir
-    to redirect API traffic through the vault.  The patch spec
-    is declared in the agent YAML — no provider-specific code needed.
+    to redirect API traffic through the vault.  The patch spec is declared
+    in the agent YAML — no provider-specific code needed.
     """
     from terok_executor.roster.loader import get_roster
 
@@ -46,13 +76,9 @@ def write_proxy_config(provider_name: str) -> None:
     if not auth_info:
         return
 
-    from terok_sandbox import SandboxConfig, get_token_broker_port
-
     from terok_executor.paths import mounts_dir
 
-    cfg = SandboxConfig()
-    port = get_token_broker_port(cfg)
-    proxy_url = f"http://host.containers.internal:{port}"
+    location = resolve_vault_location()
 
     patch = route.shared_config_patch
     shared_dir = mounts_dir() / auth_info.host_dir_name
@@ -60,9 +86,9 @@ def write_proxy_config(provider_name: str) -> None:
     config_path = _safe_config_path(shared_dir, patch["file"])
 
     if "yaml_set" in patch:
-        _apply_yaml_patch(config_path, patch, proxy_url)
+        _apply_yaml_patch(config_path, patch, location)
     elif "toml_table" in patch:
-        _apply_toml_patch(config_path, patch, proxy_url)
+        _apply_toml_patch(config_path, patch, location)
 
     print(f"Vault config written to {config_path}")
 
@@ -70,18 +96,14 @@ def write_proxy_config(provider_name: str) -> None:
 def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
     """Re-apply every ``shared_config_patch`` for the whole roster.
 
-    Called during task start so that shared mount directories (which may
-    have been recreated empty) always contain the correct vault URLs.
+    Called during task start so shared mount directories (which may have
+    been recreated empty) always contain the correct vault addresses.
     Idempotent: safe to call on every launch.
 
     Raises :class:`ConfigPatchError` on failure — callers must not start
     the container if vault routing cannot be established.
     """
-    from terok_sandbox import SandboxConfig, get_token_broker_port
-
-    cfg = SandboxConfig()
-    port = get_token_broker_port(cfg)
-    proxy_url = f"http://host.containers.internal:{port}"
+    location = resolve_vault_location()
 
     for name, route in roster.vault_routes.items():
         if not route.shared_config_patch:
@@ -97,9 +119,9 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
             config_path = _safe_config_path(shared_dir, patch["file"])
 
             if "yaml_set" in patch:
-                _apply_yaml_patch(config_path, patch, proxy_url)
+                _apply_yaml_patch(config_path, patch, location)
             elif "toml_table" in patch:
-                _apply_toml_patch(config_path, patch, proxy_url)
+                _apply_toml_patch(config_path, patch, location)
             _logger.debug("Applied config patch for %s → %s", name, config_path)
         except ConfigPatchError:
             raise
@@ -107,6 +129,37 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
             raise ConfigPatchError(
                 f"Failed to apply vault config patch for {name} (file={patch.get('file')!r})"
             ) from exc
+
+
+def resolve_vault_location() -> VaultLocation:
+    """Resolve the container-side vault addresses for the active transport.
+
+    Reads the sandbox config once to decide whether we're in socket or TCP
+    mode.  Exposed as a public helper so the env builder can use the same
+    values it later writes to config files.
+    """
+    from terok_sandbox import SandboxConfig, get_token_broker_port
+
+    from terok_executor.vault_addr import (
+        CONTAINER_VAULT_SOCKET,
+        LOOPBACK_BRIDGE_SOCKET,
+        LOOPBACK_VAULT_PORT,
+    )
+
+    port = get_token_broker_port(SandboxConfig())
+    if port is None:
+        # Socket mode: container mounts the host vault socket directly; the
+        # loopback bridge serves clients that can only speak HTTP-over-TCP.
+        return VaultLocation(
+            url=f"http://localhost:{LOOPBACK_VAULT_PORT}",
+            socket=CONTAINER_VAULT_SOCKET,
+        )
+    # TCP mode: direct broker on the host; socat on the container side turns
+    # a local Unix socket into a TCP connection for socket-only clients.
+    return VaultLocation(
+        url=f"http://host.containers.internal:{port}",
+        socket=LOOPBACK_BRIDGE_SOCKET,
+    )
 
 
 # ── Private helpers ──────────────────────────────────────────────────────
@@ -183,7 +236,14 @@ def _write_nofollow(path: Path, data: bytes) -> None:
         os.close(fd)
 
 
-def _apply_toml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
+def _substitute(value: object, location: VaultLocation) -> object:
+    """Expand ``{vault_url}`` / ``{vault_socket}`` tokens in a patch value."""
+    if not isinstance(value, str):
+        return value
+    return value.replace("{vault_url}", location.url).replace("{vault_socket}", location.socket)
+
+
+def _apply_toml_patch(config_path: Path, patch: dict, location: VaultLocation) -> None:
     """Patch a TOML array-of-tables entry."""
     import tomllib
 
@@ -193,7 +253,7 @@ def _apply_toml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
             existing = tomllib.loads(raw.decode("utf-8"))
         except Exception as exc:
             print(
-                f"Warning [proxy-config]: failed to parse {config_path}: "
+                f"Warning [vault-config]: failed to parse {config_path}: "
                 f"{type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
@@ -203,10 +263,7 @@ def _apply_toml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
 
     table_key = patch["toml_table"]
     match_criteria = patch["toml_match"]
-    values = {
-        k: v.replace("{proxy_url}", proxy_url) if isinstance(v, str) else v
-        for k, v in patch["toml_set"].items()
-    }
+    values = {k: _substitute(v, location) for k, v in patch["toml_set"].items()}
 
     entries = existing.get(table_key, [])
     target = next(
@@ -224,7 +281,7 @@ def _apply_toml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
     _write_nofollow(config_path, tomli_w.dumps(existing).encode("utf-8"))
 
 
-def _apply_yaml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
+def _apply_yaml_patch(config_path: Path, patch: dict, location: VaultLocation) -> None:
     """Set top-level keys in a YAML config file."""
     import io
 
@@ -238,7 +295,7 @@ def _apply_yaml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
             existing = yaml.load(raw)
         except Exception as exc:
             print(
-                f"Warning [proxy-config]: failed to parse {config_path}: "
+                f"Warning [vault-config]: failed to parse {config_path}: "
                 f"{type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
@@ -249,7 +306,7 @@ def _apply_yaml_patch(config_path: Path, patch: dict, proxy_url: str) -> None:
         existing = {}
 
     for k, v in patch["yaml_set"].items():
-        existing[k] = v.replace("{proxy_url}", proxy_url) if isinstance(v, str) else v
+        existing[k] = _substitute(v, location)
 
     buf = io.BytesIO()
     yaml.dump(existing, buf)

--- a/src/terok_executor/doctor.py
+++ b/src/terok_executor/doctor.py
@@ -21,6 +21,12 @@ from urllib.parse import urlparse
 
 from terok_sandbox.doctor import CheckVerdict, DoctorCheck
 
+from .vault_addr import (
+    CONTAINER_VAULT_SOCKET,
+    LOOPBACK_BRIDGE_SOCKET,
+    LOOPBACK_VAULT_PORT,
+)
+
 if TYPE_CHECKING:
     from .roster import AgentRoster
 
@@ -31,8 +37,8 @@ if TYPE_CHECKING:
 _BRIDGE_PIDDIR = "/tmp/.terok"  # nosec B108 — matches ensure-bridges.sh in-container paths
 _SSH_AGENT_PIDFILE = f"{_BRIDGE_PIDDIR}/ssh-agent.pid"
 _SSH_AGENT_SOCKET = "/tmp/ssh-agent.sock"  # nosec B108
-_GH_PROXY_PIDFILE = f"{_BRIDGE_PIDDIR}/gh-proxy.pid"
-_GH_PROXY_SOCKET = "/tmp/terok-gh-proxy.sock"  # nosec B108
+_VAULT_LOOPBACK_PIDFILE = f"{_BRIDGE_PIDDIR}/vault-loopback.pid"
+_VAULT_SOCKET_PIDFILE = f"{_BRIDGE_PIDDIR}/vault-socket.pid"
 
 # Matches phantom tokens: "terok-p-" prefix + 32 hex chars
 _PHANTOM_TOKEN_RE = re.compile(r"^terok-p-[0-9a-fA-F]{32}$")
@@ -53,20 +59,22 @@ def agent_doctor_checks(
 
     Args:
         roster: The loaded agent roster.
-        token_broker_port: Vault TCP port. Required for base URL checks;
-            if ``None``, base URL checks are skipped.
+        token_broker_port: Host-side vault broker TCP port.  ``None``
+            selects socket mode; any integer selects TCP mode.  Base URL
+            checks use the port (or the in-container loopback port) to
+            derive the expected host.
 
     Returns:
         List of :class:`DoctorCheck` instances ready for orchestration.
     """
+    socket_mode = token_broker_port is None
     checks: list[DoctorCheck] = [
         _make_ssh_bridge_check(),
-        _make_gh_proxy_bridge_check(),
+        _make_vault_bridge_check(socket_mode=socket_mode),
     ]
     checks.extend(_make_credential_file_checks(roster))
     checks.extend(_make_phantom_token_checks(roster))
-    if token_broker_port is not None:
-        checks.extend(_make_base_url_checks(roster, token_broker_port))
+    checks.extend(_make_base_url_checks(roster, token_broker_port))
     return checks
 
 
@@ -101,28 +109,39 @@ def _make_ssh_bridge_check() -> DoctorCheck:
     )
 
 
-def _make_gh_proxy_bridge_check() -> DoctorCheck:
-    """Check that the gh vault socat bridge is alive."""
+def _make_vault_bridge_check(*, socket_mode: bool) -> DoctorCheck:
+    """Check the vault-side socat bridge for the active transport.
+
+    In socket mode the bridge exposes the mounted host socket as a TCP
+    loopback so HTTP-only clients can reach it.  In TCP mode the bridge
+    exposes a local Unix socket that tunnels to the host broker over TCP
+    (for socket-only clients).
+    """
+    if socket_mode:
+        label = "Vault loopback bridge (TCP → /run/terok/vault.sock)"
+        probe = (
+            f"test -S {CONTAINER_VAULT_SOCKET}"
+            f" && kill -0 $(cat {_VAULT_LOOPBACK_PIDFILE} 2>/dev/null) 2>/dev/null"
+        )
+        dead_detail = "Vault loopback bridge dead — HTTP clients cannot reach the mounted socket"
+    else:
+        label = "Vault socket bridge (/tmp/terok-vault.sock → broker TCP)"
+        probe = (
+            f"kill -0 $(cat {_VAULT_SOCKET_PIDFILE} 2>/dev/null) 2>/dev/null"
+            f" && test -S {LOOPBACK_BRIDGE_SOCKET}"
+        )
+        dead_detail = "Vault socket bridge dead — socat process or socket missing"
 
     def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
         """Evaluate bridge liveness probe."""
         if rc == 0:
-            return CheckVerdict("ok", "gh proxy bridge alive (PID + socket)")
-        return CheckVerdict(
-            "error",
-            "gh proxy bridge dead — socat process or socket missing",
-            fixable=True,
-        )
+            return CheckVerdict("ok", f"{label} alive")
+        return CheckVerdict("error", dead_detail, fixable=True)
 
     return DoctorCheck(
         category="bridge",
-        label="gh proxy bridge (socat)",
-        probe_cmd=[
-            "bash",
-            "-c",
-            f"kill -0 $(cat {_GH_PROXY_PIDFILE} 2>/dev/null) 2>/dev/null"
-            f" && test -S {_GH_PROXY_SOCKET}",
-        ],
+        label=label,
+        probe_cmd=["bash", "-c", probe],
         evaluate=_eval,
         fix_cmd=["bash", "-lc", "source ensure-bridges.sh"],
         fix_description="Re-source ensure-bridges.sh to restart the socat bridge.",
@@ -243,11 +262,21 @@ def _make_phantom_token_checks(roster: AgentRoster) -> list[DoctorCheck]:
 # ---------------------------------------------------------------------------
 
 
-def _make_base_url_checks(roster: AgentRoster, token_broker_port: int) -> list[DoctorCheck]:
-    """Verify base URL env vars point to the vault, not upstream."""
+def _make_base_url_checks(roster: AgentRoster, token_broker_port: int | None) -> list[DoctorCheck]:
+    """Verify base URL env vars point to the vault, not upstream.
+
+    Under socket transport the base URL points at the in-container
+    loopback bridge (``localhost:<LOOPBACK_VAULT_PORT>``); under TCP
+    transport it points at ``host.containers.internal:<broker_port>``.
+    """
     checks: list[DoctorCheck] = []
     seen_vars: set[str] = set()
-    expected_host = f"host.containers.internal:{token_broker_port}"
+    if token_broker_port is None:
+        expected_host = f"localhost:{LOOPBACK_VAULT_PORT}"
+        mode_label = "vault loopback"
+    else:
+        expected_host = f"host.containers.internal:{token_broker_port}"
+        mode_label = "vault broker"
 
     for name, route in roster.vault_routes.items():
         if not route.base_url_env:
@@ -257,19 +286,19 @@ def _make_base_url_checks(roster: AgentRoster, token_broker_port: int) -> list[D
             continue
         seen_vars.add(var)
 
-        def _make_eval(env_var: str, pname: str, host: str):  # noqa: ANN202
+        def _make_eval(env_var: str, pname: str, host: str, mode: str):  # noqa: ANN202
             """Create evaluate closure for a base URL check."""
 
             def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
-                """Check if base URL points to proxy."""
+                """Check if base URL points to the active vault endpoint."""
                 val = stdout.strip()
                 if not val:
-                    return CheckVerdict("warn", f"{env_var}: not set — proxy bypass possible")
+                    return CheckVerdict("warn", f"{env_var}: not set — vault bypass possible")
                 if urlparse(val).netloc == host:
-                    return CheckVerdict("ok", f"{env_var}: routed through proxy ({pname})")
+                    return CheckVerdict("ok", f"{env_var}: routed through {mode} ({pname})")
                 return CheckVerdict(
                     "error",
-                    f"{env_var}: points to {val!r}, not proxy — restart task",
+                    f"{env_var}: points to {val!r}, not {mode} — restart task",
                 )
 
             return _eval
@@ -279,7 +308,7 @@ def _make_base_url_checks(roster: AgentRoster, token_broker_port: int) -> list[D
                 category="env",
                 label=f"Base URL ({var})",
                 probe_cmd=["printenv", var],
-                evaluate=_make_eval(var, name, expected_host),
+                evaluate=_make_eval(var, name, expected_host, mode_label),
             )
         )
     return checks

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -150,10 +150,10 @@ def _fix_credentials(provider: str) -> bool:
     except SystemExit:
         return False
 
-    # Write proxy config patches for the authenticated provider
-    from terok_executor.credentials.vault_config import write_proxy_config
+    # Write vault config patches for the authenticated provider
+    from terok_executor.credentials.vault_config import write_vault_config
 
-    write_proxy_config(provider)
+    write_vault_config(provider)
     return True
 
 

--- a/src/terok_executor/resources/agents/claude.yaml
+++ b/src/terok_executor/resources/agents/claude.yaml
@@ -54,7 +54,6 @@ vault:
   oauth_phantom_env:
     CLAUDE_CODE_OAUTH_TOKEN: true
   base_url_env: ANTHROPIC_BASE_URL
-  socket_path: /tmp/terok-claude-proxy.sock
   socket_env: ANTHROPIC_UNIX_SOCKET
 
 auth:

--- a/src/terok_executor/resources/agents/gh.yaml
+++ b/src/terok_executor/resources/agents/gh.yaml
@@ -18,7 +18,7 @@ vault:
     GH_TOKEN: true
   shared_config_patch:
     file: config.yml
-    yaml_set: {http_unix_socket: "/tmp/terok-gh-proxy.sock"}
+    yaml_set: {http_unix_socket: "{vault_socket}"}
 
 auth:
   host_dir: _gh-config

--- a/src/terok_executor/resources/agents/vibe.yaml
+++ b/src/terok_executor/resources/agents/vibe.yaml
@@ -42,7 +42,7 @@ vault:
     file: config.toml
     toml_table: providers
     toml_match: {name: mistral}
-    toml_set: {api_base: "{proxy_url}/v1"}
+    toml_set: {api_base: "{vault_url}/v1"}
 
 auth:
   host_dir: _vibe-config

--- a/src/terok_executor/resources/scripts/ensure-bridges.sh
+++ b/src/terok_executor/resources/scripts/ensure-bridges.sh
@@ -5,14 +5,20 @@
 
 # Idempotent socat bridge launcher for container ↔ host-side services.
 #
-# Manages four bridges:
-#   1. SSH signer  — UNIX socket → ssh-agent-bridge.sh → TCP or host socket
-#   2. gh proxy    — UNIX socket → TCP (plain relay to token broker)
-#   3. Claude proxy — UNIX socket → TCP (enables OAuth subscription mode)
-#   4. Gate server — TCP listener → host UNIX socket (git HTTP-over-socket)
+# Manages up to three bridges:
 #
-# Transport selection is env-var driven — set at container creation, not
-# auto-detected.  Socket mode mounts the host runtime dir at /run/terok/.
+#   1. SSH signer        — UNIX socket → ssh-agent-bridge.sh → TCP or host socket
+#   2. Vault (HTTP leg)  — in socket mode: TCP-LISTEN → /run/terok/vault.sock
+#                          (lets HTTP-only clients reach the vault via localhost)
+#   3. Vault (socket leg) — in TCP mode:    /tmp/terok-vault.sock → TCP broker
+#                          (lets socket-only clients — gh, claude — reach the
+#                          broker, which is only exposed on TCP)
+#   4. Gate server       — TCP listener → host UNIX socket (git HTTP-over-socket)
+#
+# Transport selection is env-var driven (set at container creation):
+#
+#   Socket mode: TEROK_VAULT_LOOPBACK_PORT=<port>, /run/terok/vault.sock mounted
+#   TCP mode:    TEROK_TOKEN_BROKER_PORT=<port>
 #
 # Uses PID files (not socket existence) to detect dead bridges — stale
 # socket files persist after process death and are unreliable sentinels.
@@ -43,26 +49,30 @@ if [[ -n "${TEROK_SSH_SIGNER_TOKEN:-}" ]] \
   export SSH_AUTH_SOCK=/tmp/ssh-agent.sock
 fi
 
-# ── gh token broker bridge ───────────────────────────────────────────────
-if [[ -n "${TEROK_TOKEN_BROKER_PORT:-}" ]] && [[ -n "${GH_TOKEN:-}" ]] \
+# ── Vault loopback bridge (socket mode) ──────────────────────────────────
+# The host vault socket is mounted at /run/terok/vault.sock.  Socket-native
+# clients (gh, claude) use it directly; everyone else reaches it via this
+# TCP loopback so their "base URL" knob has something to point at.
+if [[ -n "${TEROK_VAULT_LOOPBACK_PORT:-}" ]] \
+   && [[ -S /run/terok/vault.sock ]] \
    && command -v socat >/dev/null 2>&1 \
-   && ! _terok_bridge_alive "$_TEROK_PIDDIR/gh-proxy.pid"; then
-  rm -f /tmp/terok-gh-proxy.sock
-  socat UNIX-LISTEN:/tmp/terok-gh-proxy.sock,fork \
-    TCP:host.containers.internal:"${TEROK_TOKEN_BROKER_PORT}" &
-  echo $! > "$_TEROK_PIDDIR/gh-proxy.pid"
+   && ! _terok_bridge_alive "$_TEROK_PIDDIR/vault-loopback.pid"; then
+  socat "TCP-LISTEN:${TEROK_VAULT_LOOPBACK_PORT},bind=127.0.0.1,fork,reuseaddr" \
+    UNIX-CONNECT:/run/terok/vault.sock &
+  echo $! > "$_TEROK_PIDDIR/vault-loopback.pid"
 fi
 
-# ── Claude token broker bridge (ANTHROPIC_UNIX_SOCKET transport) ────────
-# Routes Claude API traffic through the token broker via a Unix socket
-# instead of ANTHROPIC_BASE_URL (enables OAuth subscription mode in Claude Code).
-if [[ -n "${TEROK_TOKEN_BROKER_PORT:-}" ]] && [[ -n "${ANTHROPIC_UNIX_SOCKET:-}" ]] \
+# ── Vault socket bridge (TCP mode) ───────────────────────────────────────
+# The broker is only reachable over TCP on the host.  gh and claude can
+# only speak HTTP-over-UNIX, so expose a local Unix socket fronted by
+# socat that pipes through to the broker.
+if [[ -n "${TEROK_TOKEN_BROKER_PORT:-}" ]] \
    && command -v socat >/dev/null 2>&1 \
-   && ! _terok_bridge_alive "$_TEROK_PIDDIR/claude-proxy.pid"; then
-  rm -f "${ANTHROPIC_UNIX_SOCKET}"
-  socat UNIX-LISTEN:"${ANTHROPIC_UNIX_SOCKET}",fork \
+   && ! _terok_bridge_alive "$_TEROK_PIDDIR/vault-socket.pid"; then
+  rm -f /tmp/terok-vault.sock
+  socat UNIX-LISTEN:/tmp/terok-vault.sock,fork \
     TCP:host.containers.internal:"${TEROK_TOKEN_BROKER_PORT}" &
-  echo $! > "$_TEROK_PIDDIR/claude-proxy.pid"
+  echo $! > "$_TEROK_PIDDIR/vault-socket.pid"
 fi
 
 # ── Gate server bridge (socket mode) ─────────────────────────────────────

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -107,13 +107,15 @@ class VaultRoute:
     """
 
     base_url_env: str = ""
-    """Env var to override with proxy URL (e.g. ``"ANTHROPIC_BASE_URL"``)."""
-
-    socket_path: str = ""
-    """Unix socket path for socat bridge (e.g. ``"/tmp/terok-claude-proxy.sock"``)."""
+    """Env var to override with the vault's HTTP URL (e.g. ``"ANTHROPIC_BASE_URL"``)."""
 
     socket_env: str = ""
-    """Env var that receives :attr:`socket_path` (e.g. ``"ANTHROPIC_UNIX_SOCKET"``)."""
+    """Env var that receives the container-side vault socket path.
+
+    Set when the agent speaks HTTP-over-UNIX natively (e.g. Claude reads
+    ``ANTHROPIC_UNIX_SOCKET``).  The resolved value is mode-dependent and
+    injected centrally by the env builder.
+    """
 
     shared_config_patch: dict | None = None
     """Optional shared config patch applied after auth (e.g. Vibe's config.toml)."""
@@ -840,11 +842,10 @@ def _to_vault_route(name: str, data: dict) -> VaultRoute | None:
         if required not in cp:
             raise ValueError(f"Agent {name!r}: vault missing required key {required!r}")
     oauth_phantom_env = cp.get("oauth_phantom_env") or {}
-    socket_path = cp.get("socket_path") or ""
-    socket_env = cp.get("socket_env") or ""
-    if bool(socket_path) != bool(socket_env):
+    if "socket_path" in cp:
         raise ValueError(
-            f"Agent {name!r}: vault requires both 'socket_path' and 'socket_env' together"
+            f"Agent {name!r}: 'socket_path' is no longer configurable — "
+            "remove it; the env builder resolves the vault socket path centrally"
         )
     return VaultRoute(
         provider=name,
@@ -857,8 +858,7 @@ def _to_vault_route(name: str, data: dict) -> VaultRoute | None:
         phantom_env=cp.get("phantom_env", {}),
         oauth_phantom_env=oauth_phantom_env,
         base_url_env=cp.get("base_url_env", ""),
-        socket_path=socket_path,
-        socket_env=socket_env,
+        socket_env=cp.get("socket_env") or "",
         shared_config_patch=cp.get("shared_config_patch"),
         oauth_refresh=_validated_oauth_refresh(name, cp.get("oauth_refresh")),
     )

--- a/src/terok_executor/vault_addr.py
+++ b/src/terok_executor/vault_addr.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Container-side vault addressing — single source of truth.
+
+Two transports reach the vault from inside a task container:
+
+- **Socket mode** (default, preferred): the host's vault socket is
+  bind-mounted into the container at :data:`CONTAINER_VAULT_SOCKET`.
+  Clients that can speak HTTP-over-UNIX (``gh``, ``claude``) connect
+  directly; everyone else goes through an in-container socat bridge that
+  exposes the vault as plain TCP on ``localhost:LOOPBACK_VAULT_PORT``.
+
+- **TCP mode** (legacy): the vault's token broker listens on a host TCP
+  port (``host.containers.internal:<broker_port>``).  Socket-only
+  clients reach it via a local socat bridge that presents a Unix socket
+  at :data:`LOOPBACK_BRIDGE_SOCKET`.
+
+These paths and port numbers have to agree across the python builders,
+the shell bridge script, and the doctor probes — define them here so
+every layer imports the same value.
+"""
+
+from __future__ import annotations
+
+from terok_sandbox import CONTAINER_RUNTIME_DIR
+
+CONTAINER_VAULT_SOCKET = f"{CONTAINER_RUNTIME_DIR}/vault.sock"
+"""Host vault socket as seen inside the container (socket mode only)."""
+
+LOOPBACK_BRIDGE_SOCKET = "/tmp/terok-vault.sock"  # nosec B108 — container-only path
+"""Local socat-created socket that fronts the broker in TCP mode."""
+
+LOOPBACK_VAULT_PORT = 9419
+"""TCP port the in-container loopback bridge listens on (socket mode).
+
+Sits next to the gate bridge on 9418; picked once, hardcoded everywhere.
+"""
+
+VAULT_LOOPBACK_PORT_ENV = "TEROK_VAULT_LOOPBACK_PORT"
+"""Env var name the bridge script reads to find the loopback port."""

--- a/tach.toml
+++ b/tach.toml
@@ -37,6 +37,12 @@ depends_on = []
 path = "terok_executor.resources"
 depends_on = []
 
+# Container-side vault addressing constants — shared by env builder,
+# config patcher, and doctor.  Depends only on terok_sandbox (external).
+[[modules]]
+path = "terok_executor.vault_addr"
+depends_on = []
+
 # ── roster/ — agent catalog ─────────────────────────────────────────
 
 # YAML agent roster — loads bundled + user agent definitions
@@ -119,6 +125,7 @@ depends_on = [
     "terok_executor.credentials.vault_commands",
     "terok_executor.credentials.vault_config",
     "terok_executor.paths",
+    "terok_executor.vault_addr",
 ]
 
 # Agent runner facade — composes sandbox + agent config + container launch
@@ -151,12 +158,13 @@ depends_on = [
     "terok_executor.paths",
 ]
 
-# Post-auth shared config patching (proxy URL writes)
+# Post-auth shared config patching (vault URL writes)
 [[modules]]
 path = "terok_executor.credentials.vault_config"
 depends_on = [
     "terok_executor.paths",
     "terok_executor.roster.loader",
+    "terok_executor.vault_addr",
 ]
 
 # Credential proxy CLI commands — wraps sandbox lifecycle + route generation
@@ -206,7 +214,9 @@ depends_on = [
 # Agent-level container health checks
 [[modules]]
 path = "terok_executor.doctor"
-depends_on = []
+depends_on = [
+    "terok_executor.vault_addr",
+]
 
 # Package root — public API re-exports + roster bootstrap
 [[modules]]

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -11,9 +11,9 @@ from terok_executor.doctor import (
     _PHANTOM_TOKEN_RE,
     _make_base_url_checks,
     _make_credential_file_checks,
-    _make_gh_proxy_bridge_check,
     _make_phantom_token_checks,
     _make_ssh_bridge_check,
+    _make_vault_bridge_check,
     agent_doctor_checks,
 )
 from terok_executor.roster import get_roster
@@ -45,26 +45,49 @@ class TestSSHBridgeCheck:
         assert check.category == "bridge"
 
 
-class TestGhProxyBridgeCheck:
-    """gh token broker socat bridge liveness check."""
+class TestVaultBridgeCheck:
+    """Vault socat bridge liveness check — two probe shapes, one semantic role."""
 
-    def test_ok_when_alive(self) -> None:
-        check = _make_gh_proxy_bridge_check()
+    def test_socket_mode_ok_when_alive(self) -> None:
+        check = _make_vault_bridge_check(socket_mode=True)
         verdict = check.evaluate(0, "", "")
         assert verdict.severity == "ok"
 
-    def test_error_when_dead(self) -> None:
-        check = _make_gh_proxy_bridge_check()
+    def test_socket_mode_error_when_dead(self) -> None:
+        check = _make_vault_bridge_check(socket_mode=True)
         verdict = check.evaluate(1, "", "")
         assert verdict.severity == "error"
         assert verdict.fixable is True
 
+    def test_tcp_mode_ok_when_alive(self) -> None:
+        check = _make_vault_bridge_check(socket_mode=False)
+        verdict = check.evaluate(0, "", "")
+        assert verdict.severity == "ok"
+
+    def test_tcp_mode_error_when_dead(self) -> None:
+        check = _make_vault_bridge_check(socket_mode=False)
+        verdict = check.evaluate(1, "", "")
+        assert verdict.severity == "error"
+        assert verdict.fixable is True
+
+    def test_socket_mode_probes_mounted_vault_socket(self) -> None:
+        check = _make_vault_bridge_check(socket_mode=True)
+        probe = " ".join(check.probe_cmd)
+        assert "/run/terok/vault.sock" in probe
+        assert "vault-loopback.pid" in probe
+
+    def test_tcp_mode_probes_local_bridge_socket(self) -> None:
+        check = _make_vault_bridge_check(socket_mode=False)
+        probe = " ".join(check.probe_cmd)
+        assert "/tmp/terok-vault.sock" in probe
+        assert "vault-socket.pid" in probe
+
     def test_has_fix_cmd(self) -> None:
-        check = _make_gh_proxy_bridge_check()
+        check = _make_vault_bridge_check(socket_mode=True)
         assert check.fix_cmd is not None
 
     def test_category_is_bridge(self) -> None:
-        check = _make_gh_proxy_bridge_check()
+        check = _make_vault_bridge_check(socket_mode=True)
         assert check.category == "bridge"
 
 
@@ -169,18 +192,32 @@ class TestPhantomTokenChecks:
 class TestBaseUrlChecks:
     """Base URL override verification."""
 
-    def test_generates_checks(self) -> None:
+    def test_generates_checks_tcp(self) -> None:
         roster = get_roster()
         checks = _make_base_url_checks(roster, TOKEN_BROKER_PORT)
         assert len(checks) > 0
 
-    def test_ok_when_routed(self) -> None:
+    def test_generates_checks_socket(self) -> None:
+        roster = get_roster()
+        checks = _make_base_url_checks(roster, None)
+        assert len(checks) > 0
+
+    def test_tcp_ok_when_routed(self) -> None:
         roster = get_roster()
         checks = _make_base_url_checks(roster, TOKEN_BROKER_PORT)
         if checks:
             verdict = checks[0].evaluate(
                 0, f"http://host.containers.internal:{TOKEN_BROKER_PORT}\n", ""
             )
+            assert verdict.severity == "ok"
+
+    def test_socket_ok_when_routed(self) -> None:
+        from terok_executor.vault_addr import LOOPBACK_VAULT_PORT
+
+        roster = get_roster()
+        checks = _make_base_url_checks(roster, None)
+        if checks:
+            verdict = checks[0].evaluate(0, f"http://localhost:{LOOPBACK_VAULT_PORT}\n", "")
             assert verdict.severity == "ok"
 
     def test_error_when_bypassed(self) -> None:
@@ -225,14 +262,15 @@ class TestAgentDoctorChecks:
         categories = {c.category for c in checks}
         assert "env" in categories
 
-    def test_skips_base_url_without_port(self) -> None:
+    def test_base_url_checks_emitted_in_both_modes(self) -> None:
+        """Socket and TCP mode both need base-URL checks — the probe host differs."""
         roster = get_roster()
-        checks_with = agent_doctor_checks(roster, token_broker_port=TOKEN_BROKER_PORT)
-        checks_without = agent_doctor_checks(roster, token_broker_port=None)
-        base_url_with = [c for c in checks_with if "Base URL" in c.label]
-        base_url_without = [c for c in checks_without if "Base URL" in c.label]
-        assert len(base_url_with) > 0
-        assert len(base_url_without) == 0
+        checks_tcp = agent_doctor_checks(roster, token_broker_port=TOKEN_BROKER_PORT)
+        checks_socket = agent_doctor_checks(roster, token_broker_port=None)
+        base_url_tcp = [c for c in checks_tcp if "Base URL" in c.label]
+        base_url_socket = [c for c in checks_socket if "Base URL" in c.label]
+        assert len(base_url_tcp) > 0
+        assert len(base_url_socket) > 0
 
     def test_all_are_doctor_check_instances(self) -> None:
         roster = get_roster()

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -495,30 +495,32 @@ class TestVaultTokenInjection:
         assert "ANTHROPIC_API_KEY" not in result.env
 
     def test_vault_socket_transport_injects_socket_env(self, workspace, envs_dir, roster, tmp_path):
-        """Socket transport injects socket_env and socket_path for routes that declare them."""
+        """Socket transport points socket_env at the mounted host vault socket."""
         cfg = _make_vault_db(tmp_path)
         spec = _spec(workspace, envs_dir, credential_scope="proj", vault_transport="socket")
         with (
             patch("terok_sandbox.is_vault_socket_active", return_value=True),
             patch("terok_sandbox.SandboxConfig", return_value=cfg),
+            patch("terok_sandbox.get_token_broker_port", return_value=None),
         ):
             result = assemble_container_env(spec, roster, caller_manages_vault=False)
 
-        # Claude route declares socket_env=ANTHROPIC_UNIX_SOCKET
-        assert "ANTHROPIC_UNIX_SOCKET" in result.env
-        assert result.env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
+        assert result.env["ANTHROPIC_UNIX_SOCKET"] == "/run/terok/vault.sock"
 
-    def test_vault_direct_transport_omits_socket_env(self, workspace, envs_dir, roster, tmp_path):
-        """Direct transport (default) does not inject socket_env."""
+    def test_vault_direct_transport_points_socket_at_local_bridge(
+        self, workspace, envs_dir, roster, tmp_path
+    ):
+        """Direct (TCP) transport still sets socket_env — now to the local socat bridge."""
         cfg = _make_vault_db(tmp_path)
         spec = _spec(workspace, envs_dir, credential_scope="proj", vault_transport="direct")
         with (
             patch("terok_sandbox.is_vault_socket_active", return_value=True),
             patch("terok_sandbox.SandboxConfig", return_value=cfg),
+            patch("terok_sandbox.get_token_broker_port", return_value=18731),
         ):
             result = assemble_container_env(spec, roster, caller_manages_vault=False)
 
-        assert "ANTHROPIC_UNIX_SOCKET" not in result.env
+        assert result.env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-vault.sock"
 
     def test_vault_socket_transport_omits_tcp_broker_env_when_port_none(
         self, workspace, envs_dir, roster, tmp_path
@@ -527,10 +529,9 @@ class TestVaultTokenInjection:
 
         Under socket transport the broker listens only on the mounted Unix socket,
         and ``get_token_broker_port`` returns ``None``.  The assembled env must
-        omit every TCP-flavoured variable rather than interpolate the literal
-        string ``"None"`` — that string would otherwise leak through as
-        ``TEROK_TOKEN_BROKER_PORT="None"``, trip bridge scripts inside the
-        container, and silently break credential routing.
+        omit the TCP broker port variable rather than interpolate the literal
+        string ``"None"`` — that string would otherwise trip bridge scripts and
+        silently break credential routing.
         """
         cfg = _make_vault_db(tmp_path)
         spec = _spec(workspace, envs_dir, credential_scope="proj", vault_transport="socket")
@@ -542,11 +543,13 @@ class TestVaultTokenInjection:
             result = assemble_container_env(spec, roster, caller_manages_vault=False)
 
         assert "TEROK_TOKEN_BROKER_PORT" not in result.env
-        assert "GITLAB_API_HOST" not in result.env
-        # No env value should contain the stringified ``None`` port.
+        # GITLAB_API_HOST is now always set for glab — but never with "None".
         assert not any("None" in v for v in result.env.values())
-        # Socket transport is still honoured.
-        assert result.env.get("ANTHROPIC_UNIX_SOCKET") == "/tmp/terok-claude-proxy.sock"
+        # Socket transport uses the mounted host socket directly.
+        assert result.env.get("ANTHROPIC_UNIX_SOCKET") == "/run/terok/vault.sock"
+        # The in-container loopback port is advertised so ensure-bridges.sh
+        # stands up its TCP→UNIX bridge.
+        assert result.env.get("TEROK_VAULT_LOOPBACK_PORT") == "9419"
 
     def test_vault_required_raises_when_unreachable(self, workspace, envs_dir, roster):
         """vault_required=True raises SystemExit when vault is not running."""

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -31,15 +31,17 @@ class TestApplyTomlPatchWarning:
             "file": "config.toml",
             "toml_table": "servers",
             "toml_match": {"name": "proxy"},
-            "toml_set": {"api_base": "{proxy_url}/v1"},
+            "toml_set": {"api_base": "{vault_url}/v1"},
         }
 
-        from terok_executor.credentials.vault_config import _apply_toml_patch
+        from terok_executor.credentials.vault_config import VaultLocation, _apply_toml_patch
 
-        _apply_toml_patch(config_path, patch_spec, "http://localhost:9999")
+        _apply_toml_patch(
+            config_path, patch_spec, VaultLocation(url="http://localhost:9999", socket="")
+        )
 
         captured = capsys.readouterr()
-        assert "Warning [proxy-config]" in captured.err
+        assert "Warning [vault-config]" in captured.err
         assert str(config_path) in captured.err
 
         # The file should still be written with the new entry (fallback to empty dict)
@@ -59,12 +61,14 @@ class TestApplyTomlPatchWarning:
             "file": "nonexistent.toml",
             "toml_table": "servers",
             "toml_match": {"name": "proxy"},
-            "toml_set": {"api_base": "{proxy_url}/v1"},
+            "toml_set": {"api_base": "{vault_url}/v1"},
         }
 
-        from terok_executor.credentials.vault_config import _apply_toml_patch
+        from terok_executor.credentials.vault_config import VaultLocation, _apply_toml_patch
 
-        _apply_toml_patch(config_path, patch_spec, "http://localhost:9999")
+        _apply_toml_patch(
+            config_path, patch_spec, VaultLocation(url="http://localhost:9999", socket="")
+        )
 
         captured = capsys.readouterr()
         assert "Warning" not in captured.err
@@ -78,12 +82,14 @@ class TestApplyTomlPatchWarning:
             "file": "config.toml",
             "toml_table": "servers",
             "toml_match": {"name": "proxy"},
-            "toml_set": {"api_base": "{proxy_url}/v1"},
+            "toml_set": {"api_base": "{vault_url}/v1"},
         }
 
-        from terok_executor.credentials.vault_config import _apply_toml_patch
+        from terok_executor.credentials.vault_config import VaultLocation, _apply_toml_patch
 
-        _apply_toml_patch(config_path, patch_spec, "http://localhost:9999")
+        _apply_toml_patch(
+            config_path, patch_spec, VaultLocation(url="http://localhost:9999", socket="")
+        )
 
         captured = capsys.readouterr()
         assert "Warning" not in captured.err
@@ -104,15 +110,17 @@ class TestApplyYamlPatchWarning:
 
         patch_spec = {
             "file": "config.yaml",
-            "yaml_set": {"api_base": "{proxy_url}/v1"},
+            "yaml_set": {"api_base": "{vault_url}/v1"},
         }
 
-        from terok_executor.credentials.vault_config import _apply_yaml_patch
+        from terok_executor.credentials.vault_config import VaultLocation, _apply_yaml_patch
 
-        _apply_yaml_patch(config_path, patch_spec, "http://localhost:9999")
+        _apply_yaml_patch(
+            config_path, patch_spec, VaultLocation(url="http://localhost:9999", socket="")
+        )
 
         captured = capsys.readouterr()
-        assert "Warning [proxy-config]" in captured.err
+        assert "Warning [vault-config]" in captured.err
         assert str(config_path) in captured.err
 
         # The file should be written with only the new key (fallback to empty)
@@ -129,12 +137,14 @@ class TestApplyYamlPatchWarning:
         config_path = tmp_path / "nonexistent.yaml"
         patch_spec = {
             "file": "nonexistent.yaml",
-            "yaml_set": {"api_base": "{proxy_url}/v1"},
+            "yaml_set": {"api_base": "{vault_url}/v1"},
         }
 
-        from terok_executor.credentials.vault_config import _apply_yaml_patch
+        from terok_executor.credentials.vault_config import VaultLocation, _apply_yaml_patch
 
-        _apply_yaml_patch(config_path, patch_spec, "http://localhost:9999")
+        _apply_yaml_patch(
+            config_path, patch_spec, VaultLocation(url="http://localhost:9999", socket="")
+        )
 
         captured = capsys.readouterr()
         assert "Warning" not in captured.err
@@ -146,12 +156,14 @@ class TestApplyYamlPatchWarning:
 
         patch_spec = {
             "file": "config.yaml",
-            "yaml_set": {"api_base": "{proxy_url}/v1"},
+            "yaml_set": {"api_base": "{vault_url}/v1"},
         }
 
-        from terok_executor.credentials.vault_config import _apply_yaml_patch
+        from terok_executor.credentials.vault_config import VaultLocation, _apply_yaml_patch
 
-        _apply_yaml_patch(config_path, patch_spec, "http://localhost:9999")
+        _apply_yaml_patch(
+            config_path, patch_spec, VaultLocation(url="http://localhost:9999", socket="")
+        )
 
         captured = capsys.readouterr()
         assert "Warning" not in captured.err

--- a/tests/unit/test_vault_config_symlink.py
+++ b/tests/unit/test_vault_config_symlink.py
@@ -17,11 +17,14 @@ import pytest
 
 from terok_executor.credentials.vault_config import (
     ConfigPatchError,
+    VaultLocation,
     _apply_toml_patch,  # noqa: PLC2701
     _apply_yaml_patch,  # noqa: PLC2701
     _read_nofollow,  # noqa: PLC2701
     _write_nofollow,  # noqa: PLC2701
 )
+
+_TEST_LOCATION = VaultLocation(url="http://vault", socket="/tmp/terok-testing/vault.sock")
 
 
 class TestWriteNofollow:
@@ -84,10 +87,10 @@ class TestApplyPatchesSymlinkSafety:
             "file": "config.toml",
             "toml_table": "providers",
             "toml_match": {"name": "mistral"},
-            "toml_set": {"base_url": "{proxy_url}"},
+            "toml_set": {"base_url": "{vault_url}"},
         }
         with pytest.raises(ConfigPatchError, match="symlink"):
-            _apply_toml_patch(config, patch, proxy_url="http://vault")
+            _apply_toml_patch(config, patch, _TEST_LOCATION)
         assert victim.read_bytes() == b"UNCHANGED"
 
     def test_yaml_patch_rejects_symlinked_config(self, tmp_path: Path) -> None:
@@ -98,10 +101,10 @@ class TestApplyPatchesSymlinkSafety:
 
         patch = {
             "file": "config.yml",
-            "yaml_set": {"http_unix_socket": "/tmp/terok-testing/gh.sock"},
+            "yaml_set": {"http_unix_socket": "{vault_socket}"},
         }
         with pytest.raises(ConfigPatchError, match="symlink"):
-            _apply_yaml_patch(config, patch, proxy_url="http://vault")
+            _apply_yaml_patch(config, patch, _TEST_LOCATION)
         assert victim.read_bytes() == b"UNCHANGED"
 
     def test_toml_patch_writes_when_no_symlink(self, tmp_path: Path) -> None:
@@ -110,9 +113,9 @@ class TestApplyPatchesSymlinkSafety:
             "file": "config.toml",
             "toml_table": "providers",
             "toml_match": {"name": "mistral"},
-            "toml_set": {"base_url": "{proxy_url}/v1"},
+            "toml_set": {"base_url": "{vault_url}/v1"},
         }
-        _apply_toml_patch(config, patch, proxy_url="http://vault")
+        _apply_toml_patch(config, patch, _TEST_LOCATION)
         assert config.is_file() and not config.is_symlink()
         text = config.read_text(encoding="utf-8")
         assert "http://vault/v1" in text

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -28,7 +28,6 @@ class TestVaultRoutesParsed:
         assert "ANTHROPIC_API_KEY" in route.phantom_env
         assert "CLAUDE_CODE_OAUTH_TOKEN" in route.oauth_phantom_env
         assert route.base_url_env == "ANTHROPIC_BASE_URL"
-        assert route.socket_path == "/tmp/terok-claude-proxy.sock"
         assert route.socket_env == "ANTHROPIC_UNIX_SOCKET"
 
     def test_codex_route_exists(self) -> None:
@@ -59,18 +58,16 @@ class TestVaultRoutesParsed:
             route = get_roster().vault_routes.get(name)
             assert route is not None, f"{name} missing vault route"
             assert route.oauth_phantom_env == {}, f"{name} should have no oauth_phantom_env"
-            assert route.socket_path == "", f"{name} should have no socket_path"
             assert route.socket_env == "", f"{name} should have no socket_env"
 
-    def test_partial_socket_config_rejected(self) -> None:
-        """Setting only socket_path or only socket_env raises ValueError."""
+    def test_rejects_legacy_socket_path_field(self) -> None:
+        """socket_path was removed — declaring it must fail loudly so stale
+        agent manifests don't silently drift out of sync."""
         from terok_executor.roster.loader import _to_vault_route
 
         base = {"route_prefix": "test", "upstream": "https://example.com"}
-        with pytest.raises(ValueError, match="both.*together"):
+        with pytest.raises(ValueError, match="socket_path.*no longer"):
             _to_vault_route("test", {"vault": {**base, "socket_path": "/tmp/s.sock"}})
-        with pytest.raises(ValueError, match="both.*together"):
-            _to_vault_route("test", {"vault": {**base, "socket_env": "MY_SOCK"}})
 
     def test_opencode_agents_have_routes(self) -> None:
         """Blablador and KISSKI have vault routes."""
@@ -565,8 +562,8 @@ class TestFormatCredentials:
 class TestToVaultRoute:
     """Verify _to_vault_route() parsing edge cases."""
 
-    def test_both_socket_fields_accepted(self) -> None:
-        """Both socket_path and socket_env together are valid."""
+    def test_socket_env_alone_accepted(self) -> None:
+        """socket_env (without socket_path) is the new valid form."""
         from terok_executor.roster.loader import _to_vault_route
 
         route = _to_vault_route(
@@ -575,17 +572,15 @@ class TestToVaultRoute:
                 "vault": {
                     "route_prefix": "test",
                     "upstream": "https://example.com",
-                    "socket_path": "/tmp/test.sock",
                     "socket_env": "TEST_SOCKET",
                 }
             },
         )
         assert route is not None
-        assert route.socket_path == "/tmp/test.sock"
         assert route.socket_env == "TEST_SOCKET"
 
     def test_neither_socket_field_accepted(self) -> None:
-        """Omitting both socket fields is valid (no socket transport)."""
+        """Omitting socket_env is valid (agent has no socket transport)."""
         from terok_executor.roster.loader import _to_vault_route
 
         route = _to_vault_route(
@@ -598,7 +593,6 @@ class TestToVaultRoute:
             },
         )
         assert route is not None
-        assert route.socket_path == ""
         assert route.socket_env == ""
 
     def test_oauth_phantom_env_parsed(self) -> None:


### PR DESCRIPTION
## Summary

- In socket mode the container already mounts the host vault socket at `/run/terok/vault.sock`, but `gh` was still pointed at a bridge socket (`/tmp/terok-gh-proxy.sock`) that `ensure-bridges.sh` only created in TCP mode — so every `gh` call died with EOF. Claude was silently broken the same way via `ANTHROPIC_UNIX_SOCKET`.
- Replace per-agent bridge sockets with a single, centrally-resolved vault address. Sockets land on the mounted host socket in socket mode and on a single socat-fronted `/tmp/terok-vault.sock` in TCP mode.
- HTTP-only clients (`vibe`, `codex`, `opencode`, `sonar`, `glab`) now get an in-container TCP→UNIX loopback on `localhost:9419` so their base-URL knob works in socket mode too.
- Agent YAMLs reference two templates — `{vault_url}` and `{vault_socket}` — that resolve per-transport, so manifests no longer hard-code paths.
- Drop "proxy" terminology throughout (`write_proxy_config` → `write_vault_config`, `{proxy_url}` → `{vault_url}`, `gh-proxy.sock` → `vault.sock`). Doctor checks now probe the right bridge for the active transport.

## Why now

New containers built after the sandbox `credential-proxy.sock` → `vault.sock` rename (sandbox #161) started failing `gh` calls because `gh.yaml` hard-coded the old bridge-socket path and the bridge itself only runs in TCP mode. This collapses the per-agent abstraction that only made sense in TCP mode anyway — the vault already routes purely by phantom token, not URL, so one shared entrypoint is enough for every client.

## Socket-capability survey

Only `gh` and `claude` speak HTTP-over-UNIX natively. `vibe` (httpx no-transport), `codex` (reqwest no custom connector), `opencode` (plain globalThis.fetch), `sonar` (JDK HttpClient), `glab` (Go http.Transport), and `coderabbit` (HTTPS_PROXY only) all need a TCP endpoint — hence the in-container loopback bridge in socket mode.

## Test plan

- [x] `make check` green (lint, format, 641 unit tests, tach, docstrings ≥95%, REUSE, bandit 0 medium/high)
- [x] New doctor coverage: `TestVaultBridgeCheck` exercises both socket-mode and TCP-mode probes
- [x] New env-builder coverage: socket transport sets `ANTHROPIC_UNIX_SOCKET=/run/terok/vault.sock` and `TEROK_VAULT_LOOPBACK_PORT=9419`; TCP transport points it at `/tmp/terok-vault.sock`
- [ ] Manual smoke in a real container: `gh auth status`, `claude --version`, and one `vibe`/`codex` call against the vault in socket mode
- [ ] Manual smoke in TCP mode to confirm the legacy path still works

## Out of scope

- `coderabbit` is forward-proxy-only (HTTPS_PROXY CONNECT tunnel) and can't be routed through the reverse-proxy vault without a deeper refactor; it gets its own container type anyway, so it's left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)