### PR TITLE
feat(setup): compose routes + sandbox aggregator in ensure_sandbox_ready

### DIFF
--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -102,7 +102,7 @@ from .roster import (
 )
 
 # -- Sandbox bootstrap composition ---------------------------------------------
-from .sandbox import ensure_sandbox_ready, uninstall_sandbox_services
+from .sandbox import ensure_sandbox_ready
 
 # -- Storage queries (filesystem footprint measurement) -------------------------
 from .storage import (
@@ -221,5 +221,4 @@ __all__ = [
     "inject_prompt",
     # Sandbox bootstrap composition
     "ensure_sandbox_ready",
-    "uninstall_sandbox_services",
 ]

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -101,6 +101,9 @@ from .roster import (
     parse_agent_selection,
 )
 
+# -- Sandbox bootstrap composition ---------------------------------------------
+from .sandbox import ensure_sandbox_ready, uninstall_sandbox_services
+
 # -- Storage queries (filesystem footprint measurement) -------------------------
 from .storage import (
     SharedMountStorageInfo,
@@ -216,4 +219,7 @@ __all__ = [
     # Sealed injection helpers
     "inject_agent_config",
     "inject_prompt",
+    # Sandbox bootstrap composition
+    "ensure_sandbox_ready",
+    "uninstall_sandbox_services",
 ]

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -407,9 +407,9 @@ def _handle_uninstall(
     if not keep_images:
         _remove_images(base)
     if not no_sandbox:
-        from .sandbox import uninstall_sandbox_services
+        from terok_sandbox.commands import _handle_sandbox_uninstall
 
-        uninstall_sandbox_services(root=root)
+        _handle_sandbox_uninstall(root=root)
 
     print()
     print("Uninstall complete.")

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -377,9 +377,9 @@ def _handle_setup(
         return
 
     if not no_sandbox:
-        from terok_sandbox.commands import _handle_sandbox_setup
+        from .sandbox import ensure_sandbox_ready
 
-        _handle_sandbox_setup(root=root)
+        ensure_sandbox_ready(root=root)
 
     if not no_images:
         _build_images_with_banner(base, family)
@@ -407,9 +407,9 @@ def _handle_uninstall(
     if not keep_images:
         _remove_images(base)
     if not no_sandbox:
-        from terok_sandbox.commands import _handle_sandbox_uninstall
+        from .sandbox import uninstall_sandbox_services
 
-        _handle_sandbox_uninstall(root=root)
+        uninstall_sandbox_services(root=root)
 
     print()
     print("Uninstall complete.")

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -280,17 +280,11 @@ def _confirm(prompt: str, *, assume_yes: bool = False) -> bool:
 
 
 def _fix_sandbox_services() -> bool:
-    """Run the executor setup path to install + wire up shield+vault+gate+clearance.
+    """Self-heal missing sandbox services via :func:`ensure_sandbox_ready`.
 
-    Always installs into the per-user scope.  System-wide installation
-    is an explicit operator choice, exposed via ``terok-executor setup
-    --root``; the interactive preflight path never escalates to sudo
-    behind the user's back.  Goes through
-    :func:`terok_executor.sandbox.ensure_sandbox_ready` so the vault
-    picks up the roster-derived ``routes.json`` on first start — a
-    bare sandbox aggregator call would leave the vault running with
-    no authorization config, which breaks credential fetch on the
-    next agent run.
+    Always per-user — the interactive preflight never escalates to
+    sudo behind the operator's back.  ``--root`` is the explicit
+    opt-in via ``terok-executor setup``.
     """
     from terok_executor.sandbox import ensure_sandbox_ready
 

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -280,17 +280,22 @@ def _confirm(prompt: str, *, assume_yes: bool = False) -> bool:
 
 
 def _fix_sandbox_services() -> bool:
-    """Run the ``sandbox setup`` aggregator to install shield+vault+gate.
+    """Run the executor setup path to install + wire up shield+vault+gate+clearance.
 
     Always installs into the per-user scope.  System-wide installation
     is an explicit operator choice, exposed via ``terok-executor setup
     --root``; the interactive preflight path never escalates to sudo
-    behind the user's back.
+    behind the user's back.  Goes through
+    :func:`terok_executor.sandbox.ensure_sandbox_ready` so the vault
+    picks up the roster-derived ``routes.json`` on first start — a
+    bare sandbox aggregator call would leave the vault running with
+    no authorization config, which breaks credential fetch on the
+    next agent run.
     """
-    from terok_sandbox.commands import _handle_sandbox_setup
+    from terok_executor.sandbox import ensure_sandbox_ready
 
     try:
-        _handle_sandbox_setup()
+        ensure_sandbox_ready()
     except (SystemExit, Exception) as exc:  # noqa: BLE001
         print(f"  sandbox setup failed: {exc}", file=sys.stderr)
         return False

--- a/src/terok_executor/sandbox.py
+++ b/src/terok_executor/sandbox.py
@@ -1,24 +1,17 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Bring the sandbox layer up to a state an agent container can use.
+"""Compose terok-sandbox install with executor-side route generation.
 
-The sandbox package installs shield / vault / gate / clearance but
-leaves the vault's ``routes.json`` for its consumer to populate —
-routes are generated from terok-executor's agent roster, which
-sandbox (correctly) doesn't know about.  This module ties the two
-halves together so every caller that wants a functional runtime
-reaches for one entry point.
-
-:func:`ensure_sandbox_ready` is the composable hook every frontend
-should call: ``terok-executor setup``, ``terok-executor run`` when
-the preflight needs to self-heal, and — in PR #6 — ``terok setup``
-as it sheds its own inline orchestration.
+Routes come from the YAML agent roster — sandbox (correctly) doesn't
+know about rosters, so the pair that makes a runnable sandbox lives
+here.  One entry point means every frontend that wants a functional
+runtime reaches for the same composition.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from terok_sandbox import SandboxConfig
@@ -26,26 +19,21 @@ if TYPE_CHECKING:
 
 def ensure_sandbox_ready(
     *,
-    root: bool = False,
-    no_shield: bool = False,
-    no_vault: bool = False,
-    no_gate: bool = False,
-    no_clearance: bool = False,
     cfg: SandboxConfig | None = None,
+    no_vault: bool = False,
+    **aggregator_kwargs: Any,
 ) -> None:
     """Generate vault routes, then run the sandbox install aggregator.
 
-    Order matters: the aggregator's vault phase calls ``install_systemd_units``
-    which enables+starts the vault unit; the vault reads ``routes.json``
-    on startup, so the routes file must already exist.  Without the
-    pre-step, the vault starts empty and agents fail to fetch
-    credentials — the operator then has to remember to run
-    ``terok-executor vault routes`` separately.
+    Order matters: the aggregator's vault phase restarts the vault
+    systemd unit, which reads ``routes.json`` at startup.  A bare
+    aggregator call leaves the vault empty of routing config and
+    credential fetch breaks on the next ``terok-executor run`` until
+    the operator remembers to run ``vault routes``.
 
-    The ``no_*`` flags mirror the sandbox aggregator's shape so this
-    helper is a drop-in replacement for a direct ``_handle_sandbox_setup``
-    call in any frontend that's routing vault traffic through the
-    executor's agent roster.
+    ``no_vault`` gates the routes pre-step (if vault isn't being
+    touched, don't regenerate); everything else (``root``, other
+    ``no_*`` flags) flows through to the aggregator.
     """
     from terok_sandbox.commands import _handle_sandbox_setup
 
@@ -53,37 +41,4 @@ def ensure_sandbox_ready(
 
     if not no_vault:
         ensure_vault_routes(cfg=cfg)
-    _handle_sandbox_setup(
-        root=root,
-        no_shield=no_shield,
-        no_vault=no_vault,
-        no_gate=no_gate,
-        no_clearance=no_clearance,
-        cfg=cfg,
-    )
-
-
-def uninstall_sandbox_services(
-    *,
-    root: bool = False,
-    no_shield: bool = False,
-    no_vault: bool = False,
-    no_gate: bool = False,
-    no_clearance: bool = False,
-) -> None:
-    """Tear down the sandbox stack — routes.json is left on disk.
-
-    Operators re-installing after an uninstall keep their roster-
-    derived routes, so the next install doesn't regenerate them from
-    scratch unless the roster itself changed.  Symmetric to
-    :func:`ensure_sandbox_ready` for the ``--no-*`` opt-out flags.
-    """
-    from terok_sandbox.commands import _handle_sandbox_uninstall
-
-    _handle_sandbox_uninstall(
-        root=root,
-        no_shield=no_shield,
-        no_vault=no_vault,
-        no_gate=no_gate,
-        no_clearance=no_clearance,
-    )
+    _handle_sandbox_setup(cfg=cfg, no_vault=no_vault, **aggregator_kwargs)

--- a/src/terok_executor/sandbox.py
+++ b/src/terok_executor/sandbox.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bring the sandbox layer up to a state an agent container can use.
+
+The sandbox package installs shield / vault / gate / clearance but
+leaves the vault's ``routes.json`` for its consumer to populate —
+routes are generated from terok-executor's agent roster, which
+sandbox (correctly) doesn't know about.  This module ties the two
+halves together so every caller that wants a functional runtime
+reaches for one entry point.
+
+:func:`ensure_sandbox_ready` is the composable hook every frontend
+should call: ``terok-executor setup``, ``terok-executor run`` when
+the preflight needs to self-heal, and — in PR #6 — ``terok setup``
+as it sheds its own inline orchestration.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from terok_sandbox import SandboxConfig
+
+
+def ensure_sandbox_ready(
+    *,
+    root: bool = False,
+    no_shield: bool = False,
+    no_vault: bool = False,
+    no_gate: bool = False,
+    no_clearance: bool = False,
+    cfg: SandboxConfig | None = None,
+) -> None:
+    """Generate vault routes, then run the sandbox install aggregator.
+
+    Order matters: the aggregator's vault phase calls ``install_systemd_units``
+    which enables+starts the vault unit; the vault reads ``routes.json``
+    on startup, so the routes file must already exist.  Without the
+    pre-step, the vault starts empty and agents fail to fetch
+    credentials — the operator then has to remember to run
+    ``terok-executor vault routes`` separately.
+
+    The ``no_*`` flags mirror the sandbox aggregator's shape so this
+    helper is a drop-in replacement for a direct ``_handle_sandbox_setup``
+    call in any frontend that's routing vault traffic through the
+    executor's agent roster.
+    """
+    from terok_sandbox.commands import _handle_sandbox_setup
+
+    from terok_executor.roster.loader import ensure_vault_routes
+
+    if not no_vault:
+        ensure_vault_routes(cfg=cfg)
+    _handle_sandbox_setup(
+        root=root,
+        no_shield=no_shield,
+        no_vault=no_vault,
+        no_gate=no_gate,
+        no_clearance=no_clearance,
+        cfg=cfg,
+    )
+
+
+def uninstall_sandbox_services(
+    *,
+    root: bool = False,
+    no_shield: bool = False,
+    no_vault: bool = False,
+    no_gate: bool = False,
+    no_clearance: bool = False,
+) -> None:
+    """Tear down the sandbox stack — routes.json is left on disk.
+
+    Operators re-installing after an uninstall keep their roster-
+    derived routes, so the next install doesn't regenerate them from
+    scratch unless the roster itself changed.  Symmetric to
+    :func:`ensure_sandbox_ready` for the ``--no-*`` opt-out flags.
+    """
+    from terok_sandbox.commands import _handle_sandbox_uninstall
+
+    _handle_sandbox_uninstall(
+        root=root,
+        no_shield=no_shield,
+        no_vault=no_vault,
+        no_gate=no_gate,
+        no_clearance=no_clearance,
+    )

--- a/tach.toml
+++ b/tach.toml
@@ -179,9 +179,8 @@ depends_on = [
 
 # ── Sandbox bootstrap composition ──────────────────────────────────
 
-# Ties the sandbox install aggregator to the executor's route
-# generator so every caller that wants a functional runtime reaches
-# for one entry point.
+# Routes + sandbox aggregator in one call.  Uninstall is pure
+# delegation to the sandbox aggregator and doesn't live here.
 [[modules]]
 path = "terok_executor.sandbox"
 depends_on = [

--- a/tach.toml
+++ b/tach.toml
@@ -177,6 +177,17 @@ depends_on = [
     "terok_executor.roster.loader",
 ]
 
+# ── Sandbox bootstrap composition ──────────────────────────────────
+
+# Ties the sandbox install aggregator to the executor's route
+# generator so every caller that wants a functional runtime reaches
+# for one entry point.
+[[modules]]
+path = "terok_executor.sandbox"
+depends_on = [
+    "terok_executor.roster.loader",
+]
+
 # ── Preflight — prerequisite checks ────────────────────────────────
 
 # Pre-launch checks + interactive fixers for `terok-executor run`
@@ -188,6 +199,7 @@ depends_on = [
     "terok_executor.credentials.vault_config",
     "terok_executor.paths",
     "terok_executor.roster.loader",
+    "terok_executor.sandbox",
 ]
 
 # ── CLI surface ────────────────────────────────────────────────────
@@ -203,6 +215,7 @@ depends_on = [
     "terok_executor.paths",
     "terok_executor.preflight",
     "terok_executor.roster.loader",
+    "terok_executor.sandbox",
 ]
 
 # CLI entry point — wires command registry to argparse
@@ -241,4 +254,5 @@ depends_on = [
     "terok_executor.provider.instructions",
     "terok_executor.provider.providers",
     "terok_executor.roster",
+    "terok_executor.sandbox",
 ]

--- a/tests/unit/test_setup_flow.py
+++ b/tests/unit/test_setup_flow.py
@@ -24,24 +24,24 @@ from terok_executor.commands import (
     _handle_uninstall,
     _preflight_or_exit,
 )
+from terok_executor.sandbox import ensure_sandbox_ready
 
 # ── Fixtures ──────────────────────────────────────────────────────────
 
 
 @pytest.fixture
 def setup_spies():
-    """Replace every phase (sandbox-composition, images) with a MagicMock.
+    """Replace sandbox + image phases with MagicMocks so order is observable.
 
-    ``terok-executor setup`` now reaches sandbox through
-    :func:`terok_executor.sandbox.ensure_sandbox_ready` — a composition
-    helper that generates ``routes.json`` *before* calling the sandbox
-    aggregator.  Tests patch the composition entry point directly;
-    the ``ensure_vault_routes`` + ``_handle_sandbox_setup`` interaction
-    has its own dedicated tests in ``TestEnsureSandboxReady`` below.
+    Setup goes through ``ensure_sandbox_ready`` (the composition helper);
+    uninstall goes direct to ``_handle_sandbox_uninstall`` (nothing extra
+    to compose on teardown — routes.json survives uninstall by design).
+    The ``ensure_vault_routes`` + aggregator interaction has its own
+    ``TestEnsureSandboxReady`` coverage below.
     """
     with (
         patch("terok_executor.sandbox.ensure_sandbox_ready") as sandbox_setup,
-        patch("terok_executor.sandbox.uninstall_sandbox_services") as sandbox_uninstall,
+        patch("terok_sandbox.commands._handle_sandbox_uninstall") as sandbox_uninstall,
         patch("terok_executor.commands._build_images_with_banner") as build_images,
         patch("terok_executor.commands._remove_images") as remove_images,
     ):
@@ -122,90 +122,53 @@ class TestHandleUninstall:
 # ── Sandbox-composition helper ────────────────────────────────────────
 
 
+@pytest.fixture
+def compose_spies():
+    """Patch the two targets ``ensure_sandbox_ready`` composes: routes + aggregator."""
+    with (
+        patch("terok_executor.roster.loader.ensure_vault_routes") as routes,
+        patch("terok_sandbox.commands._handle_sandbox_setup") as aggregator,
+    ):
+        yield routes, aggregator
+
+
 class TestEnsureSandboxReady:
     """``ensure_sandbox_ready`` generates routes before calling the aggregator.
 
-    The invariant is order: routes-first is the reason this helper
-    exists.  A bare ``_handle_sandbox_setup`` call leaves the vault
-    running without ``routes.json``, so the next ``terok-executor run``
-    can't route credential requests to the right provider.
+    Order-first is the whole point of the helper: the vault reads
+    ``routes.json`` on the ``systemctl restart`` the aggregator's
+    vault phase performs, so routes must be on disk beforehand.
     """
 
-    def test_generates_routes_before_sandbox_setup(self) -> None:
-        from terok_executor.sandbox import ensure_sandbox_ready
-
+    def test_generates_routes_before_sandbox_setup(self, compose_spies) -> None:
+        routes, aggregator = compose_spies
         order: list[str] = []
-        with (
-            patch(
-                "terok_executor.roster.loader.ensure_vault_routes",
-                side_effect=lambda cfg: order.append("routes"),
-            ),
-            patch(
-                "terok_sandbox.commands._handle_sandbox_setup",
-                side_effect=lambda **_: order.append("sandbox"),
-            ),
-        ):
-            ensure_sandbox_ready()
+        routes.side_effect = lambda cfg: order.append("routes")
+        aggregator.side_effect = lambda **_: order.append("sandbox")
+        ensure_sandbox_ready()
         assert order == ["routes", "sandbox"]
 
-    def test_threads_root_flag_to_aggregator(self) -> None:
-        from terok_executor.sandbox import ensure_sandbox_ready
-
-        with (
-            patch("terok_executor.roster.loader.ensure_vault_routes"),
-            patch("terok_sandbox.commands._handle_sandbox_setup") as aggregator,
-        ):
-            ensure_sandbox_ready(root=True)
+    def test_threads_root_flag_to_aggregator(self, compose_spies) -> None:
+        _routes, aggregator = compose_spies
+        ensure_sandbox_ready(root=True)
         assert aggregator.call_args.kwargs["root"] is True
 
-    def test_no_vault_skips_route_generation(self) -> None:
+    def test_no_vault_skips_route_generation(self, compose_spies) -> None:
         """``--no-vault`` means the vault unit isn't being touched — skip routes too."""
-        from terok_executor.sandbox import ensure_sandbox_ready
-
-        with (
-            patch("terok_executor.roster.loader.ensure_vault_routes") as routes,
-            patch("terok_sandbox.commands._handle_sandbox_setup") as aggregator,
-        ):
-            ensure_sandbox_ready(no_vault=True)
+        routes, aggregator = compose_spies
+        ensure_sandbox_ready(no_vault=True)
         routes.assert_not_called()
         aggregator.assert_called_once()
         assert aggregator.call_args.kwargs["no_vault"] is True
 
-    def test_opt_out_flags_forwarded_to_aggregator(self) -> None:
+    def test_opt_out_flags_forwarded_to_aggregator(self, compose_spies) -> None:
         """Every ``no_*`` flag passes through so callers can skip specific phases."""
-        from terok_executor.sandbox import ensure_sandbox_ready
-
-        with (
-            patch("terok_executor.roster.loader.ensure_vault_routes"),
-            patch("terok_sandbox.commands._handle_sandbox_setup") as aggregator,
-        ):
-            ensure_sandbox_ready(no_shield=True, no_gate=True, no_clearance=True)
+        _routes, aggregator = compose_spies
+        ensure_sandbox_ready(no_shield=True, no_gate=True, no_clearance=True)
         kwargs = aggregator.call_args.kwargs
         assert kwargs["no_shield"] is True
         assert kwargs["no_gate"] is True
         assert kwargs["no_clearance"] is True
-
-
-class TestUninstallSandboxServices:
-    """Symmetric teardown — no routes cleanup (kept on disk for re-install)."""
-
-    def test_delegates_to_sandbox_uninstall(self) -> None:
-        from terok_executor.sandbox import uninstall_sandbox_services
-
-        with patch("terok_sandbox.commands._handle_sandbox_uninstall") as aggregator:
-            uninstall_sandbox_services(root=True)
-        assert aggregator.call_args.kwargs["root"] is True
-
-    def test_does_not_touch_routes_file(self) -> None:
-        """Routes survive uninstall — re-install picks them up without roster re-read."""
-        from terok_executor.sandbox import uninstall_sandbox_services
-
-        with (
-            patch("terok_executor.roster.loader.ensure_vault_routes") as routes,
-            patch("terok_sandbox.commands._handle_sandbox_uninstall"),
-        ):
-            uninstall_sandbox_services()
-        routes.assert_not_called()
 
 
 # ── Preflight gate ────────────────────────────────────────────────────

--- a/tests/unit/test_setup_flow.py
+++ b/tests/unit/test_setup_flow.py
@@ -30,10 +30,18 @@ from terok_executor.commands import (
 
 @pytest.fixture
 def setup_spies():
-    """Replace every phase (sandbox, images) with a MagicMock so order is observable."""
+    """Replace every phase (sandbox-composition, images) with a MagicMock.
+
+    ``terok-executor setup`` now reaches sandbox through
+    :func:`terok_executor.sandbox.ensure_sandbox_ready` — a composition
+    helper that generates ``routes.json`` *before* calling the sandbox
+    aggregator.  Tests patch the composition entry point directly;
+    the ``ensure_vault_routes`` + ``_handle_sandbox_setup`` interaction
+    has its own dedicated tests in ``TestEnsureSandboxReady`` below.
+    """
     with (
-        patch("terok_sandbox.commands._handle_sandbox_setup") as sandbox_setup,
-        patch("terok_sandbox.commands._handle_sandbox_uninstall") as sandbox_uninstall,
+        patch("terok_executor.sandbox.ensure_sandbox_ready") as sandbox_setup,
+        patch("terok_executor.sandbox.uninstall_sandbox_services") as sandbox_uninstall,
         patch("terok_executor.commands._build_images_with_banner") as build_images,
         patch("terok_executor.commands._remove_images") as remove_images,
     ):
@@ -109,6 +117,95 @@ class TestHandleUninstall:
     def test_root_flag_propagates_to_sandbox_uninstall(self, setup_spies) -> None:
         _handle_uninstall(root=True)
         setup_spies["sandbox_uninstall"].assert_called_once_with(root=True)
+
+
+# ── Sandbox-composition helper ────────────────────────────────────────
+
+
+class TestEnsureSandboxReady:
+    """``ensure_sandbox_ready`` generates routes before calling the aggregator.
+
+    The invariant is order: routes-first is the reason this helper
+    exists.  A bare ``_handle_sandbox_setup`` call leaves the vault
+    running without ``routes.json``, so the next ``terok-executor run``
+    can't route credential requests to the right provider.
+    """
+
+    def test_generates_routes_before_sandbox_setup(self) -> None:
+        from terok_executor.sandbox import ensure_sandbox_ready
+
+        order: list[str] = []
+        with (
+            patch(
+                "terok_executor.roster.loader.ensure_vault_routes",
+                side_effect=lambda cfg: order.append("routes"),
+            ),
+            patch(
+                "terok_sandbox.commands._handle_sandbox_setup",
+                side_effect=lambda **_: order.append("sandbox"),
+            ),
+        ):
+            ensure_sandbox_ready()
+        assert order == ["routes", "sandbox"]
+
+    def test_threads_root_flag_to_aggregator(self) -> None:
+        from terok_executor.sandbox import ensure_sandbox_ready
+
+        with (
+            patch("terok_executor.roster.loader.ensure_vault_routes"),
+            patch("terok_sandbox.commands._handle_sandbox_setup") as aggregator,
+        ):
+            ensure_sandbox_ready(root=True)
+        assert aggregator.call_args.kwargs["root"] is True
+
+    def test_no_vault_skips_route_generation(self) -> None:
+        """``--no-vault`` means the vault unit isn't being touched — skip routes too."""
+        from terok_executor.sandbox import ensure_sandbox_ready
+
+        with (
+            patch("terok_executor.roster.loader.ensure_vault_routes") as routes,
+            patch("terok_sandbox.commands._handle_sandbox_setup") as aggregator,
+        ):
+            ensure_sandbox_ready(no_vault=True)
+        routes.assert_not_called()
+        aggregator.assert_called_once()
+        assert aggregator.call_args.kwargs["no_vault"] is True
+
+    def test_opt_out_flags_forwarded_to_aggregator(self) -> None:
+        """Every ``no_*`` flag passes through so callers can skip specific phases."""
+        from terok_executor.sandbox import ensure_sandbox_ready
+
+        with (
+            patch("terok_executor.roster.loader.ensure_vault_routes"),
+            patch("terok_sandbox.commands._handle_sandbox_setup") as aggregator,
+        ):
+            ensure_sandbox_ready(no_shield=True, no_gate=True, no_clearance=True)
+        kwargs = aggregator.call_args.kwargs
+        assert kwargs["no_shield"] is True
+        assert kwargs["no_gate"] is True
+        assert kwargs["no_clearance"] is True
+
+
+class TestUninstallSandboxServices:
+    """Symmetric teardown — no routes cleanup (kept on disk for re-install)."""
+
+    def test_delegates_to_sandbox_uninstall(self) -> None:
+        from terok_executor.sandbox import uninstall_sandbox_services
+
+        with patch("terok_sandbox.commands._handle_sandbox_uninstall") as aggregator:
+            uninstall_sandbox_services(root=True)
+        assert aggregator.call_args.kwargs["root"] is True
+
+    def test_does_not_touch_routes_file(self) -> None:
+        """Routes survive uninstall — re-install picks them up without roster re-read."""
+        from terok_executor.sandbox import uninstall_sandbox_services
+
+        with (
+            patch("terok_executor.roster.loader.ensure_vault_routes") as routes,
+            patch("terok_sandbox.commands._handle_sandbox_uninstall"),
+        ):
+            uninstall_sandbox_services()
+        routes.assert_not_called()
 
 
 # ── Preflight gate ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

New ``terok_executor.sandbox`` module exposes ``ensure_sandbox_ready`` and ``uninstall_sandbox_services`` — the composable hooks every frontend that wants a functional runtime should call.

**Fixes a known gap**: ``terok-executor setup`` previously called the sandbox aggregator bare, leaving the vault running without ``routes.json`` on startup.  The operator then had to remember to run ``terok-executor vault routes`` separately before credentials worked.  The new helper generates routes first, then invokes the aggregator — the vault picks up its routing config on the same ``systemctl --user restart`` the aggregator already does.

## Why this composition level

Sandbox (correctly) doesn't know about the agent roster — roster is executor's own YAML.  Keeping routes-generation in executor and wrapping the aggregator here is the natural split: one module per layer-of-responsibility.  Terok (PR #6) will compose through ``ensure_sandbox_ready`` too, so it never reaches directly into sandbox.

## Sites updated

- ``_handle_setup`` → calls ``ensure_sandbox_ready`` instead of the bare aggregator
- ``_handle_uninstall`` → mirrors with ``uninstall_sandbox_services``.  ``routes.json`` stays on disk through uninstall so a re-install picks up the existing roster-derived config without regenerating
- ``_fix_sandbox_services`` (the self-healing path inside ``terok-executor run``'s preflight) — same fix; a missing-services recovery will now also generate routes

## Public API

- ``ensure_sandbox_ready`` — route-gen + sandbox aggregator with ``root`` + ``no_shield``/``no_vault``/``no_gate``/``no_clearance`` knobs.
- ``uninstall_sandbox_services`` — symmetric teardown.

Both re-exported from ``terok_executor.__init__`` and declared in ``__all__``.

## Cross-repo arc

1. ✅ terok-ai/terok-shield#261 — firewall-binaries probe
2. ✅ terok-ai/terok-clearance#67 — ContainerInspector protocol + notifier migration
3. ✅ terok-ai/terok-sandbox#201 — ``create_container_inspector`` factory
4. ✅ terok-ai/terok-sandbox#207 — master aggregator
5. **This PR**
6. Upcoming: terok — annotation writer + full ``setup.py`` collapse (delegates through ``ensure_sandbox_ready`` + adds desktop entry)

## Test plan

- [x] ``make lint`` + ``make tach`` — clean
- [x] ``make test-unit`` — 683 passed.  ``test_setup_flow.py`` reworked to patch the new composition helpers + two new classes (``TestEnsureSandboxReady`` covering routes-before-aggregator order, root-flag forwarding, per-phase opt-outs, ``no_vault`` skips routes; ``TestUninstallSandboxServices`` covering teardown without touching routes)
- [x] ``make reuse`` — compliant
- [x] ``make docstrings``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized sandbox service setup and teardown into composable functions available as part of the public API, ensuring proper initialization of vault routing configuration during setup.

* **Tests**
  * Updated tests to validate sandbox service initialization and teardown flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->