### PR TITLE
feat(auth): per-provider OAuth mount dispatch; Codex expose path

### DIFF
--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -520,6 +520,19 @@ def _codex_oauth_mount_writer(
         )
 
 
+#: Static far-future timestamp for the phantom ``auth.json``'s
+#: ``last_refresh`` field.  Codex's CLI fires a client-side token
+#: refresh against the hardcoded ``auth.openai.com`` whenever
+#: ``now - last_refresh > 8 days`` (manager.rs:1743).  Those attempts
+#: would arrive at the upstream with the phantom refresh token and come
+#: back as ``refresh_token_invalidated``, prompting the user to re-login
+#: even though vault-side refresh keeps the real credential fresh.
+#: Pinning ``last_refresh`` to year 9999 keeps the check permanently
+#: satisfied — the same trick Claude's phantom file uses with its
+#: ``"expiresAt": null`` sentinel.
+_CODEX_PHANTOM_LAST_REFRESH = "9999-01-01T00:00:00Z"
+
+
 def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
     """Write a phantom ``auth.json`` preserving public id_token claims only.
 
@@ -528,14 +541,10 @@ def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
     decodes it to read workspace/plan claims but never verifies the
     signature, so the real id_token rides into the container unchanged.
     The access/refresh tokens are the bearer secrets; both are replaced
-    with the vault's phantom marker.
-
-    ``last_refresh`` is stamped at capture time so the CLI's 8-day
-    staleness check doesn't fire an in-container refresh attempt until
-    at least eight days after the user runs ``terok auth codex``.
+    with the vault's phantom marker — inference rides through the vault,
+    which substitutes the live access token.
     """
     import json
-    from datetime import UTC, datetime
 
     tokens: dict = {
         "id_token": cred_data.get("id_token", ""),
@@ -549,7 +558,7 @@ def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
     payload = {
         "OPENAI_API_KEY": None,
         "tokens": tokens,
-        "last_refresh": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "last_refresh": _CODEX_PHANTOM_LAST_REFRESH,
     }
     dest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -384,8 +385,12 @@ def _capture_credentials(
                 print(f"  {f}")
         return
 
-    is_claude_oauth = provider_name == "claude" and cred_data.get("type") == "oauth"
-    exposed_directly = expose_token and is_claude_oauth
+    is_oauth = cred_data.get("type") == "oauth"
+    post_capture = _OAUTH_MOUNT_WRITERS.get(provider_name) if is_oauth else None
+    # Tier 3 bypass: the host-side vault never refreshes the token, so the
+    # container must own its lifecycle.  Storing in the DB would let the
+    # background refresher rotate a token nobody brokers back to the mount.
+    exposed_directly = expose_token and post_capture is not None
 
     if exposed_directly:
         print(f"\nCredentials for {provider_name} bypassing vault DB (exposed directly)")
@@ -412,33 +417,17 @@ def _capture_credentials(
             )
             return
 
-    # Write .credentials.json — real token (tier 3) or phantom marker (default)
-    if is_claude_oauth:
+    # Reconcile the shared mount with the captured credential.  Provider-specific
+    # writers drop a phantom marker (proxied mode) or copy the real file (exposed).
+    if post_capture is not None:
         if mounts_base is None:
             from terok_executor.paths import mounts_dir
 
             mounts_base = mounts_dir()
         try:
-            if expose_token:
-                _copy_real_credentials(auth_dir, mounts_base)
-                print("Real .credentials.json copied to shared Claude config mount.")
-            else:
-                _write_claude_credentials_file(cred_data, mounts_base)
-                print("Subscription metadata written to shared Claude config mount.")
+            post_capture(auth_dir, mounts_base, cred_data, expose_token)
         except Exception as exc:  # noqa: BLE001
-            print(f"Warning: could not write .credentials.json: {exc}")
-        if expose_token:
-            print(
-                "\nNote: Claude OAuth token is EXPOSED in the shared mount."
-                "\n      Every task container can read the real token."
-                "\n      The vault does NOT protect it."
-            )
-        else:
-            print(
-                "\nNote: Claude OAuth credential is shared across all task containers."
-                "\n      API calls are routed through the vault — the real"
-                "\n      token stays on the host."
-            )
+            print(f"Warning: could not reconcile {provider_name} mount: {exc}")
 
     # Apply declarative post-capture state from roster YAML
     if auth_provider and auth_provider.post_capture_state:
@@ -455,18 +444,80 @@ def _capture_credentials(
             )
 
 
-def _copy_real_credentials(auth_dir: Path, mounts_base: Path) -> None:
-    """Copy the real ``.credentials.json`` from the auth dir to the shared mount.
+def _claude_oauth_mount_writer(
+    auth_dir: Path, mounts_base: Path, cred_data: dict, expose_token: bool
+) -> None:
+    """Reconcile Claude's shared mount after an OAuth capture.
 
-    Used by tier 3 (``expose_oauth_token``) — the container needs the actual
-    OAuth token for direct API calls to ``api.anthropic.com``.
+    Default path writes a phantom ``.credentials.json`` with subscription
+    metadata only; tier 3 copies the real credential file so Claude Code
+    can reach ``api.anthropic.com`` directly (its hardcoded OAuth host).
     """
-    src = auth_dir / ".credentials.json"
-    if not src.is_file():
-        raise FileNotFoundError(f"No .credentials.json in {auth_dir}")
-    dest_dir = mounts_base / "_claude-config"
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(src, dest_dir / ".credentials.json")
+    if expose_token:
+        src = auth_dir / ".credentials.json"
+        if not src.is_file():
+            raise FileNotFoundError(f"No .credentials.json in {auth_dir}")
+        dest_dir = mounts_base / "_claude-config"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest_dir / ".credentials.json")
+        print("Real .credentials.json copied to shared Claude config mount.")
+        print(
+            "\nNote: Claude OAuth token is EXPOSED in the shared mount."
+            "\n      Every task container can read the real token."
+            "\n      The vault does NOT protect it."
+        )
+    else:
+        _write_claude_credentials_file(cred_data, mounts_base)
+        print("Subscription metadata written to shared Claude config mount.")
+        print(
+            "\nNote: Claude OAuth credential is shared across all task containers."
+            "\n      API calls are routed through the vault — the real"
+            "\n      token stays on the host."
+        )
+
+
+def _codex_oauth_mount_writer(
+    auth_dir: Path, mounts_base: Path, cred_data: dict, expose_token: bool
+) -> None:
+    """Reconcile Codex's shared mount after an OAuth capture.
+
+    Only the expose path is wired in Phase 1: the real ``auth.json`` is
+    copied into the shared mount so the in-container Codex CLI reads the
+    live token.  The non-expose path wipes any prior copy — Phase 3 will
+    add a proxied variant that restores a phantom marker.
+    """
+    del cred_data
+    dest_dir = mounts_base / "_codex-config"
+    dest_file = dest_dir / "auth.json"
+    if expose_token:
+        src = auth_dir / "auth.json"
+        if not src.is_file():
+            raise FileNotFoundError(f"No auth.json in {auth_dir}")
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest_file)
+        print("Real auth.json copied to shared Codex config mount.")
+        print(
+            "\nNote: Codex OAuth token is EXPOSED in the shared mount."
+            "\n      Every task container can read the real token."
+            "\n      The vault does NOT protect it."
+        )
+    else:
+        dest_file.unlink(missing_ok=True)
+        print(
+            "\nNote: Codex OAuth token was captured to the vault DB but is"
+            "\n      NOT reachable from task containers — no proxy route"
+            "\n      is wired yet.  Set agent.codex.expose_oauth_token to"
+            "\n      mount the real token (unsafe, experimental)."
+        )
+
+
+#: Maps provider name → post-capture mount reconciler.  OAuth-capable
+#: providers register here to share the expose/proxy dispatch in
+#: :func:`_capture_credentials`.
+_OAUTH_MOUNT_WRITERS: dict[str, Callable[[Path, Path, dict, bool], None]] = {
+    "claude": _claude_oauth_mount_writer,
+    "codex": _codex_oauth_mount_writer,
+}
 
 
 def _write_claude_credentials_file(cred_data: dict, mounts_base: Path) -> None:

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -481,19 +481,27 @@ def _codex_oauth_mount_writer(
 ) -> None:
     """Reconcile Codex's shared mount after an OAuth capture.
 
-    Only the expose path is wired in Phase 1: the real ``auth.json`` is
-    copied into the shared mount so the in-container Codex CLI reads the
-    live token.  The non-expose path wipes any prior copy — Phase 3 will
-    add a proxied variant that restores a phantom marker.
+    Two modes:
+
+    - **Exposed** (``expose_token=True``): copy the real ``auth.json``
+      verbatim so the in-container Codex reads the live OAuth token
+      (tier 3, unsafe — every task container can read it).
+    - **Default**: drop a phantom ``auth.json`` — the real ``id_token``
+      JWT (for plan-tier + workspace UI, public claims only) and
+      ``account_id`` survive, but ``access_token`` and ``refresh_token``
+      are replaced with :data:`PHANTOM_CREDENTIALS_MARKER`.  The vault
+      translates the marker back to the real token on inference
+      requests; the CLI itself never sees the live bearer.  This is the
+      fallback for tier 2 (proxied) and also a no-harm default for
+      tier 1 (vault stores creds but nothing wires the proxy yet).
     """
-    del cred_data
     dest_dir = mounts_base / "_codex-config"
     dest_file = dest_dir / "auth.json"
+    dest_dir.mkdir(parents=True, exist_ok=True)
     if expose_token:
         src = auth_dir / "auth.json"
         if not src.is_file():
             raise FileNotFoundError(f"No auth.json in {auth_dir}")
-        dest_dir.mkdir(parents=True, exist_ok=True)
         shutil.copy2(src, dest_file)
         print("Real auth.json copied to shared Codex config mount.")
         print(
@@ -502,13 +510,48 @@ def _codex_oauth_mount_writer(
             "\n      The vault does NOT protect it."
         )
     else:
-        dest_file.unlink(missing_ok=True)
+        _write_codex_phantom_auth_json(cred_data, dest_file)
+        print("Phantom auth.json written to shared Codex config mount.")
         print(
-            "\nNote: Codex OAuth token was captured to the vault DB but is"
-            "\n      NOT reachable from task containers — no proxy route"
-            "\n      is wired yet.  Set agent.codex.expose_oauth_token to"
-            "\n      mount the real token (unsafe, experimental)."
+            "\nNote: Codex OAuth credential is shared across all task containers."
+            "\n      API calls are routed through the vault — the real"
+            "\n      access/refresh tokens stay on the host.  Enable"
+            "\n      agent.codex.allow_oauth to wire the proxy routing."
         )
+
+
+def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
+    """Write a phantom ``auth.json`` preserving public id_token claims only.
+
+    Codex's ``TokenData`` serde contract (codex-rs/login/src/token_data.rs)
+    requires ``id_token`` to be a parseable JWT string — the CLI base64-
+    decodes it to read workspace/plan claims but never verifies the
+    signature, so the real id_token rides into the container unchanged.
+    The access/refresh tokens are the bearer secrets; both are replaced
+    with the vault's phantom marker.
+
+    ``last_refresh`` is stamped at capture time so the CLI's 8-day
+    staleness check doesn't fire an in-container refresh attempt until
+    at least eight days after the user runs ``terok auth codex``.
+    """
+    import json
+    from datetime import UTC, datetime
+
+    tokens: dict = {
+        "id_token": cred_data.get("id_token", ""),
+        "access_token": PHANTOM_CREDENTIALS_MARKER,
+        "refresh_token": PHANTOM_CREDENTIALS_MARKER,
+    }
+    account_id = cred_data.get("account_id")
+    if account_id:
+        tokens["account_id"] = account_id
+
+    payload = {
+        "OPENAI_API_KEY": None,
+        "tokens": tokens,
+        "last_refresh": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+    dest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
 #: Maps provider name → post-capture mount reconciler.  OAuth-capable

--- a/src/terok_executor/credentials/extractors.py
+++ b/src/terok_executor/credentials/extractors.py
@@ -75,7 +75,13 @@ def extract_claude_oauth(base_dir: Path) -> dict:
 
 
 def extract_codex_oauth(base_dir: Path) -> dict:
-    """Extract Codex (OpenAI) OAuth tokens from ``auth.json``."""
+    """Extract Codex (OpenAI) OAuth tokens from ``auth.json``.
+
+    Also preserves the ``id_token`` JWT and ``account_id`` when present —
+    the phantom auth.json the proxied tier writes into task containers
+    needs to carry the real id_token so Codex's plan-tier and workspace
+    UI keeps working without leaking the access/refresh tokens.
+    """
     cred_file = base_dir / "auth.json"
     data = _try_read_json(cred_file)
     if data is None:
@@ -86,11 +92,16 @@ def extract_codex_oauth(base_dir: Path) -> dict:
     if not access_token:
         raise ValueError("Codex credential file has no access_token")
 
-    return {
+    cred: dict = {
         "type": "oauth",
         "access_token": access_token,
         "refresh_token": tokens.get("refresh_token", ""),
     }
+    for optional in ("id_token", "account_id"):
+        value = tokens.get(optional)
+        if value:
+            cred[optional] = value
+    return cred
 
 
 def extract_api_key_env(base_dir: Path, filename: str = ".env", var_name: str = "") -> dict:

--- a/src/terok_executor/resources/agents/codex.yaml
+++ b/src/terok_executor/resources/agents/codex.yaml
@@ -35,6 +35,14 @@ vault:
   phantom_env:
     OPENAI_API_KEY: true
   base_url_env: OPENAI_BASE_URL
+  # OAuth refresh -- endpoint, client_id, and grant shape extracted from the
+  # Codex CLI source (codex-rs/login/src/auth/manager.rs v0.123.0).  The CLI
+  # itself can be redirected at its own refresh attempts via the
+  # CODEX_REFRESH_TOKEN_URL_OVERRIDE env var, but vault-side refresh is what
+  # actually keeps the stored credential fresh across task containers.
+  oauth_refresh:
+    token_url: https://auth.openai.com/oauth/token
+    client_id: app_EMoamEEZ73f0CkXaXp7hrann
 
 auth:
   host_dir: _codex-config

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -13,7 +13,8 @@ from terok_executor.credentials.auth import (
     PHANTOM_CREDENTIALS_MARKER,
     _apply_post_capture_state,
     _capture_credentials,
-    _copy_real_credentials,
+    _claude_oauth_mount_writer,
+    _codex_oauth_mount_writer,
     _write_claude_credentials_file,
     store_api_key,
 )
@@ -405,8 +406,8 @@ class TestCaptureWritesCredentialsFile:
 
         assert not (mounts / "_claude-config" / ".credentials.json").exists()
 
-    def test_capture_non_claude_skips_credentials_file(self, tmp_path: Path) -> None:
-        """Non-Claude providers don't write .credentials.json even with OAuth."""
+    def test_capture_codex_default_leaves_mount_empty(self, tmp_path: Path) -> None:
+        """Codex OAuth capture without expose wipes the shared mount copy."""
         (tmp_path / "auth.json").write_text(
             json.dumps({"tokens": {"access_token": "sk-oai", "refresh_token": "rt"}})
         )
@@ -418,31 +419,74 @@ class TestCaptureWritesCredentialsFile:
             _capture_credentials("codex", tmp_path, "default", mounts_base=mounts)
 
         assert not (mounts / "_claude-config").exists()
+        assert not (mounts / "_codex-config" / "auth.json").exists()
 
 
-class TestCopyRealCredentials:
-    """Verify _copy_real_credentials preserves the real token file."""
+class TestClaudeOAuthMountWriter:
+    """Verify the Claude mount reconciler preserves or phantomises creds."""
 
-    def test_copies_real_file(self, tmp_path: Path) -> None:
-        """Real .credentials.json is copied verbatim to the shared mount."""
+    def test_expose_copies_real_file(self, tmp_path: Path) -> None:
+        """Real .credentials.json is copied verbatim when exposed."""
         auth_dir = tmp_path / "auth"
         auth_dir.mkdir()
         real_creds = {"claudeAiOauth": {"accessToken": "real-token-abc"}}
         (auth_dir / ".credentials.json").write_text(json.dumps(real_creds))
 
         mounts = tmp_path / "mounts"
-        _copy_real_credentials(auth_dir, mounts)
+        _claude_oauth_mount_writer(auth_dir, mounts, real_creds, expose_token=True)
 
         dest = mounts / "_claude-config" / ".credentials.json"
         assert dest.is_file()
         assert json.loads(dest.read_text()) == real_creds
 
-    def test_raises_when_file_missing(self, tmp_path: Path) -> None:
-        """Raises FileNotFoundError when auth dir has no .credentials.json."""
+    def test_expose_raises_when_file_missing(self, tmp_path: Path) -> None:
+        """Raises FileNotFoundError when exposed and no .credentials.json."""
         import pytest
 
         with pytest.raises(FileNotFoundError):
-            _copy_real_credentials(tmp_path, tmp_path / "mounts")
+            _claude_oauth_mount_writer(tmp_path, tmp_path / "mounts", {}, expose_token=True)
+
+
+class TestCodexOAuthMountWriter:
+    """Verify the Codex mount reconciler copies-or-wipes auth.json."""
+
+    def test_expose_copies_real_auth_json(self, tmp_path: Path) -> None:
+        """expose_token=True copies auth.json into _codex-config."""
+        auth_dir = tmp_path / "auth"
+        auth_dir.mkdir()
+        payload = {"tokens": {"access_token": "sk-oai", "refresh_token": "rt"}}
+        (auth_dir / "auth.json").write_text(json.dumps(payload))
+
+        mounts = tmp_path / "mounts"
+        _codex_oauth_mount_writer(auth_dir, mounts, payload, expose_token=True)
+
+        dest = mounts / "_codex-config" / "auth.json"
+        assert dest.is_file()
+        assert json.loads(dest.read_text()) == payload
+
+    def test_default_wipes_stale_auth_json(self, tmp_path: Path) -> None:
+        """expose_token=False removes any prior auth.json from the mount."""
+        mounts = tmp_path / "mounts"
+        codex_dir = mounts / "_codex-config"
+        codex_dir.mkdir(parents=True)
+        stale = codex_dir / "auth.json"
+        stale.write_text("stale")
+
+        _codex_oauth_mount_writer(tmp_path, mounts, {}, expose_token=False)
+
+        assert not stale.exists()
+
+    def test_default_no_mount_dir_is_safe(self, tmp_path: Path) -> None:
+        """expose_token=False is a no-op when the mount dir is absent."""
+        # Must not raise even when the target file was never created.
+        _codex_oauth_mount_writer(tmp_path, tmp_path / "mounts", {}, expose_token=False)
+
+    def test_expose_raises_when_file_missing(self, tmp_path: Path) -> None:
+        """Raises FileNotFoundError when exposed and no auth.json."""
+        import pytest
+
+        with pytest.raises(FileNotFoundError):
+            _codex_oauth_mount_writer(tmp_path, tmp_path / "mounts", {}, expose_token=True)
 
 
 class TestCaptureWithExposeToken:

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -491,7 +491,9 @@ class TestCodexOAuthMountWriter:
         assert tokens["access_token"] == PHANTOM_CREDENTIALS_MARKER
         assert tokens["refresh_token"] == PHANTOM_CREDENTIALS_MARKER
         assert data["OPENAI_API_KEY"] is None
-        assert data["last_refresh"].endswith("Z")
+        # last_refresh is pinned far in the future so the CLI's 8-day
+        # staleness check never fires an in-container refresh attempt.
+        assert data["last_refresh"] == "9999-01-01T00:00:00Z"
 
     def test_default_overwrites_stale_real_auth_json(self, tmp_path: Path) -> None:
         """expose_token=False replaces a prior real auth.json with the phantom."""

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -406,10 +406,18 @@ class TestCaptureWritesCredentialsFile:
 
         assert not (mounts / "_claude-config" / ".credentials.json").exists()
 
-    def test_capture_codex_default_leaves_mount_empty(self, tmp_path: Path) -> None:
-        """Codex OAuth capture without expose wipes the shared mount copy."""
+    def test_capture_codex_default_writes_phantom(self, tmp_path: Path) -> None:
+        """Codex OAuth capture without expose writes a phantom auth.json."""
         (tmp_path / "auth.json").write_text(
-            json.dumps({"tokens": {"access_token": "sk-oai", "refresh_token": "rt"}})
+            json.dumps(
+                {
+                    "tokens": {
+                        "access_token": "sk-oai",
+                        "refresh_token": "rt",
+                        "id_token": "id.token.jwt",
+                    }
+                }
+            )
         )
 
         db_path = tmp_path / "proxy" / "credentials.db"
@@ -418,8 +426,13 @@ class TestCaptureWritesCredentialsFile:
             mock_cfg_cls.return_value.db_path = db_path
             _capture_credentials("codex", tmp_path, "default", mounts_base=mounts)
 
-        assert not (mounts / "_claude-config").exists()
-        assert not (mounts / "_codex-config" / "auth.json").exists()
+        phantom = mounts / "_codex-config" / "auth.json"
+        assert phantom.is_file()
+        data = json.loads(phantom.read_text())
+        assert data["tokens"]["access_token"] == PHANTOM_CREDENTIALS_MARKER
+        assert data["tokens"]["refresh_token"] == PHANTOM_CREDENTIALS_MARKER
+        # The real id_token rides in — the CLI parses claims from it.
+        assert data["tokens"]["id_token"] == "id.token.jwt"
 
 
 class TestClaudeOAuthMountWriter:
@@ -464,22 +477,35 @@ class TestCodexOAuthMountWriter:
         assert dest.is_file()
         assert json.loads(dest.read_text()) == payload
 
-    def test_default_wipes_stale_auth_json(self, tmp_path: Path) -> None:
-        """expose_token=False removes any prior auth.json from the mount."""
+    def test_default_writes_phantom_preserving_id_token(self, tmp_path: Path) -> None:
+        """expose_token=False writes a phantom auth.json with real id_token claims."""
+        mounts = tmp_path / "mounts"
+        cred = {"id_token": "real.jwt.string", "account_id": "org-42"}
+
+        _codex_oauth_mount_writer(tmp_path, mounts, cred, expose_token=False)
+
+        data = json.loads((mounts / "_codex-config" / "auth.json").read_text())
+        tokens = data["tokens"]
+        assert tokens["id_token"] == "real.jwt.string"
+        assert tokens["account_id"] == "org-42"
+        assert tokens["access_token"] == PHANTOM_CREDENTIALS_MARKER
+        assert tokens["refresh_token"] == PHANTOM_CREDENTIALS_MARKER
+        assert data["OPENAI_API_KEY"] is None
+        assert data["last_refresh"].endswith("Z")
+
+    def test_default_overwrites_stale_real_auth_json(self, tmp_path: Path) -> None:
+        """expose_token=False replaces a prior real auth.json with the phantom."""
         mounts = tmp_path / "mounts"
         codex_dir = mounts / "_codex-config"
         codex_dir.mkdir(parents=True)
-        stale = codex_dir / "auth.json"
-        stale.write_text("stale")
+        (codex_dir / "auth.json").write_text(
+            json.dumps({"tokens": {"access_token": "leaked-real"}})
+        )
 
         _codex_oauth_mount_writer(tmp_path, mounts, {}, expose_token=False)
 
-        assert not stale.exists()
-
-    def test_default_no_mount_dir_is_safe(self, tmp_path: Path) -> None:
-        """expose_token=False is a no-op when the mount dir is absent."""
-        # Must not raise even when the target file was never created.
-        _codex_oauth_mount_writer(tmp_path, tmp_path / "mounts", {}, expose_token=False)
+        data = json.loads((codex_dir / "auth.json").read_text())
+        assert data["tokens"]["access_token"] == PHANTOM_CREDENTIALS_MARKER
 
     def test_expose_raises_when_file_missing(self, tmp_path: Path) -> None:
         """Raises FileNotFoundError when exposed and no auth.json."""

--- a/tests/unit/test_credential_extractors.py
+++ b/tests/unit/test_credential_extractors.py
@@ -160,6 +160,33 @@ class TestCodexOAuth:
         with pytest.raises(ValueError, match="no access_token"):
             extract_codex_oauth(tmp_path)
 
+    def test_preserves_id_token_and_account_id(self, tmp_path: Path) -> None:
+        """id_token JWT and account_id ride along when present."""
+        (tmp_path / "auth.json").write_text(
+            json.dumps(
+                {
+                    "tokens": {
+                        "access_token": "sk-at",
+                        "refresh_token": "rt",
+                        "id_token": "a.b.c",
+                        "account_id": "org-42",
+                    }
+                }
+            )
+        )
+        result = extract_codex_oauth(tmp_path)
+        assert result["id_token"] == "a.b.c"
+        assert result["account_id"] == "org-42"
+
+    def test_omits_absent_optional_fields(self, tmp_path: Path) -> None:
+        """Missing id_token / account_id leave the keys out entirely."""
+        (tmp_path / "auth.json").write_text(
+            json.dumps({"tokens": {"access_token": "sk-at", "refresh_token": "rt"}})
+        )
+        result = extract_codex_oauth(tmp_path)
+        assert "id_token" not in result
+        assert "account_id" not in result
+
 
 class TestApiKeyEnv:
     """Verify dotenv-style API key extraction."""

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -89,11 +89,13 @@ class TestVaultRoutesParsed:
         assert "token_url" in route.oauth_refresh
         assert "client_id" in route.oauth_refresh
 
-    def test_codex_has_no_oauth_refresh(self) -> None:
-        """Codex does not yet have oauth_refresh configured."""
+    def test_codex_has_oauth_refresh(self) -> None:
+        """Codex has an oauth_refresh block so vault can rotate tokens in the background."""
         route = get_roster().vault_routes.get("codex")
         assert route is not None
-        assert route.oauth_refresh is None
+        assert route.oauth_refresh is not None
+        assert route.oauth_refresh["token_url"] == "https://auth.openai.com/oauth/token"
+        assert route.oauth_refresh["client_id"] == "app_EMoamEEZ73f0CkXaXp7hrann"
 
 
 class TestGenerateRoutesJson:


### PR DESCRIPTION
## Summary

- Replaces the Claude-only branch in `_capture_credentials` with an `_OAUTH_MOUNT_WRITERS` dispatch so any OAuth-capable provider can opt into the tier-3 expose flow without adding a new `if/else` ladder.
- Adds `_codex_oauth_mount_writer`: copies the real `auth.json` into the shared Codex mount when `expose_token=True`, and wipes any stale copy otherwise so prior tokens don't linger if the user flips the flag off.

This is Phase 1 of Codex OAuth support. The terok side (experimental config flag + env/shield plumbing + warning banner) lands in a companion PR on `terok-ai/terok`. With `expose_token=True` the real OAuth token is mounted into every task container — intentionally unsafe, gated behind `experimental: true` and `agent.codex.expose_oauth_token: true` in the user's global config. Phase 3 will wire a vault refresh route so the token stays on the host.

## Test plan
- [x] `make check` — lint / unit / tach / docstrings / REUSE / bandit all pass
- [x] New tests cover expose/wipe/missing-file paths: `TestClaudeOAuthMountWriter`, `TestCodexOAuthMountWriter`
- [ ] Manual verification deferred to the terok PR (the dispatch only fires during `terok auth codex` and requires the terok flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex OAuth support and vault OAuth refresh configuration to keep credentials current.

* **Refactor**
  * Credential capture now uses provider-specific reconciliation instead of a Claude-only flow.

* **Behavior Change**
  * Codex credential exposure now preserves JWT/account metadata when present and writes a safe "phantom" credential when not exposing tokens.

* **Tests**
  * Updated tests to cover provider-specific reconciliation and extractor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->