### PR TITLE
fix(vibe): restore MISTRAL_API_KEY binding so requests carry an Authorization header

### DIFF
--- a/src/terok_executor/resources/agents/vibe.yaml
+++ b/src/terok_executor/resources/agents/vibe.yaml
@@ -42,7 +42,14 @@ vault:
     file: config.toml
     toml_table: providers
     toml_match: {name: mistral}
-    toml_set: {api_base: "{vault_url}/v1"}
+    # api_key_env_var restores the MISTRAL_API_KEY binding that vibe's
+    # DEFAULT_PROVIDERS sets — the user's ``providers = [...]`` list
+    # *replaces* defaults wholesale, so if we only write ``api_base`` the
+    # provider falls back to ``api_key_env_var=""``, vibe reads no env, and
+    # sends requests without an Authorization header (vault returns 401).
+    toml_set:
+      api_base: "{vault_url}/v1"
+      api_key_env_var: MISTRAL_API_KEY
 
 auth:
   host_dir: _vibe-config


### PR DESCRIPTION
## Summary

Fixes a silent misconfiguration where every `vibe` call in socket mode hit the vault with no `Authorization` header, resulting in vault log lines like:

\`\`\`
terok-vault WARNING POST /v1/chat/completions -> 401 Missing authentication
"POST /v1/chat/completions HTTP/1.1" 401 185 "-" "Mistral-Vibe/2.7.6"
\`\`\`

…which `vibe` surfaces to the user as a misleading *"Invalid API key"*.

## Root cause

`vibe`'s bundled `DEFAULT_PROVIDERS` list (`vibe/core/config/_settings.py:371-379`) pairs the `mistral` provider with `api_key_env_var="MISTRAL_API_KEY"` and `backend=Backend.MISTRAL`. But when the user's `config.toml` has its own `providers = [...]` list, pydantic's `providers` field **replaces** the default wholesale — it's not merged per-entry.

Our `shared_config_patch` in `vibe.yaml` only wrote `api_base`, so the resolved `ProviderConfig` fell back to `api_key_env_var=""`. `vibe` called `os.getenv("")` → `None`, `build_headers(None)` skipped the `Authorization` line (`vibe/core/llm/backend/generic.py:62-64`), and every request went out with no auth. The vault rightly rejected with 401 Missing authentication.

## Fix

Add `api_key_env_var: MISTRAL_API_KEY` to the patch so `vibe` reads the phantom token we already inject as `MISTRAL_API_KEY` and forwards it as `Authorization: Bearer …`. The vault then recognises the phantom, swaps it for the real Mistral key from the credential DB, and Mistral answers normally.

## Test plan

- [x] `make check` green
- [ ] Manual: in a fresh socket-mode container, re-run `terok auth vibe`, then `vibe` — verify 200 from `/v1/chat/completions` and no more 401s in the vault log
- [ ] Manual: verify `~/.vibe/config.toml` matches `name=mistral` entry gets both `api_base` and `api_key_env_var` updated (idempotent across task starts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mistral provider configuration to properly include API key environment variable alongside the API endpoint setting, ensuring correct authentication for API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->