### PR TITLE
feat(run): script-readable exit codes for setup-needed (3) / downgrade (4)

### DIFF
--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -49,6 +49,102 @@ class CommandDef:
 # ── Handlers ──
 
 
+def _setup_verdict_or_exit(*, skip: bool) -> None:
+    """Cheap stamp-based gate that runs before live preflight.
+
+    Reads :func:`terok_sandbox.needs_setup` and bounces the user with
+    a structured exit code when the install is missing or stale:
+
+    - ``OK`` → return; live preflight proceeds.
+    - ``FIRST_RUN`` / ``STALE_AFTER_UPDATE`` / ``STAMP_CORRUPT`` →
+      ``raise SystemExit(3)`` after printing a one-line fix hint
+      that points the user at ``terok-executor setup``.
+    - ``STALE_AFTER_DOWNGRADE`` → ``raise SystemExit(4)`` after a
+      multi-line warning naming the downgraded package(s).
+      Downgrades aren't tested; refuse rather than risk inconsistent
+      state from older code reading newer schemas.
+
+    The ``skip`` flag ( ``--no-preflight``) waives this gate too —
+    the user's escape hatch is one knob, not two.  Sub-millisecond
+    cost on the OK path so wiring it in front of live preflight
+    doesn't change perceived startup latency.
+    """
+    if skip:
+        return
+
+    import sys
+
+    from terok_sandbox import SetupVerdict, needs_setup
+    from terok_sandbox.setup_stamp import _installed_versions, _read_stamp, stamp_path
+
+    verdict = needs_setup()
+    if verdict is SetupVerdict.OK:
+        return
+
+    if verdict is SetupVerdict.STALE_AFTER_DOWNGRADE:
+        downgraded = _name_downgraded_packages(stamp_path(), _read_stamp, _installed_versions)
+        names = ", ".join(downgraded) or "one or more packages"
+        print(
+            f"terok-executor: refusing to run — downgrade detected ({names}).\n"
+            "  Downgrades aren't supported; older code may not read newer state correctly.\n"
+            "  Either upgrade back to the stamped version, or "
+            "remove the stamp at your own risk:\n"
+            f"    rm {stamp_path()}",
+            file=sys.stderr,
+        )
+        raise SystemExit(4)
+
+    # FIRST_RUN, STALE_AFTER_UPDATE, STAMP_CORRUPT all collapse to "run setup".
+    nudge = {
+        SetupVerdict.FIRST_RUN: "no setup stamp found — terok-executor hasn't been initialised",
+        SetupVerdict.STALE_AFTER_UPDATE: (
+            "package versions changed since the last setup — re-run to apply"
+        ),
+        SetupVerdict.STAMP_CORRUPT: "setup stamp is unreadable — re-run setup to refresh it",
+    }[verdict]
+    print(
+        f"terok-executor: {nudge}.\n"
+        "  Fix:    terok-executor setup\n"
+        "  Or:     terok-executor run --no-preflight ...   (skip the gate)",
+        file=sys.stderr,
+    )
+    raise SystemExit(3)
+
+
+def _name_downgraded_packages(
+    path: Path,
+    read_stamp_fn: Callable[[Path], dict[str, str]],
+    installed_fn: Callable[[], dict[str, str]],
+) -> list[str]:
+    """Return ``[pkg]`` whose installed version is < stamped, or missing entirely.
+
+    Best-effort: if the stamp can't be re-read (race with a parallel
+    setup overwrite) we return an empty list so the caller falls back
+    to a generic "downgrade detected" message instead of crashing.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        stamped = read_stamp_fn(path)
+    except Exception:  # noqa: BLE001 — diagnostic helper, never the source of truth
+        return []
+    installed = installed_fn()
+
+    out: list[str] = []
+    for pkg, stamp_ver in stamped.items():
+        if pkg not in installed:
+            out.append(f"{pkg} (uninstalled)")
+            continue
+        cur = installed[pkg]
+        try:
+            if Version(cur) < Version(stamp_ver):
+                out.append(f"{pkg} {stamp_ver} → {cur}")
+        except InvalidVersion:
+            if cur < stamp_ver:
+                out.append(f"{pkg} {stamp_ver} → {cur}")
+    return out
+
+
 def _preflight_or_exit(
     provider: str,
     *,
@@ -138,11 +234,13 @@ def _handle_run(
     no_preflight: bool = False,
 ) -> None:
     """Run an agent in a hardened container."""
-
+    _setup_verdict_or_exit(skip=no_preflight)
     if not _preflight_or_exit(
         agent, base=base, family=family, assume_yes=yes, skip_preflight=no_preflight
     ):
-        raise SystemExit(1)
+        # Preflight failure = setup-needed signal for the script-friendly
+        # exit-code contract (3 = run setup; 1 stays for task-level failure).
+        raise SystemExit(3)
 
     from .container.runner import AgentRunner
 
@@ -216,10 +314,11 @@ def _handle_run_tool(
     no_preflight: bool = False,
 ) -> None:
     """Run a tool in a sidecar container."""
+    _setup_verdict_or_exit(skip=no_preflight)
     if not _preflight_or_exit(
         tool, base=base, family=family, assume_yes=yes, skip_preflight=no_preflight
     ):
-        raise SystemExit(1)
+        raise SystemExit(3)
 
     from .container.runner import AgentRunner
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -109,6 +109,7 @@ class TestSharedDirArgs:
         from terok_executor.commands import _handle_run
 
         with (
+            patch("terok_executor.commands._setup_verdict_or_exit"),
             patch("terok_executor.commands._preflight_or_exit", return_value=True),
             patch("terok_executor.container.runner.AgentRunner") as mock_cls,
         ):
@@ -130,6 +131,7 @@ class TestSharedDirArgs:
         from terok_executor.commands import _handle_run
 
         with (
+            patch("terok_executor.commands._setup_verdict_or_exit"),
             patch("terok_executor.commands._preflight_or_exit", return_value=True),
             patch("terok_executor.container.runner.AgentRunner") as mock_cls,
         ):

--- a/tests/unit/test_setup_verdict_gate.py
+++ b/tests/unit/test_setup_verdict_gate.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cheap stamp-based gate that runs before live preflight on ``run`` / ``run-tool``.
+
+Pins the script-readable exit-code contract from epic terok-ai/terok#685
+phase 4: ``3 = setup needed`` for FIRST_RUN / STALE_AFTER_UPDATE /
+STAMP_CORRUPT, ``4 = downgrade detected`` for STALE_AFTER_DOWNGRADE,
+no exit on OK.  ``--no-preflight`` waives the gate as a single escape
+hatch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from terok_sandbox import SetupVerdict
+
+from terok_executor.commands import _setup_verdict_or_exit
+
+# ── Verdict → exit-code mapping ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("verdict", "expected_code", "expected_fragment"),
+    [
+        pytest.param(
+            SetupVerdict.FIRST_RUN,
+            3,
+            "no setup stamp found",
+            id="first-run-exits-3",
+        ),
+        pytest.param(
+            SetupVerdict.STALE_AFTER_UPDATE,
+            3,
+            "package versions changed",
+            id="stale-after-update-exits-3",
+        ),
+        pytest.param(
+            SetupVerdict.STAMP_CORRUPT,
+            3,
+            "stamp is unreadable",
+            id="stamp-corrupt-exits-3",
+        ),
+    ],
+)
+def test_setup_needed_verdicts_all_exit_three(
+    verdict: SetupVerdict,
+    expected_code: int,
+    expected_fragment: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The three "setup needed" verdicts collapse to exit 3 with a fix hint."""
+    with patch("terok_sandbox.needs_setup", return_value=verdict):
+        with pytest.raises(SystemExit) as excinfo:
+            _setup_verdict_or_exit(skip=False)
+    assert excinfo.value.code == expected_code
+    err = capsys.readouterr().err
+    assert expected_fragment in err
+    # Every "setup needed" path points at the canonical fix.
+    assert "terok-executor setup" in err
+
+
+def test_downgrade_exits_four_with_named_packages(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """STALE_AFTER_DOWNGRADE refuses with exit 4, names the offending packages."""
+    with (
+        patch("terok_sandbox.needs_setup", return_value=SetupVerdict.STALE_AFTER_DOWNGRADE),
+        patch(
+            "terok_executor.commands._name_downgraded_packages",
+            return_value=["terok-sandbox 0.0.97 → 0.0.95"],
+        ),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            _setup_verdict_or_exit(skip=False)
+    assert excinfo.value.code == 4
+    err = capsys.readouterr().err
+    assert "downgrade detected" in err
+    assert "terok-sandbox 0.0.97 → 0.0.95" in err
+    # Downgrade message points at the deliberate override path, not the easy fix.
+    assert "rm" in err and "stamp" in err
+
+
+def test_downgrade_falls_back_to_generic_when_diff_unavailable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When the stamp can't be re-read for diffing, surface a generic refusal — never crash."""
+    with (
+        patch("terok_sandbox.needs_setup", return_value=SetupVerdict.STALE_AFTER_DOWNGRADE),
+        patch("terok_executor.commands._name_downgraded_packages", return_value=[]),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            _setup_verdict_or_exit(skip=False)
+    assert excinfo.value.code == 4
+    assert "one or more packages" in capsys.readouterr().err
+
+
+def test_ok_verdict_returns_silently() -> None:
+    """OK is the happy path — no print, no exit, control flows back to preflight."""
+    with patch("terok_sandbox.needs_setup", return_value=SetupVerdict.OK):
+        # No SystemExit raised; helper returns None.
+        assert _setup_verdict_or_exit(skip=False) is None
+
+
+# ── Escape hatch ──────────────────────────────────────────────────────
+
+
+def test_skip_bypasses_gate_without_calling_needs_setup() -> None:
+    """``--no-preflight`` waives the gate too — same knob, same scope.
+
+    The user's escape hatch is one flag, not two.  Crucially we don't
+    even call ``needs_setup`` when skipping — pinning that no I/O
+    happens on the bypass path.
+    """
+    with patch("terok_sandbox.needs_setup") as mock_needs_setup:
+        assert _setup_verdict_or_exit(skip=True) is None
+        mock_needs_setup.assert_not_called()
+
+
+# ── _name_downgraded_packages helper ──────────────────────────────────
+
+
+def test_name_downgraded_packages_lists_each_offender(tmp_path) -> None:
+    """Helper compares stamped vs installed and names every package that regressed."""
+    from terok_executor.commands import _name_downgraded_packages
+
+    stamp = tmp_path / "setup.stamp"
+
+    def fake_read(_path):
+        return {"terok-sandbox": "0.0.97", "terok-executor": "0.0.115", "terok-shield": "0.6.31"}
+
+    def fake_installed():
+        # sandbox went backwards, executor stayed put, shield disappeared entirely.
+        return {"terok-sandbox": "0.0.95", "terok-executor": "0.0.115"}
+
+    out = _name_downgraded_packages(stamp, fake_read, fake_installed)
+    assert "terok-sandbox 0.0.97 → 0.0.95" in out
+    assert "terok-shield (uninstalled)" in out
+    # Equal versions don't get listed.
+    assert not any("terok-executor" in entry for entry in out)
+
+
+def test_name_downgraded_packages_swallows_read_error(tmp_path) -> None:
+    """A racing setup overwriting the stamp can't crash the diagnostic helper."""
+    from terok_executor.commands import _name_downgraded_packages
+
+    def boom(_path):
+        raise RuntimeError("stamp went away mid-diff")
+
+    out = _name_downgraded_packages(tmp_path / "x", boom, lambda: {})
+    assert out == []


### PR DESCRIPTION
## Summary

Phase 4 of [epic terok-ai/terok#685](https://github.com/terok-ai/terok/issues/685). Adds a stamp-based gate in front of live preflight on ``run`` / ``run-tool`` so scripts can distinguish "go run setup" from a real task failure without grepping human-readable output.

## Exit-code contract

| Code | Meaning |
|---|---|
| 0 | success |
| 1 | task-level failure (e.g. AgentRunner crash) |
| 2 | argparse / generic CLI error |
| **3** | **setup needed** ← NEW |
| **4** | **downgrade detected, refuses** ← NEW |

## Verdict routing

```python
verdict = needs_setup()  # from terok_sandbox (the stamp primitive shipped in PR #206)
match verdict:
    case OK:                       return                # live preflight runs
    case FIRST_RUN | STALE_AFTER_UPDATE | STAMP_CORRUPT:
        print("Fix: terok-executor setup"); raise SystemExit(3)
    case STALE_AFTER_DOWNGRADE:
        print("downgrade detected (terok-sandbox 0.0.97 → 0.0.95)\n  rm <stamp> at your own risk")
        raise SystemExit(4)
```

Downgrades aren't tested; the refusal is the policy in the epic. Message names the offending packages so the user knows whether to upgrade back or override.

## Live-preflight exit-code follow-on

Mandatory live-preflight failures (podman missing, sandbox services down, images absent) now also exit **3** instead of generic 1 — by the contract those are setup-fixable preconditions. Per-check ``--fix-X`` granularity (epic phase 3b) is still pending and will flow through once ``CheckResult.suggest`` ships; today's hint just points at the umbrella ``terok-executor setup`` command.

## Single escape hatch

``--no-preflight`` waives both the cheap gate and the live preflight. No new flag, no new mental model — same scope.

## Cost

Sub-millisecond on the OK path (one ``Path.is_file``, one JSON decode, ~5 ``importlib.metadata.version`` lookups). Doesn't move perceived startup latency.

## Test plan

- [x] `tests/unit/test_setup_verdict_gate.py` — 9 new tests:
  - All 3 "setup needed" verdicts → exit 3 + canonical fix hint (parametrised)
  - Downgrade → exit 4, named packages in stderr, points at ``rm <stamp>``
  - Downgrade with unavailable diff → graceful generic message, still exit 4
  - OK → silent return, no exit
  - ``--no-preflight`` skips the gate entirely (and doesn't even call ``needs_setup``)
  - ``_name_downgraded_packages`` helper: lists each offender, swallows read errors
- [x] Updated 2 existing CLI tests to mock the new gate alongside the existing preflight mock
- [x] `make check` — 690 tests pass; lint, format, tach, docstrings (99.4%), reuse all clean

## Follow-ups in epic #685

- Phase 3b: structured `CheckResult.suggest` so the fix hint becomes per-check (`--fix-kvm`, `--fix-images`) instead of the umbrella ``setup``
- Phase 5/6: same exit-code treatment on the terok-side (`terok task start`)
- Phase 7: TUI consumes `needs_setup()` on startup — first-run modal / stale banner / downgrade warning
- Phase 8: command-palette "Terok: Run setup"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Execution commands now perform setup verification before running.
  * Standardized exit codes: preflight failures now return code 3 (setup needed) instead of 1.
  * Enhanced error messaging for setup, corruption, and downgrade scenarios with actionable guidance.
  * The `--no-preflight` flag now bypasses setup verification.

* **Tests**
  * Added comprehensive unit tests for setup verification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->