### PR TITLE
fix(auth): accept None project_id for host-wide auth

### DIFF
--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -255,7 +255,7 @@ def _handle_auth(*, agent: str, api_key: str | None = None) -> None:
         image = l1_image_tag("ubuntu:24.04")
         from .paths import mounts_dir
 
-        authenticate("standalone", agent, mounts_dir=mounts_dir(), image=image)
+        authenticate(None, agent, mounts_dir=mounts_dir(), image=image)
 
     # Write vault URLs to shared config files (e.g. Vibe config.toml, gh config.yml)
     from .credentials.vault_config import write_vault_config

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -121,20 +121,14 @@ AUTH_PROVIDERS: dict[str, AuthProvider] = {}
 
 
 def authenticate(
-    project_id: str,
+    project_id: str | None,
     provider: str,
     *,
     mounts_dir: Path,
     image: str,
     expose_token: bool = False,
 ) -> None:
-    """Run the auth flow for *provider* against *project_id*.
-
-    Args:
-        expose_token: When True, copy the real credential files into
-            the shared mount instead of writing a phantom marker.  Used
-            by tier 3 (``expose_oauth_token``) where containers need
-            the actual token.
+    """Run the auth flow for *provider*, optionally scoped to a project.
 
     Dispatches based on the provider's ``modes`` field:
 
@@ -143,10 +137,17 @@ def authenticate(
     - **both**: ask user to choose, then dispatch accordingly
 
     Args:
-        project_id: Project identifier (for container naming).
+        project_id: Project identifier used for container naming and the
+            banner line.  Pass ``None`` for host-wide auth — the banner
+            drops the project reference and the container gets a neutral
+            ``host-auth-<provider>`` name.
         provider: Auth provider name (e.g. ``"claude"``).
         mounts_dir: Base directory for shared config bind-mounts.
         image: Container image to use for the auth container.
+        expose_token: When True, copy the real credential files into
+            the shared mount instead of writing a phantom marker.  Used
+            by tier 3 (``expose_oauth_token``) where containers need
+            the actual token.
 
     Raises ``SystemExit`` if the provider name is unknown.
     """
@@ -234,7 +235,7 @@ def _prompt_api_key(info: AuthProvider) -> str:
 
 
 def _run_auth_container(
-    project_id: str,
+    project_id: str | None,
     provider: AuthProvider,
     *,
     mounts_dir: Path,
@@ -262,7 +263,11 @@ def _run_auth_container(
     with tempfile.TemporaryDirectory(prefix=f"terok-auth-{provider.name}-") as tmpdir:
         host_dir = Path(tmpdir)
 
-        container_name = f"{project_id}-auth-{provider.name}"
+        # ``project_id`` must lead the container name; Podman rejects names
+        # starting with ``_`` or other non-alphanumeric chars, so the
+        # host-wide caller passes ``None`` and we fall back to ``host``.
+        name_prefix = project_id or "host"
+        container_name = f"{name_prefix}-auth-{provider.name}"
         _cleanup_existing_container(container_name)
 
         cmd = ["podman", "run", "--rm"]
@@ -276,7 +281,10 @@ def _run_auth_container(
         cmd.extend(provider.command)
 
         # Banner
-        print(f"Authenticating {provider.label} for project: {project_id}")
+        if project_id:
+            print(f"Authenticating {provider.label} for project: {project_id}")
+        else:
+            print(f"Authenticating {provider.label} (host-wide)")
         print()
         for line in provider.banner_hint.splitlines():
             print(line)

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -335,7 +335,7 @@ def _fix_credentials(provider: str) -> bool:
 
     image = l1_image_tag("ubuntu:24.04")
     try:
-        authenticate("standalone", provider, mounts_dir=mounts_dir(), image=image)
+        authenticate(None, provider, mounts_dir=mounts_dir(), image=image)
     except SystemExit:
         return False
 


### PR DESCRIPTION
## Summary

- `podman run` was rejecting the host-wide auth container because the caller passed `_host` as `project_id`, which became the leading segment of the container name. Podman's name rule (`[a-zA-Z0-9][a-zA-Z0-9_.-]*`) forbids a leading underscore, so `terok auth gh` crashed with:

  ```
  Error: running container create option: names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*: invalid argument
  ```

- Make `authenticate`'s `project_id` `Optional[str]`: `None` now means host-wide. The container falls back to a neutral `host-auth-<provider>` name, and the banner switches from the misleading `Authenticating X for project: _host` to `Authenticating X (host-wide)`.
- Internal callers (`commands._handle_auth`, `preflight._fix_credentials`) now pass `None` instead of the placeholder `"standalone"` — same UX improvement for `terok-executor auth <name>` and the first-run preflight.

## Test plan

- [x] `make check` passes (lint, 670 unit tests, tach, docstrings, reuse, bandit)
- [ ] Manual: `terok auth gh` (host-wide) picks the container name `host-auth-gh` and prints `Authenticating GitHub CLI (host-wide)`
- [ ] Manual: `terok auth gh --project foo` still names the container `foo-auth-gh` and prints `Authenticating GitHub CLI for project: foo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced authentication flow to support host-wide credential setup. When no specific project is selected, authentication now configures credentials at the system level with improved container naming and clearer prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->