### PR TITLE
refactor(vault): inline _ensure_routes wrapper

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2756,13 +2756,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.3"
+version = "0.6.4"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_clearance-0.6.3-py3-none-any.whl", hash = "sha256:4817075644bfe8221430598c8ee2c9bbd7b37440f685d2755da31223bf62484f"},
+    {file = "terok_clearance-0.6.4-py3-none-any.whl", hash = "sha256:51b025dd71f290d3923a48c53beebd474df9efa3a702be6db4f6ce1a2e91aebb"},
 ]
 
 [package.dependencies]
@@ -2772,17 +2772,17 @@ pyyaml = ">=6.0,<7.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.3/terok_clearance-0.6.3-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.4/terok_clearance-0.6.4-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.98"
+version = "0.0.99"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.98-py3-none-any.whl", hash = "sha256:9812d72049641cfd04415722927859248004668c1e23189b95fb1e81460b3e8f"},
+    {file = "terok_sandbox-0.0.99-py3-none-any.whl", hash = "sha256:d70a03fe8a9b13b6aacbd3152b0f6f7483526f541c4bde17c965df83b5574715"},
 ]
 
 [package.dependencies]
@@ -2791,22 +2791,22 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.3/terok_clearance-0.6.3-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.31/terok_shield-0.6.31-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.4/terok_clearance-0.6.4-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.32/terok_shield-0.6.32-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.98/terok_sandbox-0.0.98-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.99/terok_sandbox-0.0.99-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.31"
+version = "0.6.32"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.31-py3-none-any.whl", hash = "sha256:580dea24fb376f6cba51ce0d6a1145c0642c618d3e2c3a8f1c09d12be435f18c"},
+    {file = "terok_shield-0.6.32-py3-none-any.whl", hash = "sha256:bb473fc890ec41a72e1e0b61248e6ab9be06a3becb772ed212dafb7f1d6ff56f"},
 ]
 
 [package.dependencies]
@@ -2815,7 +2815,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.31/terok_shield-0.6.31-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.32/terok_shield-0.6.32-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -3214,4 +3214,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "fd41122273de18a5c4146515c595d57cf3966c0003dd1efde9f1ee0ab859bcb4"
+content-hash = "0fe5a3d3b9155a034c5fb72e0cfa6d28cacd557877f486ed9d8ba43fba80d63c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.117"
+version = "0.0.118"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -31,7 +31,7 @@ python = ">=3.12,<4.0"
 # — a stale URL pin here would otherwise conflict with terok's git pin
 # on the upstream sandbox tip.  Release script flips it to a URL pin
 # when the next sandbox wheel ships.
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.98/terok_sandbox-0.0.98-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.99/terok_sandbox-0.0.99-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -20,21 +20,16 @@ if TYPE_CHECKING:
     from terok_sandbox import SandboxConfig
 
 
-def _ensure_routes(cfg: SandboxConfig | None = None) -> Path:
-    """Generate routes.json from the YAML agent roster."""
-    from terok_executor.roster.loader import ensure_vault_routes
-
-    return ensure_vault_routes(cfg=cfg)
-
-
 def _handle_start(*, cfg: SandboxConfig | None = None) -> None:
     """Generate routes and start the vault daemon."""
     from terok_sandbox import is_vault_running, start_vault
 
+    from terok_executor.roster.loader import ensure_vault_routes
+
     if is_vault_running(cfg=cfg):
         print("Vault is already running.")
         sys.exit(1)
-    _ensure_routes(cfg=cfg)
+    ensure_vault_routes(cfg=cfg)
     start_vault(cfg=cfg)
     print("Vault started.")
 
@@ -178,13 +173,15 @@ def _handle_install(*, cfg: SandboxConfig | None = None) -> None:
     """Generate routes and install systemd socket activation."""
     from terok_sandbox import install_vault_systemd, is_vault_systemd_available
 
+    from terok_executor.roster.loader import ensure_vault_routes
+
     if not is_vault_systemd_available():
         print(
             "Error: systemd user services are not available on this host.\n"
             "Use 'start' to run the vault without systemd."
         )
         sys.exit(1)
-    _ensure_routes(cfg=cfg)
+    ensure_vault_routes(cfg=cfg)
     install_vault_systemd(cfg=cfg)
     print("Vault installed via systemd socket activation.")
 
@@ -202,7 +199,9 @@ def _handle_uninstall(*, cfg: SandboxConfig | None = None) -> None:
 
 def _handle_routes(*, cfg: SandboxConfig | None = None) -> None:
     """Regenerate routes.json from the YAML agent roster."""
-    path = _ensure_routes(cfg=cfg)
+    from terok_executor.roster.loader import ensure_vault_routes
+
+    path = ensure_vault_routes(cfg=cfg)
     if path:
         print(f"Routes written to {path}")
 

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -229,7 +229,7 @@ class TestVaultCommandHandlers:
     """Verify vault CLI command handlers."""
 
     @patch("terok_sandbox.start_vault")
-    @patch("terok_executor.credentials.vault_commands._ensure_routes")
+    @patch("terok_executor.roster.loader.ensure_vault_routes")
     @patch("terok_sandbox.is_vault_running", return_value=False)
     def test_start_generates_routes_and_starts(self, _running, _routes, _start, capsys) -> None:
         """start generates routes then starts the daemon."""
@@ -288,7 +288,7 @@ class TestVaultCommandHandlers:
         assert "claude" in out
 
     @patch("terok_sandbox.install_vault_systemd")
-    @patch("terok_executor.credentials.vault_commands._ensure_routes")
+    @patch("terok_executor.roster.loader.ensure_vault_routes")
     @patch("terok_sandbox.is_vault_systemd_available", return_value=True)
     def test_install_generates_routes_and_installs(self, _sd, _routes, _install, capsys) -> None:
         """install generates routes then installs systemd units."""
@@ -326,7 +326,7 @@ class TestVaultCommandHandlers:
             _handle_uninstall()
 
     @patch(
-        "terok_executor.credentials.vault_commands._ensure_routes",
+        "terok_executor.roster.loader.ensure_vault_routes",
         return_value=Path("/tmp/routes.json"),
     )
     def test_routes_prints_path(self, _routes, capsys) -> None:


### PR DESCRIPTION
## Summary

Inline the 3-line ``_ensure_routes`` wrapper at its three call sites (``_handle_start``, ``_handle_install``, ``_handle_routes``) in ``credentials/vault_commands.py``.  It was a WHAT-not-WHY passthrough to ``terok_executor.roster.loader.ensure_vault_routes`` that added no context beyond what the import already conveys.

Tests patch ``terok_executor.roster.loader.ensure_vault_routes`` now (the real target) instead of the private wrapper.

## Why

Parked from the ``/simplify`` review of PR #228.  Independent of the in-flight stage-helper chain in sandbox/terok/clearance — can ship any time.

## Test plan

- [x] ``make lint``
- [x] ``make test-unit`` (696 passing)
- [x] ``make tach`` / ``make docstrings`` / ``make reuse``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal vault credential handling by inlining prior helper behavior for CLI commands.

* **Tests**
  * Updated unit tests for vault CLI handlers to match the revised implementation.

* **Chores**
  * Project version bumped to 0.0.118 and related package artifact updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->