### PR TITLE
feat(container): propagate host timezone to task containers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.100"
+version = "0.0.101"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_executor/_util/__init__.py
+++ b/src/terok_executor/_util/__init__.py
@@ -8,9 +8,11 @@ Standalone — no terok-executor domain imports, safe to use from any layer.
 
 from ._fs import ensure_dir, ensure_dir_writable
 from ._podman import podman_userns_args
+from ._timezone import detect_host_timezone
 from ._yaml import load as yaml_load
 
 __all__ = [
+    "detect_host_timezone",
     "ensure_dir",
     "ensure_dir_writable",
     "podman_userns_args",

--- a/src/terok_executor/_util/_timezone.py
+++ b/src/terok_executor/_util/_timezone.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Detects the host's IANA timezone for propagation into containers.
+
+Returned as a plain string (``"Europe/Prague"``, ``"UTC"``, …) suitable
+for use as a ``TZ`` env var inside the container — glibc resolves it
+against ``/usr/share/zoneinfo`` without needing the host's filesystem.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_ZONEINFO_MARKER = "/zoneinfo/"
+
+
+def detect_host_timezone() -> str | None:
+    """Return the host's IANA timezone name, or ``None`` if it can't be detected.
+
+    Tried in order:
+
+    1. ``$TZ`` — the user's explicit override.
+    2. ``/etc/timezone`` — Debian/Ubuntu convention, single-line zone name.
+    3. ``/etc/localtime`` symlink — systemd-family hosts (and macOS) symlink
+       this into the zoneinfo database; the zone name is the path suffix
+       after the ``zoneinfo/`` component.
+
+    Returns ``None`` on hosts that expose none of the above (containers with
+    only a copied-in ``/etc/localtime`` file, for instance), letting the
+    caller fall back to the image default rather than guessing.
+    """
+    if tz := os.environ.get("TZ"):
+        return tz
+
+    try:
+        if zone := Path("/etc/timezone").read_text(encoding="utf-8").strip():
+            return zone
+    except OSError:
+        pass
+
+    try:
+        target = Path("/etc/localtime").resolve().as_posix()
+    except OSError:
+        return None
+    if _ZONEINFO_MARKER in target:
+        return target.split(_ZONEINFO_MARKER, 1)[1]
+    return None

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -94,6 +94,7 @@ def _handle_run(
     shared_mount: str = "/shared",
     base: str = "ubuntu:24.04",
     family: str | None = None,
+    timezone: str | None = None,
 ) -> None:
     """Run an agent in a hardened container."""
     import sys
@@ -130,6 +131,7 @@ def _handle_run(
         "human_email": human_email,
         "authorship": authorship,
         "shared_dir": resolved_shared_dir,
+        "timezone": timezone,
     }
     if resolved_shared_dir:
         common["shared_mount"] = shared_mount
@@ -169,6 +171,7 @@ def _handle_run_tool(
     tool_args: list[str] | None = None,
     base: str = "ubuntu:24.04",
     family: str | None = None,
+    timezone: str | None = None,
 ) -> None:
     """Run a tool in a sidecar container."""
     from .container.runner import AgentRunner
@@ -183,6 +186,7 @@ def _handle_run_tool(
         gate=effective_gate,
         name=name,
         timeout=timeout,
+        timezone=timezone,
     )
     print(f"Container: {cname}")
 
@@ -398,6 +402,14 @@ RUN_COMMAND = CommandDef(
             default=None,
             help="Override package family for unknown base images (deb or rpm)",
         ),
+        ArgDef(
+            name="--timezone",
+            default=None,
+            help=(
+                "IANA timezone for the container (e.g. 'Europe/Prague', 'UTC'). "
+                "Default: follow the host."
+            ),
+        ),
     ),
 )
 
@@ -419,6 +431,14 @@ RUN_TOOL_COMMAND = CommandDef(
             name="--family",
             default=None,
             help="Override package family for unknown base images (deb or rpm)",
+        ),
+        ArgDef(
+            name="--timezone",
+            default=None,
+            help=(
+                "IANA timezone for the container (e.g. 'Europe/Prague', 'UTC'). "
+                "Default: follow the host."
+            ),
         ),
     ),
 )

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING, Literal
 
 from terok_sandbox import Sharing, VolumeSpec
 
+from terok_executor._util import detect_host_timezone
+
 _CONTAINER_RUNTIME_DIR = "/run/terok"
 """Container-side mount point — must match :data:`terok_sandbox.CONTAINER_RUNTIME_DIR`."""
 
@@ -128,6 +130,18 @@ class ContainerEnvSpec:
     unrestricted: bool = True
     """Enable auto-approve flags for all agents."""
 
+    # -- Locale ------------------------------------------------------------
+
+    timezone: str | None = None
+    """IANA timezone name propagated to the container as ``TZ``.
+
+    ``None`` (the default) means *detect the host's timezone* via
+    :func:`terok_executor._util.detect_host_timezone` — the container
+    then follows the host.  Pass an explicit string (``"UTC"``,
+    ``"Europe/Prague"``) to override, including to pin the container to
+    UTC for reproducible runs.  If neither detection nor an override
+    yields a zone, ``TZ`` is not set and the image default applies."""
+
     # -- Agent config ------------------------------------------------------
 
     agent_config_dir: Path | None = None
@@ -214,6 +228,10 @@ def assemble_container_env(
     env["GIT_RESET_MODE"] = "none"
     env["TEROK_CONTAINER_PROTOCOL"] = str(CONTAINER_PROTOCOL)
     env["CLAUDE_CONFIG_DIR"] = "/home/dev/.claude"
+
+    # 1b. Timezone — explicit override wins, otherwise follow the host
+    if tz := spec.timezone or detect_host_timezone():
+        env["TZ"] = tz
 
     # 2. OpenCode provider env
     env.update(roster.collect_opencode_provider_env())

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING
 
 from terok_sandbox import Sharing, VolumeSpec
 
+from terok_executor._util import detect_host_timezone
+
 from .build import BuildError, build_base_images
 
 if TYPE_CHECKING:
@@ -143,6 +145,7 @@ class AgentRunner:
         authorship: str | None = None,
         shared_dir: Path | None = None,
         shared_mount: str = "/shared",
+        timezone: str | None = None,
     ) -> str:
         """Launch a headless agent run. Returns container name.
 
@@ -172,6 +175,7 @@ class AgentRunner:
             authorship=authorship,
             shared_dir=shared_dir,
             shared_mount=shared_mount,
+            timezone=timezone,
         )
 
     def run_interactive(
@@ -192,6 +196,7 @@ class AgentRunner:
         authorship: str | None = None,
         shared_dir: Path | None = None,
         shared_mount: str = "/shared",
+        timezone: str | None = None,
     ) -> str:
         """Launch an interactive container. Returns container name.
 
@@ -214,6 +219,7 @@ class AgentRunner:
             authorship=authorship,
             shared_dir=shared_dir,
             shared_mount=shared_mount,
+            timezone=timezone,
         )
 
     def run_web(
@@ -235,6 +241,7 @@ class AgentRunner:
         authorship: str | None = None,
         shared_dir: Path | None = None,
         shared_mount: str = "/shared",
+        timezone: str | None = None,
     ) -> str:
         """Launch a toad web container. Returns container name.
 
@@ -262,6 +269,7 @@ class AgentRunner:
             authorship=authorship,
             shared_dir=shared_dir,
             shared_mount=shared_mount,
+            timezone=timezone,
         )
 
     def run_tool(
@@ -275,6 +283,7 @@ class AgentRunner:
         name: str | None = None,
         follow: bool = True,
         timeout: int = 600,
+        timezone: str | None = None,
     ) -> str:
         """Launch a sidecar tool container. Returns container name.
 
@@ -292,6 +301,7 @@ class AgentRunner:
             timeout=timeout,
             tool_args=tool_args,
             branch=branch,
+            timezone=timezone,
         )
 
     def launch_prepared(
@@ -576,6 +586,7 @@ class AgentRunner:
         authorship: str | None = None,
         shared_dir: Path | None = None,
         shared_mount: str = "/shared",
+        timezone: str | None = None,
     ) -> str:
         """Unified launch flow for all modes (headless, interactive, web, tool)."""
         from terok_executor.paths import mounts_dir
@@ -608,6 +619,8 @@ class AgentRunner:
                 "REPO_ROOT": "/workspace",
                 "GIT_RESET_MODE": "none",
             }
+            if tz := timezone or detect_host_timezone():
+                env["TZ"] = tz
             if branch:
                 env["GIT_BRANCH"] = branch
             env.update(self._direct_credential_env(provider))
@@ -660,6 +673,7 @@ class AgentRunner:
                 "agent_config_dir": agent_config_dir,
                 "task_dir": task_dir,
                 "envs_dir": mounts_base,
+                "timezone": timezone,
             }
             if human_name:
                 spec_kwargs["human_name"] = human_name

--- a/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
@@ -10,11 +10,13 @@ ENV {% if family == "deb" %}DEBIAN_FRONTEND=noninteractive \
     LANGUAGE="en_US:en" \
     USER="dev"
 
-# Basic dev tooling common to all projects.
+# Basic dev tooling common to all projects.  ``tzdata`` is explicit on both
+# families so the runtime ``TZ`` env var — set from the host's timezone —
+# can resolve against ``/usr/share/zoneinfo``.
 {% if family == "deb" -%}
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl gnupg git locales openssh-client socat sudo \
-      ripgrep vim tmux \
+      ripgrep vim tmux tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 # Ensure en_US.UTF-8 exists so bash and agent-spawned shells can always set LC_ALL safely.
@@ -26,7 +28,7 @@ RUN set -eux; \
 # glibc-langpack-en provides en_US.UTF-8 directly — no locale-gen step needed.
 RUN dnf install -y --setopt=install_weak_deps=False \
       ca-certificates curl gnupg2 git glibc-langpack-en openssh-clients \
-      socat sudo ripgrep vim tmux \
+      socat sudo ripgrep vim tmux tzdata \
     && dnf clean all
 {%- endif %}
 

--- a/tach.toml
+++ b/tach.toml
@@ -122,6 +122,7 @@ depends_on = []
 [[modules]]
 path = "terok_executor.container.env"
 depends_on = [
+    "terok_executor._util",
     "terok_executor.credentials.vault_commands",
     "terok_executor.credentials.vault_config",
     "terok_executor.paths",
@@ -132,6 +133,7 @@ depends_on = [
 [[modules]]
 path = "terok_executor.container.runner"
 depends_on = [
+    "terok_executor._util",
     "terok_executor.container.build",
     "terok_executor.container.cache",
     "terok_executor.container.env",

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -220,6 +220,48 @@ class TestAuthorship:
 
 
 # ---------------------------------------------------------------------------
+# Timezone
+# ---------------------------------------------------------------------------
+
+
+class TestTimezone:
+    """Verify TZ propagation: explicit override wins, otherwise follow the host."""
+
+    def test_explicit_override(self, workspace, envs_dir, roster):
+        spec = _spec(workspace, envs_dir, timezone="Europe/Prague")
+        result = assemble_container_env(spec, roster, caller_manages_vault=True)
+        assert result.env["TZ"] == "Europe/Prague"
+
+    def test_explicit_utc_pins_container(self, workspace, envs_dir, roster):
+        """Passing ``"UTC"`` explicitly is how callers opt out of host-follow."""
+        spec = _spec(workspace, envs_dir, timezone="UTC")
+        result = assemble_container_env(spec, roster, caller_manages_vault=True)
+        assert result.env["TZ"] == "UTC"
+
+    def test_detects_host_when_unset(self, base_spec, roster):
+        with patch("terok_executor.container.env.detect_host_timezone") as mock_detect:
+            mock_detect.return_value = "America/Los_Angeles"
+            result = assemble_container_env(base_spec, roster, caller_manages_vault=True)
+        assert result.env["TZ"] == "America/Los_Angeles"
+
+    def test_explicit_wins_over_detection(self, workspace, envs_dir, roster):
+        """Override takes precedence — detection is never even consulted."""
+        spec = _spec(workspace, envs_dir, timezone="Asia/Tokyo")
+        with patch("terok_executor.container.env.detect_host_timezone") as mock_detect:
+            mock_detect.return_value = "Europe/Berlin"
+            result = assemble_container_env(spec, roster, caller_manages_vault=True)
+            mock_detect.assert_not_called()
+        assert result.env["TZ"] == "Asia/Tokyo"
+
+    def test_undetectable_host_omits_tz(self, base_spec, roster):
+        """No override + no detectable host TZ → leave TZ unset (use image default)."""
+        with patch("terok_executor.container.env.detect_host_timezone") as mock_detect:
+            mock_detect.return_value = None
+            result = assemble_container_env(base_spec, roster, caller_manages_vault=True)
+        assert "TZ" not in result.env
+
+
+# ---------------------------------------------------------------------------
 # Repository setup
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_timezone.py
+++ b/tests/unit/test_timezone.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for host timezone detection.
+
+Each source (``$TZ``, ``/etc/timezone``, ``/etc/localtime`` symlink) is
+exercised by swapping the module's ``Path`` for a stub that routes the
+two hardcoded probes to test-owned files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from terok_executor._util import _timezone
+from terok_executor._util._timezone import detect_host_timezone
+
+
+@pytest.fixture
+def no_tz_env(monkeypatch):
+    """Clear ``$TZ`` so fallback sources are reached."""
+    monkeypatch.delenv("TZ", raising=False)
+
+
+def _route_paths(timezone_file: Path | None, localtime_target: Path | None):
+    """Return a ``Path`` stub that swaps in test files for the two probed locations.
+
+    ``timezone_file=None`` makes the ``/etc/timezone`` read raise; likewise
+    ``localtime_target=None`` makes the ``/etc/localtime`` resolve raise.
+    """
+    missing = Path("/this/does/not/exist")
+
+    class _LocaltimeStub:
+        @staticmethod
+        def resolve():
+            if localtime_target is None:
+                raise OSError("missing")
+            return localtime_target
+
+    def _factory(arg):
+        if arg == "/etc/timezone":
+            return timezone_file if timezone_file is not None else missing
+        if arg == "/etc/localtime":
+            return _LocaltimeStub()
+        raise AssertionError(f"unexpected Path({arg!r}) in timezone probe")
+
+    return _factory
+
+
+class TestEnvVar:
+    """``$TZ`` wins over every other source."""
+
+    def test_env_var_wins_over_filesystem(self, monkeypatch):
+        monkeypatch.setenv("TZ", "Europe/Prague")
+        with patch.object(_timezone, "Path", side_effect=AssertionError("should not read")):
+            assert detect_host_timezone() == "Europe/Prague"
+
+
+class TestEtcTimezone:
+    """``/etc/timezone`` supplies the zone as a single line on Debian/Ubuntu."""
+
+    def test_reads_zone_name(self, no_tz_env, tmp_path):
+        zone_file = tmp_path / "timezone"
+        zone_file.write_text("Europe/Prague\n")
+        with patch.object(_timezone, "Path", side_effect=_route_paths(zone_file, None)):
+            assert detect_host_timezone() == "Europe/Prague"
+
+    def test_blank_file_falls_through_to_localtime(self, no_tz_env, tmp_path):
+        blank = tmp_path / "timezone"
+        blank.write_text("   \n")
+        target = Path("/usr/share/zoneinfo/UTC")
+        with patch.object(_timezone, "Path", side_effect=_route_paths(blank, target)):
+            assert detect_host_timezone() == "UTC"
+
+
+class TestEtcLocaltime:
+    """``/etc/localtime`` symlink supplies the zone via its resolved target."""
+
+    def test_resolves_symlink_target(self, no_tz_env):
+        target = Path("/usr/share/zoneinfo/Asia/Tokyo")
+        with patch.object(_timezone, "Path", side_effect=_route_paths(None, target)):
+            assert detect_host_timezone() == "Asia/Tokyo"
+
+    def test_macos_layout(self, no_tz_env):
+        """macOS symlinks into ``/var/db/timezone/zoneinfo/<zone>``."""
+        target = Path("/var/db/timezone/zoneinfo/America/New_York")
+        with patch.object(_timezone, "Path", side_effect=_route_paths(None, target)):
+            assert detect_host_timezone() == "America/New_York"
+
+
+class TestUnresolvable:
+    """When every source is silent the helper returns ``None`` — never guesses."""
+
+    def test_all_sources_missing(self, no_tz_env):
+        with patch.object(_timezone, "Path", side_effect=_route_paths(None, None)):
+            assert detect_host_timezone() is None
+
+    def test_localtime_target_not_in_zoneinfo(self, no_tz_env):
+        """A ``/etc/localtime`` that points outside a ``zoneinfo/`` dir is unusable."""
+        target = Path("/some/random/path")
+        with patch.object(_timezone, "Path", side_effect=_route_paths(None, target)):
+            assert detect_host_timezone() is None


### PR DESCRIPTION
## Summary

- Add `ContainerEnvSpec.timezone` + `--timezone` flag on `run` / `run-tool`; unset = follow host, explicit = override.
- Detect host TZ via `$TZ` → `/etc/timezone` → `/etc/localtime` symlink; inject as `TZ` env var (runtime-only, no rebuild).
- Pin `tzdata` on both Debian and Fedora in the L0 Dockerfile so glibc can resolve the zone.

## Why

Task containers shipped with GMT/UTC regardless of the host. Logs, `date`, git commit authoredates all diverged from what the operator sees on the host. `TZ` is the cleanest fix: one env var, nothing filesystem-dependent, and pinning to a fixed zone (e.g. `UTC` in CI) is a one-liner.

## Test plan

- [x] `make check` — lint, tach, docstrings, security, reuse green
- [x] 656 unit tests pass, including new `test_timezone.py` (7) and timezone block in `test_env_builder.py` (5)
- [ ] Manual smoke on a test machine: launch a container with and without `--timezone`, verify `date` and `$TZ`
- [ ] Verify Debian + Fedora base images both resolve `TZ=Europe/Prague` correctly

## Paired change

terok PR wires `run.timezone` in project.yml through to this field. See terok-ai/terok#<TBD>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Containers now detect and propagate the host system timezone; new --timezone option lets you override it for run and run-tool.

* **Tests**
  * Added comprehensive tests for timezone detection and container environment behavior.

* **Chores**
  * Development image now includes timezone data; package version incremented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->