### PR TITLE
feat(sandbox): wrap vault-routes regen in a stage_line

### DIFF
--- a/src/terok_executor/sandbox.py
+++ b/src/terok_executor/sandbox.py
@@ -34,11 +34,21 @@ def ensure_sandbox_ready(
     ``no_vault`` gates the routes pre-step (if vault isn't being
     touched, don't regenerate); everything else (``root``, other
     ``no_*`` flags) flows through to the aggregator.
+
+    Routes regeneration renders a ``Vault routes`` stage line so it
+    sits in the same column as the aggregator's own output rather
+    than failing silently above it — a corrupt YAML roster is the
+    most plausible reason for setup to fail before the aggregator
+    even starts, and a stage-shaped failure beats an unframed
+    traceback.
     """
+    from terok_sandbox import stage_line
     from terok_sandbox.commands import _handle_sandbox_setup
 
     from terok_executor.roster.loader import ensure_vault_routes
 
     if not no_vault:
-        ensure_vault_routes(cfg=cfg)
+        with stage_line("Vault routes") as s:
+            ensure_vault_routes(cfg=cfg)
+            s.ok("regenerated")
     _handle_sandbox_setup(cfg=cfg, no_vault=no_vault, **aggregator_kwargs)


### PR DESCRIPTION
## Summary

``ensure_sandbox_ready`` calls ``ensure_vault_routes`` before the sandbox install aggregator runs, but the call was silent.  A corrupt YAML roster — the most plausible pre-aggregator failure mode — yielded an unframed traceback above the otherwise tidy install log.

This PR wraps the regen step in ``stage_line(\"Vault routes\")``, borrowing sandbox's column-aligned progressive output for executor's only pre-aggregator step:

```
  Vault routes         ok (regenerated)
Prerequisites:
  podman               ok (/usr/bin/podman)
  ...
Services:
  Shield hooks         ok (active)
  ...
```

Auto-FAIL surfaces YAML/IO errors with the exception text inline, instead of crashing the operator's pipx-installed ``terok-executor setup`` mid-run with no breadcrumb.

## Context

Closes the gap from the recent stage-line refactor in terok-sandbox (#214 → #216):

- **terok-sandbox** owns the renderer + ``StageLine`` context manager.
- **terok** (#827, post-refactor) routes its own setup/uninstall stages through ``stage_line``.
- **terok-executor** had no stage-line usage of its own — its only pre-aggregator step (vault routes regen) was silent.  This PR fills that one gap.

## Test plan

- [x] ``make lint``
- [x] ``make tach``
- [x] ``make test-unit`` (696 passing)
- [x] ``make docstrings``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced progress reporting during sandbox initialization with clearer status messages for vault route operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->