### PR TITLE
docs(security): fix conflation of --no-gate with egress firewall

### DIFF
--- a/docs/launch-modes.md
+++ b/docs/launch-modes.md
@@ -56,7 +56,7 @@ terok-executor stop my-task    # stop a specific container
 
 | Flag | Description |
 |------|-------------|
-| `--gate` / `--no-gate` | Enable or disable the egress firewall (default: on) |
+| `--gate` / `--no-gate` | Route git clone through the host-side gate mirror, or skip it and let the container clone upstream directly (default: on — the gate is faster and offers staleness comparison; the shield firewall is unaffected) |
 | `--restricted` | No auto-approve, no-new-privileges |
 | `--branch <ref>` | Check out a specific git branch |
 | `--name <name>` | Container name override |

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,16 +5,19 @@ a vault, optional restricted mode, and rootless containers.
 
 ## Egress firewall
 
-On by default. The firewall
-([terok-shield](https://terok-ai.github.io/terok-shield/)) restricts
-outbound traffic to explicitly allowed domains — the agent's API endpoint,
-package registries, and git hosts. Everything else is blocked at the
-nftables level.
+On by default for every container that starts through terok-executor.
+The firewall ([terok-shield](https://terok-ai.github.io/terok-shield/))
+restricts outbound traffic to explicitly allowed domains — the agent's
+API endpoint, package registries, and git hosts.  Everything else is
+blocked at the nftables level.
 
-```bash
-terok-executor run claude . -p "…"         # firewall on (default)
-terok-executor run claude . --no-gate -p "…"  # disable for development
-```
+The firewall is attached via OCI hooks at install time (``terok-executor
+setup`` / ``terok-sandbox setup``); there is no per-run opt-out.  To
+loosen it for development, edit the shield profile or run
+``terok-executor uninstall`` + reinstall without the hooks.
+
+The git gate mirror (``--gate`` / ``--no-gate``) is a separate concern
+from the firewall — see [Launch modes](launch-modes.md) for that flag.
 
 ## Vault
 


### PR DESCRIPTION
Two small accuracy fixes in the user-facing docs, caught while sweeping the doc set after the gate/upstream feature landed.

## What was wrong

**`docs/launch-modes.md`** — the `--gate` / `--no-gate` row in the flags table said "Enable or disable the egress firewall (default: on)".  The flag controls whether git clone is routed through the host-side gate mirror; it has nothing to do with the shield firewall.

**`docs/security.md`** — the "Egress firewall" section used `terok-executor run claude . --no-gate -p '…' # disable for development` as an example of disabling the firewall.  Misleading on two counts: `--no-gate` doesn't disable the firewall, and there is no per-run opt-out for the shield anyway (OCI-hook-level install concern; loosening it means editing the shield profile or re-installing without hooks).

## What changed

- Rewrote the `--gate`/`--no-gate` row to describe the git-gate routing distinction and explicitly note the firewall is independent.
- Replaced the misleading security.md example with an honest note that the firewall is attached at install time and there is no per-run opt-out; pointed at `launch-modes.md` for the gate flag.

Docs only — no code or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)