### PR TITLE
fix: share codex oauth state through the vault

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -68,7 +68,7 @@ their SDK supports:
 | Agent | How it reaches the token broker | Notes |
 |-------|-------------------------|-------|
 | **Claude** | `ANTHROPIC_BASE_URL=http://host.containers.internal:<port>` | Anthropic SDK respects this env var (default port: 18731) |
-| **Codex** | `OPENAI_BASE_URL=http://host.containers.internal:<port>` | OpenAI SDK respects this env var (default port: 18731) |
+| **Codex** | Shared `~/.codex/config.toml` rewrite (`openai_base_url`, `chatgpt_base_url`) | Codex's built-in first-party auth is file/config based, so terok patches the shared Codex config instead of relying on env vars |
 | **Vibe** | `config.toml` with `api_base` in shared `~/.vibe` mount | Mistral SDK ignores URL path in api_base, only uses host:port. Written by `shared_config_patch` in YAML |
 | **KISSKI** | `TEROK_OC_KISSKI_BASE_URL` env var override | OpenCode reads this; overridden from the real upstream to token broker |
 | **Blablador** | `TEROK_OC_BLABLADOR_BASE_URL` env var override | Same pattern as KISSKI |
@@ -185,8 +185,9 @@ After storing credentials, `write_proxy_config()` applies any
 
 ## Known Limitations
 
-- **Codex**: The token broker only handles HTTP. Codex needs WebSocket
-  support for its realtime protocol, which the token broker does not yet provide.
+- **Codex**: ChatGPT/backend-api and realtime websocket traffic are routed
+  through the token broker, but any newly added Codex-specific upstream
+  surfaces still need explicit vault route coverage.
 
 - **Copilot**: Not proxied yet. No `vault` section in YAML.
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -107,16 +107,19 @@ shared_config_patch:
   file: config.toml
   toml_table: providers
   toml_match: {name: mistral}
-  toml_set: {api_base: "{proxy_url}/v1"}
+  toml_set: {api_base: "{vault_url}/v1"}
 
 # gh: YAML patch
 shared_config_patch:
   file: config.yml
-  yaml_set: {http_unix_socket: "/tmp/terok-gh-proxy.sock"}
+  yaml_set: {http_unix_socket: "{vault_socket}"}
 ```
 
-The patch is applied after auth (`write_proxy_config() in proxy_config.py`).
-Only non-secret values (URLs, socket paths) are written to shared mounts.
+The patch is applied after auth and reconciled on every task launch.  Only
+non-secret values (URLs, socket paths) are written to shared mounts.  The
+patcher also writes a `.terok-managed-config.json` sidecar beside the config
+file so callers can later disable a provider and remove only values still
+owned by terok; user-edited values are preserved.
 
 ## Agent YAML Registry
 
@@ -165,9 +168,12 @@ Prompts for an API key on the terminal. No container needed.
 
 ### Post-auth config patching
 
-After storing credentials, `write_proxy_config()` applies any
+After storing credentials, `write_vault_config()` applies any
 `shared_config_patch` from the YAML registry. This writes token broker URLs
-(not secrets) to the provider's shared config mount.
+(not secrets) to the provider's shared config mount.  Task launch re-applies
+enabled patches and removes disabled provider patches using the managed
+sidecar, which keeps global shared config directories from retaining stale
+vault routing after a feature mode changes.
 
 ## Per-Provider Credential Extractors
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2797,7 +2797,7 @@ terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/codex-shared-oauth-vault"
-resolved_reference = "ca8fa65ea1e49365a2aa81ce304856e446b7f155"
+resolved_reference = "eb22e08bab11f9e61333afdcfe257d9d6b77ab1f"
 
 [[package]]
 name = "terok-shield"

--- a/poetry.lock
+++ b/poetry.lock
@@ -238,19 +238,18 @@ dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)"
 
 [[package]]
 name = "backrefs"
-version = "6.2"
+version = "7.0"
 description = "A wrapper around re and regex that adds additional back references."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["docs"]
 files = [
-    {file = "backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8"},
-    {file = "backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be"},
-    {file = "backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90"},
-    {file = "backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b"},
-    {file = "backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7"},
-    {file = "backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7"},
-    {file = "backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49"},
+    {file = "backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9"},
+    {file = "backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475"},
+    {file = "backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12"},
+    {file = "backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a"},
+    {file = "backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9"},
+    {file = "backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82"},
 ]
 
 [package.extras]
@@ -590,109 +589,106 @@ markers = {dev = "platform_system == \"Windows\"", test = "sys_platform == \"win
 
 [[package]]
 name = "complexipy"
-version = "5.3.0"
+version = "5.4.0"
 description = "An extremely fast Python library to calculate the cognitive complexity of Python files, written in Rust."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "complexipy-5.3.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:986e3833b622047caaff3d48e5726251f80c46fdfb50d8f3fec9fc5afa6daba5"},
-    {file = "complexipy-5.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2cb0d86be1fc5e7cb8a3b64721c3270b1eff59228dc5adae4734f351a976854d"},
-    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6fe1ce8804675b2b196091cf0779e0d1ca51058d71c1f15b4fb3a67cbcdf5bf6"},
-    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:c71058f43b6b48b50f1b835a97904bd15b0f82d4d3b1cc046a88fb166392eaa2"},
-    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ed84d9f8ebee3edd08a8d169594d19e36ff1e859eed4105d84d683010c463b0f"},
-    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:21e653cbe981b764d5a39a15def56f554b869974a0e6a3e9d7150b66d84a3514"},
-    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6d300e92712cf43c69bf7f361f35ce749803f0025bc9d7d0801547debf8022cc"},
-    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:64331e481432b6cbea3856346d787453eae98586bc62efccfc30677e77b392a2"},
-    {file = "complexipy-5.3.0-cp310-cp310-win32.whl", hash = "sha256:e413bba9bf05ffd5f21d8cf0853e068d780f4bc45cb0fc3199d8a84782587d5d"},
-    {file = "complexipy-5.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:98d3f3fffb472ca39ecdfbe06bb853f30ab1f800ed82d6047eeb18f2167c2fdc"},
-    {file = "complexipy-5.3.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a5684388a2ac21997e669fd6664cb48d39dcf3699b79a59209c3b0283473f39f"},
-    {file = "complexipy-5.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a6bde4a3060818d267f1b12bff41fc8dd0f28175730e8899669373831a016353"},
-    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7dffd3c512ddba2259109a7ca8c79843dadd986755c8498b35a3e242eeeac0e8"},
-    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:7521d85dcfef17ca797b89508ba4db43d4f017d2389fa57bc144e5882e1b2c8a"},
-    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5ae64b84f0e9b83844c10a6fe5a0610348176560ed5a89e2b33ef0858f48b720"},
-    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f800807a050cbc37a12071bc8d86356a2c06a88285bf52e4be9f5116f4ab444"},
-    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:403902d32189102cfda5462884a302d847234b3267d14ab5ccc2f77160c37710"},
-    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:033cc22618d958c123d62c377c953aef466a3e8774b595c6c8604678c6c3c114"},
-    {file = "complexipy-5.3.0-cp311-cp311-win32.whl", hash = "sha256:42931056b1f92364f859e2798c93e49c66976899af144fce74b2aebb8fa84079"},
-    {file = "complexipy-5.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:a7b2f0cdeb5fc3a395c7215d1d82f28e498bb154d8d95dbae05895fbf0d6fbde"},
-    {file = "complexipy-5.3.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:04d6137eff0a17e6fd352a6cdc7c7fb6fdf4200a9e6db3f627c60fe79b82cfe3"},
-    {file = "complexipy-5.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86680349d5f1f72b1e512bc045d3f7999941c8e7f5dfe235c308a0556265888c"},
-    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52f6fad6e998a3d6a03c737ed0a915565ce8f90c51921597e7156a717b65110d"},
-    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:a5bdd1ded9c83e0cc0f2d47c21e3066aa7443cce2d9b556d0915cb407ac26af3"},
-    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:474270be61ed0666e26b8b6f2c40b3b131ef3baf647a290641e894c9f24062aa"},
-    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a93322f7350f8ac514384986794309e2f13d4593b6ac579c31d3ef257190e3f0"},
-    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c0834678ed93729d72bfd9be72e19abf38cce5094ef18fb66a7ed64c6eb05be2"},
-    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80cc9cefca8c8cecc75096f2a9b207f050d009f2dee5c32d909c1db7a60db747"},
-    {file = "complexipy-5.3.0-cp312-cp312-win32.whl", hash = "sha256:8b1a0f88cfc0214e4c7dbd328c92d79046e4be64f8f58eaecfd3fc59d567de12"},
-    {file = "complexipy-5.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:6415b99c675115f4ef24136c9b5baed06c61e0b6416620d012baa7cad33419f0"},
-    {file = "complexipy-5.3.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ea9b82c62b872079ad61f643b1ef2459e4008285d95b1671b2e36167f5c255f7"},
-    {file = "complexipy-5.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb55e0e5a15d63869af7bbbe51cc92e2432233d571b1d1089bb15e3b50f0bb62"},
-    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dc3099aebe6f885cfbc73229c3f137f5491abe355c74a300616cb6537c2a14dc"},
-    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:b2a4c31158f1f31d3c059384878adfd2edcebe2037de36125e14101a3316d110"},
-    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5a679dd88e03c36a003190e912d0cf953c767cf01dc6669b05f4941aad5fdab6"},
-    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:13c7cb4ce9946504539d77c718772331056b5ab11e9b1a3e791e79f43dee9208"},
-    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:297fa947410db3dde3e5770d06148509b560992b251a1bbce7035505dcafe8b8"},
-    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c5a1966bd608515064e6e5ef63713bafe222561858549c0cb286518b99ded510"},
-    {file = "complexipy-5.3.0-cp313-cp313-win32.whl", hash = "sha256:347f1570feaff948085dcb6eb2af4b97ff6c724cc2ee70e7a91a340ae2941c0f"},
-    {file = "complexipy-5.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:34789f2c9b64ccc2c03efb61ad6c96f3b3a53cbb472caf8c389bbca3067db4c3"},
-    {file = "complexipy-5.3.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:76c57b535e09546898aa560347f489e596b721c26bd748fe12a882f22c8c5804"},
-    {file = "complexipy-5.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0bcdbe80efaa6d9ef5d25358bf78862fc905e1e9b1bcab2763b208c1e1b135c9"},
-    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:833bf17a31eddd5c694b84a571f04a9c07c226474cbeefd23e832d34e93877dd"},
-    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:3b5076647fdd18f26a832e831e85946f65cb665832c0498ea4a0be1b9b0659ac"},
-    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:508d4eabf52061b3877e0ec67937db34f7414b20ddb67dcf1a43aba3d090f5cc"},
-    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:07654b531e49ae6788e276c5b7f26c5cbd8e785b788b4ec2af00c48f38ba46b5"},
-    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6d30def78c5ccf64edb006e1185afd07e9504ed04aee850941acd86a73bc7fe"},
-    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e651e094e09c0b3b66bb320a4091177febd59cb7326c06a442c161e2d90c0f9c"},
-    {file = "complexipy-5.3.0-cp314-cp314-win32.whl", hash = "sha256:f1596e5e535c278ea3308f98e033ec99110f80b44db3251f4992d6e5f9f5c402"},
-    {file = "complexipy-5.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:f5daedb399a678ac176e31cc0b7a2b399a5382c3fe4924ff89d3c052af6a25a2"},
-    {file = "complexipy-5.3.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:14a968ededbde743807456e893dfde913de56e0dbe0d712f91a0a0ae6f0d1afc"},
-    {file = "complexipy-5.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:dfbead9b18109a51f7cf65da4e78845d6e01e52efc4ee7bee21dc73c7ca18a90"},
-    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:00652681e8eff1ce5742680834d2f995f84594cb0a3d8baf1b7113d492a6d58b"},
-    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:7f1687b87df9d7a828b190fdc98053e171a28775812799d675d8e947984a334f"},
-    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4d1498e078f586fa0ed4b9225669bf298ed639514439e27f4a343a43986250d7"},
-    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1814b5210004b46a94148e89b0e4d8e7ae07adf7f94986b0b0c459ca6034d70d"},
-    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:0d83980281854b19388104e7999b1888f7e6f94e8af5aea6c56c65882cc12967"},
-    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c4d6c5d469f91aa729049e51ebdd06813c084b364ac2d225bc07dc278cf10090"},
-    {file = "complexipy-5.3.0-cp38-cp38-win32.whl", hash = "sha256:a19fa14a2d1c859608bd5aab738c13fe750c1432b9a9f196f64dc4f1877fa0d6"},
-    {file = "complexipy-5.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:29d6c2da75719907add67f7136afbbc292e800ef828f9982dbdc9b3db2ca80fd"},
-    {file = "complexipy-5.3.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:1863284380f236282eff90fa598751580b1b8fd98b859628e571f8dd63bceca5"},
-    {file = "complexipy-5.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:abd0d4ad0d79367d617e34bd450215ba9dd2427b275dbbdf65f1535251be8aa7"},
-    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b80b83ce06dbe80ac9004cd3c946d2393224e158d23919287b2e4845d135f3fe"},
-    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:1c04a72464c0496f7bc6a770276336ab2bb3f2a05dd0b0a7915ea198626e87d2"},
-    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:682d28e04fbb0b89d06972b2752c16e4722dbe1fa22fb832b8af2d3d0acad54e"},
-    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93a8facd860583fa7cf7e559e9037da92de68c7aefb589e9f8d10a97e49cb2c"},
-    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2f711c40c775712541d3d32aaa7f679cb282970669835b6aa35727113deb77e0"},
-    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a555d349940dbca7f4c5b73b135e95a0ee3fbff20fdca8425967806330aa53c"},
-    {file = "complexipy-5.3.0-cp39-cp39-win32.whl", hash = "sha256:866190715b4b60c079951d4aa3d9d549bd3f71b458d0054947650624e16d14fe"},
-    {file = "complexipy-5.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:2224fcdb5f5763831fde2af360c92965506d41518fa9f34c90b397ede51a11d6"},
-    {file = "complexipy-5.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08d4c8f45173bbbeff81d36ed9f637bb8084bc9df2eff58e81f7a6d99bd8ffe8"},
-    {file = "complexipy-5.3.0-pp310-pypy310_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:4d318b2ae1ae0ab69356ee42c3c5010d6e143aa7602e8e5719d41ebce8fac09e"},
-    {file = "complexipy-5.3.0-pp310-pypy310_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3456c3c86b677d3c460e11b9bd23526454eefc2c53b0c3650aa2fc7ba0dd2262"},
-    {file = "complexipy-5.3.0-pp310-pypy310_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ba77e7ef31ee2c44dac896e1ce4180d046839f2bc22da653c556e82726564537"},
-    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d03454a9bd650ed56dc694a8cb985b020ff792ca5be6208f5bc7c9861bfe3521"},
-    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:91e9bedd18d693cc4e5482e76a52a53298e831020eb6fdb4084b89d5547df78f"},
-    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:15b7c1f60c4ec73f4fa180a5e1ebd2b2db1aa16b2de2612cf2313b97396552c9"},
-    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6ee0dc76a30a282ee1869723abdefbca9c8c1c94b3088ed50ab2b109d7019b4e"},
-    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:46622e5bd80e0aaa1ca9bd333f7cc71d03007d71fb7016ea2a68b404b9c8e3d7"},
-    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7e24f151789ee320fff80cca1ccbde9ff3905ef4a88a3dbcbc83d29545c4c232"},
-    {file = "complexipy-5.3.0-pp38-pypy38_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:54746ed1a45c973ceb409da7c08010d9df9bdb31dd5b8e271d26508a8fc50070"},
-    {file = "complexipy-5.3.0-pp38-pypy38_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:4db8097654674811ca57bc647cfb1e1161b6877db75eab8a336747fb826249ad"},
-    {file = "complexipy-5.3.0-pp38-pypy38_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8174c2854d5a8e77ac97f656b503ffbd9a04c3f388a1136dbafd5f7582ac064a"},
-    {file = "complexipy-5.3.0-pp38-pypy38_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:58e6d3b8990b460316d522075209f4cab5afbc0ba7d2338f7b62a588b6b8a186"},
-    {file = "complexipy-5.3.0-pp39-pypy39_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:11c9e44a7a9603e7d83345220f363fc298a5bfddf3e479279a352494ba360dbc"},
-    {file = "complexipy-5.3.0-pp39-pypy39_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:41b663586702b04e3c1fdb23717b94c3dcf41f1ee48457ae1e886978a0850a6d"},
-    {file = "complexipy-5.3.0-pp39-pypy39_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e104096a676d753f17fe0b0b588158386afb609f2ce25f4d96627791334d8c2"},
-    {file = "complexipy-5.3.0-pp39-pypy39_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dbd66d11cc04398ff09e6c9694d820c0824221c0ddee70897ba1bc2aa1f924f5"},
-    {file = "complexipy-5.3.0.tar.gz", hash = "sha256:b60b60c24b5f4e4eca1dd18f145f41f428c607c40477305b4f8302726b3e1eb6"},
+    {file = "complexipy-5.4.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:8e6e886ef933cc3ec2cef0f893282e31c33504792b4aee2441897e4a8b9c37f3"},
+    {file = "complexipy-5.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc6fcd0dd983398f611bde1d108a998ce77238db2b977669d5d90557957bb582"},
+    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0253fae6f08a56e2d35564b0070d164fa5dde18c6e8927fb2fcda87e9448293"},
+    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:88b53ce470315438bced6338960ca28e6b1c0e7d1bc37f9efc9370c6dc4c0ff4"},
+    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:a4d34148bb62f2ef9cf196c405bda2046ad2c84ec52808879547f1eab2211452"},
+    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:cb485cd8b708bd4df837189282926c46c280f2ddd8470e9bbd0c8ffd7055a47a"},
+    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:e9c1850f475c6cd55ef17223dc26682ed37a9d4f5f7566d21598f0ce00b36ca1"},
+    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7684fdb587b42e72e14fbe97c91b0e415ace0a3ee16a0451edd87ad524de5621"},
+    {file = "complexipy-5.4.0-cp310-cp310-win32.whl", hash = "sha256:a091ee0e37ecf263101cf4c0cd3ff77e80a73da01eff314d8f14ac1ed0f2365a"},
+    {file = "complexipy-5.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:4cdfdb00bd8e887fe2948a351b46d6a55a22645c1d3b5462089596a6427ae537"},
+    {file = "complexipy-5.4.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3fba640f0920fc130dcca0414e269624c15d676c2bb4a4e53352befcf01d5f43"},
+    {file = "complexipy-5.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8ca4f5c5d0c89e40bb4c19f0190a9ab4a1d5fe20b2c6fb10659795ccb19f967f"},
+    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9f7598dffe65271daa8f0ef82433ebd4224104650962dedbf5ed27ac1f1ea76f"},
+    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:0ab5c9e6cd1c5562cda89137ddc6d4960c5eac93310918658d35a592ff1fe3a9"},
+    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:860ed17eba40cda83b3685c8121844cb06e3cbbbcd90fe59f3d0200ada6ca636"},
+    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:07c71369e3eed0a675fede71ab0da91f1d3441a8070e51de28a9c2125070b872"},
+    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:bf9fff738f10b02fcbc5dea463e7f614384b8c1a8bb09775fb05a29e3f643ed5"},
+    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4aeef65a8ce9cadc7343adeb3991026b2ac14fafef3f9c73ee25078a2b2607a1"},
+    {file = "complexipy-5.4.0-cp311-cp311-win32.whl", hash = "sha256:a476d0d00e5012c2713915d854474fc564bd142f97a464d235a6cff71b5b3501"},
+    {file = "complexipy-5.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:a22e6e20823ae0208451e6ed60e9230a0161c331db4d09c6c94ce4eb0a0b76fc"},
+    {file = "complexipy-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:e5ff5f785cf903dbf59121cd489c413901d79f19ccd43e4ca590501b14accdab"},
+    {file = "complexipy-5.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7bb23bd23bdebfc7193821dcfb53952eb46c07404c0d94d04944d69abb416c81"},
+    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee36d113becdbe44ee45183c0f8042aea6c81d1f9e78f843012afe2c962a2bf6"},
+    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:72f3fb62cde1feea36b7cf01bbbc7f83ac0de27e682152bdab2d7fa89a8cdb01"},
+    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b9cbe2477fbe259ad9bcf3ab4b1e4489afd10145aaf43c2ad1fd31ba9d5dc667"},
+    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:224f166699fd4d2044fb06ba0ac2de0c9961f76e5889ef4dc7b42863a302a3e6"},
+    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:00395ca31d033695d603e89f3707087badfa44b0b2316a58a3fca94fdedf3617"},
+    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:48402ae78a0d328c29262bd5337833ae633be5e1679e3019ee508bab621bfc9f"},
+    {file = "complexipy-5.4.0-cp312-cp312-win32.whl", hash = "sha256:f8c9a1256534b180d4e7627fc534ff8a20a6e75989ea041f878b61bb1318f083"},
+    {file = "complexipy-5.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:3fb6757cef095d400dd374645d6c97c4041c0148a7c9042dd3d4ad50c0021d62"},
+    {file = "complexipy-5.4.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1d4e57e38d7f81b0859bbfea7b0811bb0278fac76ecbe5349db519ddcab1bcd2"},
+    {file = "complexipy-5.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b6506a346f76680e02707d7f8b15736262c80f75efc0f58b0b97475f130d389f"},
+    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:70c7da3dc24155059239837f13c2d22ec1cd7bb29a482b8db458e298e5c92e38"},
+    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:2776e41408dd6103edfe2427f80e01b3c5b5f23b37b203d1d6571242f275af7d"},
+    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:6ba5e652741801096f0b5b5a365d05f4268db1b6f26cdc91ad54844d03de980a"},
+    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bb7586443257586cc1ab1c524bb71d8553e7acee433d78b4c1b2f61825237272"},
+    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:96f92fea96b97726cbbcb2b7f5979ab4c8d3fcb351a4c08f9ec0d58e1aba0ef9"},
+    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:037d9b14f9297e37f8a5752b3f0c26bb5ed70dd62b7b033f92ffe63e9dde423b"},
+    {file = "complexipy-5.4.0-cp313-cp313-win32.whl", hash = "sha256:48b0ae7706a6c54da8ebfe0453d3a4b962e1300cca5db28c1aa3575fd1a61df2"},
+    {file = "complexipy-5.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:8a97b47ff486a3607c1331540e8ea2b401babef1f95ec3dac079e17cc5e65505"},
+    {file = "complexipy-5.4.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d11519de249f0dae9e14eb12bfb32a41ce18720ca6506fdf23f8bbce3a300030"},
+    {file = "complexipy-5.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ef21d5fa4bfcd9851a300ff08f3eea85ddd21afda656ab74198d01c74913d33"},
+    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:488097d185265556e64fec3a31d334f684ec55304bbb2533bd5708b4add420dd"},
+    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:43dca0070306007915b3c022239031df652a2c64ae0d3ffa10ba034d40b96226"},
+    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1d8fb02e164264234e0d664d6d71d85a93706a77fdc54e603bc609a7fc9037d6"},
+    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:101938466d910088d81f5494637ed8da992c93f417a69defc1e07b09771c4c1d"},
+    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:bbaed28e0bbfe527df43534bf0ba67b1459c52b55a46c01b802f227427043760"},
+    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5dc5d1db0c7d2befbf02e45a5ed2a64276c1ba4b710c1e86d031244eb33dea1c"},
+    {file = "complexipy-5.4.0-cp314-cp314-win32.whl", hash = "sha256:60cbcdd503e869fdf314db4594cd0220a0b5d6f0432c4fc4ed49f92e635917ff"},
+    {file = "complexipy-5.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:d2ef116c563e98b16c7494f6c8f1b2ddf47fcfc8f6665f7db98fc2b8b24087d2"},
+    {file = "complexipy-5.4.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:f384993042472948f7ba4b316cdfaf38fed607982d4afe772a228d10c4253b05"},
+    {file = "complexipy-5.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3f7c06ddd4898a9e4d5b53bd188b55c73992ba478f5e655b7751cd5abe7937e3"},
+    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b37a6bb0926381478a684564aee9952286c6c0b803bae7b1aafbf7c8ae4d77b"},
+    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:408ae0070d72d5505f12816080898e6a8359f4cacc43b12cdbe6b333bc14021c"},
+    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:7e55d83945369b8c13aa334e06061f15fa828a47bf54f5b2b0ea83d7c409d329"},
+    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:72a161b98d6427d02299c02ff64f8c210e099692ad15baefc22478953c66fef3"},
+    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:86129fdd22fb18cc2d2cf0e348b649703bb7a17f97288a4e876ceb319d773455"},
+    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cd515000632969bf489c7d931dcb5ca5ff70e42bea6c0405460e168789e4564"},
+    {file = "complexipy-5.4.0-cp38-cp38-win32.whl", hash = "sha256:c5100015a66f051af9a1c78ab19026b2fbbb843866504b2e3f3e033b64985f1b"},
+    {file = "complexipy-5.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:71e0b589788ea2f72a2dc7acbb949d089de4614ce1b6ebc5473ea94a0681f146"},
+    {file = "complexipy-5.4.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:57520d419b5ca616c22ee20bdaf8ff27f3fca358e122d2811f6da89517e567c7"},
+    {file = "complexipy-5.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a3c5f8c5d784af3806a65f120f29acdff3888e6223125d75e47a9a7bd35e46d1"},
+    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6547f1646d4a66c4faa25ab9445a4cc7afbc7bf5d2ba0ec3e9faf37c33affbfb"},
+    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:ae9913385f6bf59de63738fe3dee2c21508f7f1c7f4fba0c5911f3dc9bb8caa3"},
+    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0e26c79536b7181198d885f5f05bd741f08bd11e8afd694c4271a74b99b838bb"},
+    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d3fb8449ebf64d67a6ebfc452b263b053050c1b3a12fb07b068d4fc60cfd3f02"},
+    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c952ec52b6c71e582c834b7de3a44d7279a8992fd5740466350448e128b210d5"},
+    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:92eaeb6e0a9b3602217eb773319bbfffda2eba07cd3344b7ff7d07e904d876af"},
+    {file = "complexipy-5.4.0-cp39-cp39-win32.whl", hash = "sha256:cbec33b155c2e8b2b205b4cf89059e87a1f3b5f995e2b087ccd088442b8bf5c7"},
+    {file = "complexipy-5.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:d8bfe9e34600c0d19184c273bfd89ce4adc405ace6f60d113e978d705749cfe4"},
+    {file = "complexipy-5.4.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:476f7d56eac53c056811d581e6583a69bd448f9ae6575f8c74c3f5cc2cc31fae"},
+    {file = "complexipy-5.4.0-pp310-pypy310_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:8a0679ecfa5bc30e18e297b33ecf77719e0dd3f3594d986402f849997f24a2c8"},
+    {file = "complexipy-5.4.0-pp310-pypy310_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:84224a066b73c782bd1fb030a6f04978a16c4eb62cca96092d07f3da4bef7699"},
+    {file = "complexipy-5.4.0-pp310-pypy310_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5d0abc858e6761e5cf452432e029700516b8ce6e0521b7f60d30cdbad446489f"},
+    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0052d64c42d56e64173f4c808c361e754a61ec09de6435d5e469bb0eaf191d4"},
+    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:9a94600c379712c72602180cc4694e2c8e5791e8538080d6bfffea45dc68d922"},
+    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:a76a94be193ad427f60ac985678b9bea8c34a34b023b0f8cbad37eec05975e22"},
+    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5ce1df8f659263ab23610af5d3e9ac9c18b665c5c852f2344645823f6d671ea1"},
+    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c7f2d6812adca07336febe69acb4eac2a642fd7387bab4aba064e0545bc68ac3"},
+    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c7fcc410e60c273a1dca4846a79d33e60ff537884263fa1909d157ce05d77bad"},
+    {file = "complexipy-5.4.0-pp38-pypy38_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2eb148e4825346d66ef1a619fb0fa2ca4e39e6aea50df7026c59067f99382841"},
+    {file = "complexipy-5.4.0-pp38-pypy38_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:42acff7817ee427588db6da95b247af7cf5d1441140beb3ffb8cdffb3e682509"},
+    {file = "complexipy-5.4.0-pp38-pypy38_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d7cba702265ca50f23c9852ed1e9aa70107f8fe5c6237530d6e29e7b1b7e4304"},
+    {file = "complexipy-5.4.0-pp38-pypy38_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:370c449cc37368565358e26b36a5dff65d841f9a0378aca8d28f43451ee3f18b"},
+    {file = "complexipy-5.4.0-pp39-pypy39_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9149f5d5df62729f1b6afc49704a853c056ad9454478bd7535917cb616598188"},
+    {file = "complexipy-5.4.0-pp39-pypy39_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:b718eec8847f2f67980fcf2e5c0678cae8ddd93a34f87d48fa1815446c8a0c97"},
+    {file = "complexipy-5.4.0-pp39-pypy39_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a745aeb6fe10210a596228ea833e2a8699e3c8fa783876f435ed0e82de1c6b01"},
+    {file = "complexipy-5.4.0-pp39-pypy39_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:adc93ff8c6e655b01c16465a59717a0e4130aa04446e584b4e6f216dcb754824"},
+    {file = "complexipy-5.4.0.tar.gz", hash = "sha256:eecfdf77821839c79c3853d0567235a7773e8037ed896a897487350251f68404"},
 ]
 
 [package.dependencies]
 tomli = ">=2.2.1"
 typer = ">=0.12.5"
-
-[package.extras]
-dev = ["ruff (>=0.9.0)", "ty (>=0.0.1a1)"]
 
 [[package]]
 name = "coverage"
@@ -815,75 +811,68 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "47.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main"]
 files = [
-    {file = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"},
-    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85"},
-    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e"},
-    {file = "cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457"},
-    {file = "cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"},
-    {file = "cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2"},
-    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e"},
-    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee"},
-    {file = "cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298"},
-    {file = "cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb"},
-    {file = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"},
-    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85"},
-    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e"},
-    {file = "cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246"},
-    {file = "cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4"},
-    {file = "cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"},
+    {file = "cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8"},
+    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318"},
+    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001"},
+    {file = "cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203"},
+    {file = "cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa"},
+    {file = "cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7"},
+    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52"},
+    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd"},
+    {file = "cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63"},
+    {file = "cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b"},
+    {file = "cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe"},
+    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31"},
+    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7"},
+    {file = "cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310"},
+    {file = "cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8"},
+    {file = "cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb"},
 ]
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
-docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
-nox = ["nox[uv] (>=2024.4.15)"]
-pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
-sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
-test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dbus-fast"
@@ -1152,14 +1141,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.49"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905"},
-    {file = "gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd"},
+    {file = "gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c"},
+    {file = "gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1"},
 ]
 
 [package.dependencies]
@@ -1819,14 +1808,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "docs", "test"]
 files = [
-    {file = "packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"},
-    {file = "packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"},
+    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
+    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
 
 [[package]]
@@ -1847,14 +1836,14 @@ lint = ["black"]
 
 [[package]]
 name = "pathspec"
-version = "1.1.0"
+version = "1.1.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
 groups = ["docs"]
 files = [
-    {file = "pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42"},
-    {file = "pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080"},
+    {file = "pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"},
+    {file = "pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"},
 ]
 
 [package.extras]
@@ -2756,13 +2745,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.5"
+version = "0.6.7"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_clearance-0.6.5-py3-none-any.whl", hash = "sha256:620d5a20aae27737af268510e7a0a2db842e59b6af2bd083d7b202aeed746932"},
+    {file = "terok_clearance-0.6.7-py3-none-any.whl", hash = "sha256:463dfaebfbb8408f4f9b1cb327edba0f5c75f16a0dfce8750ffe2c174724ee7f"},
 ]
 
 [package.dependencies]
@@ -2772,11 +2761,11 @@ pyyaml = ">=6.0,<7.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.5/terok_clearance-0.6.5-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.103"
+version = "0.0.105"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -2790,24 +2779,24 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.5/terok_clearance-0.6.5-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.33/terok_shield-0.6.33-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
 
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/codex-shared-oauth-vault"
-resolved_reference = "eb22e08bab11f9e61333afdcfe257d9d6b77ab1f"
+resolved_reference = "949d50e504e5cb1083b035ad50f28b56ea321bae"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.33"
+version = "0.6.35"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.33-py3-none-any.whl", hash = "sha256:37498a7911131065ed2474c3b69269a65e3402761df004cf770907913609660c"},
+    {file = "terok_shield-0.6.35-py3-none-any.whl", hash = "sha256:611c7756a54658131c172d115de9bc7f315320c7ee0dd223af1219acc27c4933"},
 ]
 
 [package.dependencies]
@@ -2816,7 +2805,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.33/terok_shield-0.6.33-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -2923,20 +2912,20 @@ telegram = ["requests"]
 
 [[package]]
 name = "typer"
-version = "0.24.2"
+version = "0.25.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8"},
-    {file = "typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480"},
+    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
+    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 click = ">=8.2.1"
-rich = ">=12.3.0"
+rich = ">=13.8.0"
 shellingham = ">=1.3.0"
 
 [[package]]
@@ -2986,14 +2975,14 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtualenv"
-version = "21.2.4"
+version = "21.3.0"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac"},
-    {file = "virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada"},
+    {file = "virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7"},
+    {file = "virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e"},
 ]
 
 [package.dependencies]
@@ -3059,14 +3048,14 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "wcwidth"
-version = "0.6.0"
+version = "0.7.0"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad"},
-    {file = "wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"},
+    {file = "wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2"},
+    {file = "wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2745,13 +2745,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.7"
+version = "0.6.8"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_clearance-0.6.7-py3-none-any.whl", hash = "sha256:463dfaebfbb8408f4f9b1cb327edba0f5c75f16a0dfce8750ffe2c174724ee7f"},
+    {file = "terok_clearance-0.6.8-py3-none-any.whl", hash = "sha256:e07f9683e7c6089591f254e9b01b121f71814681c383dfbd45f7d887540eff55"},
 ]
 
 [package.dependencies]
@@ -2761,17 +2761,18 @@ pyyaml = ">=6.0,<7.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.8/terok_clearance-0.6.8-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.105"
+version = "0.0.106"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.106-py3-none-any.whl", hash = "sha256:8d4ad1ce0986b8175df04fd8b30b00e4c582f3b76956d39f8dc16944fa126edd"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -2779,24 +2780,22 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.8/terok_clearance-0.6.8-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.36/terok_shield-0.6.36-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/codex-shared-oauth-vault"
-resolved_reference = "949d50e504e5cb1083b035ad50f28b56ea321bae"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.35"
+version = "0.6.36"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.35-py3-none-any.whl", hash = "sha256:611c7756a54658131c172d115de9bc7f315320c7ee0dd223af1219acc27c4933"},
+    {file = "terok_shield-0.6.36-py3-none-any.whl", hash = "sha256:21f86400ae9f2e333fb88a6da3d8c26d5a6efd3beb2596fcfb1cf28f8e1d86e3"},
 ]
 
 [package.dependencies]
@@ -2805,7 +2804,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.36/terok_shield-0.6.36-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -3204,4 +3203,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "9152d278f929b8a6d49390b590b367525340e9db5417fc90e4de540c028e19c9"
+content-hash = "17a8577630473c3dff411ab51316eaa4989a2bd52ffd95b091d234661873267d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2797,7 +2797,7 @@ terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/codex-shared-oauth-vault"
-resolved_reference = "394ba8c8f775d5db5fc245c97c93d68af21264b4"
+resolved_reference = "ca8fa65ea1e49365a2aa81ce304856e446b7f155"
 
 [[package]]
 name = "terok-shield"

--- a/poetry.lock
+++ b/poetry.lock
@@ -238,18 +238,19 @@ dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)"
 
 [[package]]
 name = "backrefs"
-version = "7.0"
+version = "6.2"
 description = "A wrapper around re and regex that adds additional back references."
 optional = false
-python-versions = ">=3.10"
+python-versions = ">=3.9"
 groups = ["docs"]
 files = [
-    {file = "backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9"},
-    {file = "backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475"},
-    {file = "backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12"},
-    {file = "backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a"},
-    {file = "backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9"},
-    {file = "backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82"},
+    {file = "backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8"},
+    {file = "backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be"},
+    {file = "backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90"},
+    {file = "backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b"},
+    {file = "backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7"},
+    {file = "backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7"},
+    {file = "backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49"},
 ]
 
 [package.extras]
@@ -589,106 +590,109 @@ markers = {dev = "platform_system == \"Windows\"", test = "sys_platform == \"win
 
 [[package]]
 name = "complexipy"
-version = "5.4.0"
+version = "5.3.0"
 description = "An extremely fast Python library to calculate the cognitive complexity of Python files, written in Rust."
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "complexipy-5.4.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:8e6e886ef933cc3ec2cef0f893282e31c33504792b4aee2441897e4a8b9c37f3"},
-    {file = "complexipy-5.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fc6fcd0dd983398f611bde1d108a998ce77238db2b977669d5d90557957bb582"},
-    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0253fae6f08a56e2d35564b0070d164fa5dde18c6e8927fb2fcda87e9448293"},
-    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:88b53ce470315438bced6338960ca28e6b1c0e7d1bc37f9efc9370c6dc4c0ff4"},
-    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:a4d34148bb62f2ef9cf196c405bda2046ad2c84ec52808879547f1eab2211452"},
-    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:cb485cd8b708bd4df837189282926c46c280f2ddd8470e9bbd0c8ffd7055a47a"},
-    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:e9c1850f475c6cd55ef17223dc26682ed37a9d4f5f7566d21598f0ce00b36ca1"},
-    {file = "complexipy-5.4.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7684fdb587b42e72e14fbe97c91b0e415ace0a3ee16a0451edd87ad524de5621"},
-    {file = "complexipy-5.4.0-cp310-cp310-win32.whl", hash = "sha256:a091ee0e37ecf263101cf4c0cd3ff77e80a73da01eff314d8f14ac1ed0f2365a"},
-    {file = "complexipy-5.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:4cdfdb00bd8e887fe2948a351b46d6a55a22645c1d3b5462089596a6427ae537"},
-    {file = "complexipy-5.4.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3fba640f0920fc130dcca0414e269624c15d676c2bb4a4e53352befcf01d5f43"},
-    {file = "complexipy-5.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8ca4f5c5d0c89e40bb4c19f0190a9ab4a1d5fe20b2c6fb10659795ccb19f967f"},
-    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9f7598dffe65271daa8f0ef82433ebd4224104650962dedbf5ed27ac1f1ea76f"},
-    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:0ab5c9e6cd1c5562cda89137ddc6d4960c5eac93310918658d35a592ff1fe3a9"},
-    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:860ed17eba40cda83b3685c8121844cb06e3cbbbcd90fe59f3d0200ada6ca636"},
-    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:07c71369e3eed0a675fede71ab0da91f1d3441a8070e51de28a9c2125070b872"},
-    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:bf9fff738f10b02fcbc5dea463e7f614384b8c1a8bb09775fb05a29e3f643ed5"},
-    {file = "complexipy-5.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4aeef65a8ce9cadc7343adeb3991026b2ac14fafef3f9c73ee25078a2b2607a1"},
-    {file = "complexipy-5.4.0-cp311-cp311-win32.whl", hash = "sha256:a476d0d00e5012c2713915d854474fc564bd142f97a464d235a6cff71b5b3501"},
-    {file = "complexipy-5.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:a22e6e20823ae0208451e6ed60e9230a0161c331db4d09c6c94ce4eb0a0b76fc"},
-    {file = "complexipy-5.4.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:e5ff5f785cf903dbf59121cd489c413901d79f19ccd43e4ca590501b14accdab"},
-    {file = "complexipy-5.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7bb23bd23bdebfc7193821dcfb53952eb46c07404c0d94d04944d69abb416c81"},
-    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee36d113becdbe44ee45183c0f8042aea6c81d1f9e78f843012afe2c962a2bf6"},
-    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:72f3fb62cde1feea36b7cf01bbbc7f83ac0de27e682152bdab2d7fa89a8cdb01"},
-    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b9cbe2477fbe259ad9bcf3ab4b1e4489afd10145aaf43c2ad1fd31ba9d5dc667"},
-    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:224f166699fd4d2044fb06ba0ac2de0c9961f76e5889ef4dc7b42863a302a3e6"},
-    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:00395ca31d033695d603e89f3707087badfa44b0b2316a58a3fca94fdedf3617"},
-    {file = "complexipy-5.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:48402ae78a0d328c29262bd5337833ae633be5e1679e3019ee508bab621bfc9f"},
-    {file = "complexipy-5.4.0-cp312-cp312-win32.whl", hash = "sha256:f8c9a1256534b180d4e7627fc534ff8a20a6e75989ea041f878b61bb1318f083"},
-    {file = "complexipy-5.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:3fb6757cef095d400dd374645d6c97c4041c0148a7c9042dd3d4ad50c0021d62"},
-    {file = "complexipy-5.4.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1d4e57e38d7f81b0859bbfea7b0811bb0278fac76ecbe5349db519ddcab1bcd2"},
-    {file = "complexipy-5.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b6506a346f76680e02707d7f8b15736262c80f75efc0f58b0b97475f130d389f"},
-    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:70c7da3dc24155059239837f13c2d22ec1cd7bb29a482b8db458e298e5c92e38"},
-    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:2776e41408dd6103edfe2427f80e01b3c5b5f23b37b203d1d6571242f275af7d"},
-    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:6ba5e652741801096f0b5b5a365d05f4268db1b6f26cdc91ad54844d03de980a"},
-    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bb7586443257586cc1ab1c524bb71d8553e7acee433d78b4c1b2f61825237272"},
-    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:96f92fea96b97726cbbcb2b7f5979ab4c8d3fcb351a4c08f9ec0d58e1aba0ef9"},
-    {file = "complexipy-5.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:037d9b14f9297e37f8a5752b3f0c26bb5ed70dd62b7b033f92ffe63e9dde423b"},
-    {file = "complexipy-5.4.0-cp313-cp313-win32.whl", hash = "sha256:48b0ae7706a6c54da8ebfe0453d3a4b962e1300cca5db28c1aa3575fd1a61df2"},
-    {file = "complexipy-5.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:8a97b47ff486a3607c1331540e8ea2b401babef1f95ec3dac079e17cc5e65505"},
-    {file = "complexipy-5.4.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d11519de249f0dae9e14eb12bfb32a41ce18720ca6506fdf23f8bbce3a300030"},
-    {file = "complexipy-5.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ef21d5fa4bfcd9851a300ff08f3eea85ddd21afda656ab74198d01c74913d33"},
-    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:488097d185265556e64fec3a31d334f684ec55304bbb2533bd5708b4add420dd"},
-    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:43dca0070306007915b3c022239031df652a2c64ae0d3ffa10ba034d40b96226"},
-    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1d8fb02e164264234e0d664d6d71d85a93706a77fdc54e603bc609a7fc9037d6"},
-    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:101938466d910088d81f5494637ed8da992c93f417a69defc1e07b09771c4c1d"},
-    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:bbaed28e0bbfe527df43534bf0ba67b1459c52b55a46c01b802f227427043760"},
-    {file = "complexipy-5.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5dc5d1db0c7d2befbf02e45a5ed2a64276c1ba4b710c1e86d031244eb33dea1c"},
-    {file = "complexipy-5.4.0-cp314-cp314-win32.whl", hash = "sha256:60cbcdd503e869fdf314db4594cd0220a0b5d6f0432c4fc4ed49f92e635917ff"},
-    {file = "complexipy-5.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:d2ef116c563e98b16c7494f6c8f1b2ddf47fcfc8f6665f7db98fc2b8b24087d2"},
-    {file = "complexipy-5.4.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:f384993042472948f7ba4b316cdfaf38fed607982d4afe772a228d10c4253b05"},
-    {file = "complexipy-5.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3f7c06ddd4898a9e4d5b53bd188b55c73992ba478f5e655b7751cd5abe7937e3"},
-    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b37a6bb0926381478a684564aee9952286c6c0b803bae7b1aafbf7c8ae4d77b"},
-    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:408ae0070d72d5505f12816080898e6a8359f4cacc43b12cdbe6b333bc14021c"},
-    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:7e55d83945369b8c13aa334e06061f15fa828a47bf54f5b2b0ea83d7c409d329"},
-    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:72a161b98d6427d02299c02ff64f8c210e099692ad15baefc22478953c66fef3"},
-    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:86129fdd22fb18cc2d2cf0e348b649703bb7a17f97288a4e876ceb319d773455"},
-    {file = "complexipy-5.4.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0cd515000632969bf489c7d931dcb5ca5ff70e42bea6c0405460e168789e4564"},
-    {file = "complexipy-5.4.0-cp38-cp38-win32.whl", hash = "sha256:c5100015a66f051af9a1c78ab19026b2fbbb843866504b2e3f3e033b64985f1b"},
-    {file = "complexipy-5.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:71e0b589788ea2f72a2dc7acbb949d089de4614ce1b6ebc5473ea94a0681f146"},
-    {file = "complexipy-5.4.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:57520d419b5ca616c22ee20bdaf8ff27f3fca358e122d2811f6da89517e567c7"},
-    {file = "complexipy-5.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a3c5f8c5d784af3806a65f120f29acdff3888e6223125d75e47a9a7bd35e46d1"},
-    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6547f1646d4a66c4faa25ab9445a4cc7afbc7bf5d2ba0ec3e9faf37c33affbfb"},
-    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:ae9913385f6bf59de63738fe3dee2c21508f7f1c7f4fba0c5911f3dc9bb8caa3"},
-    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0e26c79536b7181198d885f5f05bd741f08bd11e8afd694c4271a74b99b838bb"},
-    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d3fb8449ebf64d67a6ebfc452b263b053050c1b3a12fb07b068d4fc60cfd3f02"},
-    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c952ec52b6c71e582c834b7de3a44d7279a8992fd5740466350448e128b210d5"},
-    {file = "complexipy-5.4.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:92eaeb6e0a9b3602217eb773319bbfffda2eba07cd3344b7ff7d07e904d876af"},
-    {file = "complexipy-5.4.0-cp39-cp39-win32.whl", hash = "sha256:cbec33b155c2e8b2b205b4cf89059e87a1f3b5f995e2b087ccd088442b8bf5c7"},
-    {file = "complexipy-5.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:d8bfe9e34600c0d19184c273bfd89ce4adc405ace6f60d113e978d705749cfe4"},
-    {file = "complexipy-5.4.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:476f7d56eac53c056811d581e6583a69bd448f9ae6575f8c74c3f5cc2cc31fae"},
-    {file = "complexipy-5.4.0-pp310-pypy310_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:8a0679ecfa5bc30e18e297b33ecf77719e0dd3f3594d986402f849997f24a2c8"},
-    {file = "complexipy-5.4.0-pp310-pypy310_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:84224a066b73c782bd1fb030a6f04978a16c4eb62cca96092d07f3da4bef7699"},
-    {file = "complexipy-5.4.0-pp310-pypy310_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5d0abc858e6761e5cf452432e029700516b8ce6e0521b7f60d30cdbad446489f"},
-    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0052d64c42d56e64173f4c808c361e754a61ec09de6435d5e469bb0eaf191d4"},
-    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:9a94600c379712c72602180cc4694e2c8e5791e8538080d6bfffea45dc68d922"},
-    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:a76a94be193ad427f60ac985678b9bea8c34a34b023b0f8cbad37eec05975e22"},
-    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5ce1df8f659263ab23610af5d3e9ac9c18b665c5c852f2344645823f6d671ea1"},
-    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c7f2d6812adca07336febe69acb4eac2a642fd7387bab4aba064e0545bc68ac3"},
-    {file = "complexipy-5.4.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c7fcc410e60c273a1dca4846a79d33e60ff537884263fa1909d157ce05d77bad"},
-    {file = "complexipy-5.4.0-pp38-pypy38_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2eb148e4825346d66ef1a619fb0fa2ca4e39e6aea50df7026c59067f99382841"},
-    {file = "complexipy-5.4.0-pp38-pypy38_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:42acff7817ee427588db6da95b247af7cf5d1441140beb3ffb8cdffb3e682509"},
-    {file = "complexipy-5.4.0-pp38-pypy38_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d7cba702265ca50f23c9852ed1e9aa70107f8fe5c6237530d6e29e7b1b7e4304"},
-    {file = "complexipy-5.4.0-pp38-pypy38_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:370c449cc37368565358e26b36a5dff65d841f9a0378aca8d28f43451ee3f18b"},
-    {file = "complexipy-5.4.0-pp39-pypy39_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9149f5d5df62729f1b6afc49704a853c056ad9454478bd7535917cb616598188"},
-    {file = "complexipy-5.4.0-pp39-pypy39_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:b718eec8847f2f67980fcf2e5c0678cae8ddd93a34f87d48fa1815446c8a0c97"},
-    {file = "complexipy-5.4.0-pp39-pypy39_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a745aeb6fe10210a596228ea833e2a8699e3c8fa783876f435ed0e82de1c6b01"},
-    {file = "complexipy-5.4.0-pp39-pypy39_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:adc93ff8c6e655b01c16465a59717a0e4130aa04446e584b4e6f216dcb754824"},
-    {file = "complexipy-5.4.0.tar.gz", hash = "sha256:eecfdf77821839c79c3853d0567235a7773e8037ed896a897487350251f68404"},
+    {file = "complexipy-5.3.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:986e3833b622047caaff3d48e5726251f80c46fdfb50d8f3fec9fc5afa6daba5"},
+    {file = "complexipy-5.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2cb0d86be1fc5e7cb8a3b64721c3270b1eff59228dc5adae4734f351a976854d"},
+    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6fe1ce8804675b2b196091cf0779e0d1ca51058d71c1f15b4fb3a67cbcdf5bf6"},
+    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:c71058f43b6b48b50f1b835a97904bd15b0f82d4d3b1cc046a88fb166392eaa2"},
+    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ed84d9f8ebee3edd08a8d169594d19e36ff1e859eed4105d84d683010c463b0f"},
+    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:21e653cbe981b764d5a39a15def56f554b869974a0e6a3e9d7150b66d84a3514"},
+    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6d300e92712cf43c69bf7f361f35ce749803f0025bc9d7d0801547debf8022cc"},
+    {file = "complexipy-5.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:64331e481432b6cbea3856346d787453eae98586bc62efccfc30677e77b392a2"},
+    {file = "complexipy-5.3.0-cp310-cp310-win32.whl", hash = "sha256:e413bba9bf05ffd5f21d8cf0853e068d780f4bc45cb0fc3199d8a84782587d5d"},
+    {file = "complexipy-5.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:98d3f3fffb472ca39ecdfbe06bb853f30ab1f800ed82d6047eeb18f2167c2fdc"},
+    {file = "complexipy-5.3.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a5684388a2ac21997e669fd6664cb48d39dcf3699b79a59209c3b0283473f39f"},
+    {file = "complexipy-5.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a6bde4a3060818d267f1b12bff41fc8dd0f28175730e8899669373831a016353"},
+    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7dffd3c512ddba2259109a7ca8c79843dadd986755c8498b35a3e242eeeac0e8"},
+    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:7521d85dcfef17ca797b89508ba4db43d4f017d2389fa57bc144e5882e1b2c8a"},
+    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5ae64b84f0e9b83844c10a6fe5a0610348176560ed5a89e2b33ef0858f48b720"},
+    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f800807a050cbc37a12071bc8d86356a2c06a88285bf52e4be9f5116f4ab444"},
+    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:403902d32189102cfda5462884a302d847234b3267d14ab5ccc2f77160c37710"},
+    {file = "complexipy-5.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:033cc22618d958c123d62c377c953aef466a3e8774b595c6c8604678c6c3c114"},
+    {file = "complexipy-5.3.0-cp311-cp311-win32.whl", hash = "sha256:42931056b1f92364f859e2798c93e49c66976899af144fce74b2aebb8fa84079"},
+    {file = "complexipy-5.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:a7b2f0cdeb5fc3a395c7215d1d82f28e498bb154d8d95dbae05895fbf0d6fbde"},
+    {file = "complexipy-5.3.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:04d6137eff0a17e6fd352a6cdc7c7fb6fdf4200a9e6db3f627c60fe79b82cfe3"},
+    {file = "complexipy-5.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86680349d5f1f72b1e512bc045d3f7999941c8e7f5dfe235c308a0556265888c"},
+    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52f6fad6e998a3d6a03c737ed0a915565ce8f90c51921597e7156a717b65110d"},
+    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:a5bdd1ded9c83e0cc0f2d47c21e3066aa7443cce2d9b556d0915cb407ac26af3"},
+    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:474270be61ed0666e26b8b6f2c40b3b131ef3baf647a290641e894c9f24062aa"},
+    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a93322f7350f8ac514384986794309e2f13d4593b6ac579c31d3ef257190e3f0"},
+    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c0834678ed93729d72bfd9be72e19abf38cce5094ef18fb66a7ed64c6eb05be2"},
+    {file = "complexipy-5.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80cc9cefca8c8cecc75096f2a9b207f050d009f2dee5c32d909c1db7a60db747"},
+    {file = "complexipy-5.3.0-cp312-cp312-win32.whl", hash = "sha256:8b1a0f88cfc0214e4c7dbd328c92d79046e4be64f8f58eaecfd3fc59d567de12"},
+    {file = "complexipy-5.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:6415b99c675115f4ef24136c9b5baed06c61e0b6416620d012baa7cad33419f0"},
+    {file = "complexipy-5.3.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ea9b82c62b872079ad61f643b1ef2459e4008285d95b1671b2e36167f5c255f7"},
+    {file = "complexipy-5.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb55e0e5a15d63869af7bbbe51cc92e2432233d571b1d1089bb15e3b50f0bb62"},
+    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dc3099aebe6f885cfbc73229c3f137f5491abe355c74a300616cb6537c2a14dc"},
+    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:b2a4c31158f1f31d3c059384878adfd2edcebe2037de36125e14101a3316d110"},
+    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5a679dd88e03c36a003190e912d0cf953c767cf01dc6669b05f4941aad5fdab6"},
+    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:13c7cb4ce9946504539d77c718772331056b5ab11e9b1a3e791e79f43dee9208"},
+    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:297fa947410db3dde3e5770d06148509b560992b251a1bbce7035505dcafe8b8"},
+    {file = "complexipy-5.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c5a1966bd608515064e6e5ef63713bafe222561858549c0cb286518b99ded510"},
+    {file = "complexipy-5.3.0-cp313-cp313-win32.whl", hash = "sha256:347f1570feaff948085dcb6eb2af4b97ff6c724cc2ee70e7a91a340ae2941c0f"},
+    {file = "complexipy-5.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:34789f2c9b64ccc2c03efb61ad6c96f3b3a53cbb472caf8c389bbca3067db4c3"},
+    {file = "complexipy-5.3.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:76c57b535e09546898aa560347f489e596b721c26bd748fe12a882f22c8c5804"},
+    {file = "complexipy-5.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0bcdbe80efaa6d9ef5d25358bf78862fc905e1e9b1bcab2763b208c1e1b135c9"},
+    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:833bf17a31eddd5c694b84a571f04a9c07c226474cbeefd23e832d34e93877dd"},
+    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:3b5076647fdd18f26a832e831e85946f65cb665832c0498ea4a0be1b9b0659ac"},
+    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:508d4eabf52061b3877e0ec67937db34f7414b20ddb67dcf1a43aba3d090f5cc"},
+    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:07654b531e49ae6788e276c5b7f26c5cbd8e785b788b4ec2af00c48f38ba46b5"},
+    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a6d30def78c5ccf64edb006e1185afd07e9504ed04aee850941acd86a73bc7fe"},
+    {file = "complexipy-5.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e651e094e09c0b3b66bb320a4091177febd59cb7326c06a442c161e2d90c0f9c"},
+    {file = "complexipy-5.3.0-cp314-cp314-win32.whl", hash = "sha256:f1596e5e535c278ea3308f98e033ec99110f80b44db3251f4992d6e5f9f5c402"},
+    {file = "complexipy-5.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:f5daedb399a678ac176e31cc0b7a2b399a5382c3fe4924ff89d3c052af6a25a2"},
+    {file = "complexipy-5.3.0-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:14a968ededbde743807456e893dfde913de56e0dbe0d712f91a0a0ae6f0d1afc"},
+    {file = "complexipy-5.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:dfbead9b18109a51f7cf65da4e78845d6e01e52efc4ee7bee21dc73c7ca18a90"},
+    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:00652681e8eff1ce5742680834d2f995f84594cb0a3d8baf1b7113d492a6d58b"},
+    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:7f1687b87df9d7a828b190fdc98053e171a28775812799d675d8e947984a334f"},
+    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4d1498e078f586fa0ed4b9225669bf298ed639514439e27f4a343a43986250d7"},
+    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1814b5210004b46a94148e89b0e4d8e7ae07adf7f94986b0b0c459ca6034d70d"},
+    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:0d83980281854b19388104e7999b1888f7e6f94e8af5aea6c56c65882cc12967"},
+    {file = "complexipy-5.3.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c4d6c5d469f91aa729049e51ebdd06813c084b364ac2d225bc07dc278cf10090"},
+    {file = "complexipy-5.3.0-cp38-cp38-win32.whl", hash = "sha256:a19fa14a2d1c859608bd5aab738c13fe750c1432b9a9f196f64dc4f1877fa0d6"},
+    {file = "complexipy-5.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:29d6c2da75719907add67f7136afbbc292e800ef828f9982dbdc9b3db2ca80fd"},
+    {file = "complexipy-5.3.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:1863284380f236282eff90fa598751580b1b8fd98b859628e571f8dd63bceca5"},
+    {file = "complexipy-5.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:abd0d4ad0d79367d617e34bd450215ba9dd2427b275dbbdf65f1535251be8aa7"},
+    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b80b83ce06dbe80ac9004cd3c946d2393224e158d23919287b2e4845d135f3fe"},
+    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:1c04a72464c0496f7bc6a770276336ab2bb3f2a05dd0b0a7915ea198626e87d2"},
+    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:682d28e04fbb0b89d06972b2752c16e4722dbe1fa22fb832b8af2d3d0acad54e"},
+    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93a8facd860583fa7cf7e559e9037da92de68c7aefb589e9f8d10a97e49cb2c"},
+    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2f711c40c775712541d3d32aaa7f679cb282970669835b6aa35727113deb77e0"},
+    {file = "complexipy-5.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a555d349940dbca7f4c5b73b135e95a0ee3fbff20fdca8425967806330aa53c"},
+    {file = "complexipy-5.3.0-cp39-cp39-win32.whl", hash = "sha256:866190715b4b60c079951d4aa3d9d549bd3f71b458d0054947650624e16d14fe"},
+    {file = "complexipy-5.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:2224fcdb5f5763831fde2af360c92965506d41518fa9f34c90b397ede51a11d6"},
+    {file = "complexipy-5.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08d4c8f45173bbbeff81d36ed9f637bb8084bc9df2eff58e81f7a6d99bd8ffe8"},
+    {file = "complexipy-5.3.0-pp310-pypy310_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:4d318b2ae1ae0ab69356ee42c3c5010d6e143aa7602e8e5719d41ebce8fac09e"},
+    {file = "complexipy-5.3.0-pp310-pypy310_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3456c3c86b677d3c460e11b9bd23526454eefc2c53b0c3650aa2fc7ba0dd2262"},
+    {file = "complexipy-5.3.0-pp310-pypy310_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:ba77e7ef31ee2c44dac896e1ce4180d046839f2bc22da653c556e82726564537"},
+    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d03454a9bd650ed56dc694a8cb985b020ff792ca5be6208f5bc7c9861bfe3521"},
+    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:91e9bedd18d693cc4e5482e76a52a53298e831020eb6fdb4084b89d5547df78f"},
+    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:15b7c1f60c4ec73f4fa180a5e1ebd2b2db1aa16b2de2612cf2313b97396552c9"},
+    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6ee0dc76a30a282ee1869723abdefbca9c8c1c94b3088ed50ab2b109d7019b4e"},
+    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:46622e5bd80e0aaa1ca9bd333f7cc71d03007d71fb7016ea2a68b404b9c8e3d7"},
+    {file = "complexipy-5.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7e24f151789ee320fff80cca1ccbde9ff3905ef4a88a3dbcbc83d29545c4c232"},
+    {file = "complexipy-5.3.0-pp38-pypy38_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:54746ed1a45c973ceb409da7c08010d9df9bdb31dd5b8e271d26508a8fc50070"},
+    {file = "complexipy-5.3.0-pp38-pypy38_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:4db8097654674811ca57bc647cfb1e1161b6877db75eab8a336747fb826249ad"},
+    {file = "complexipy-5.3.0-pp38-pypy38_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:8174c2854d5a8e77ac97f656b503ffbd9a04c3f388a1136dbafd5f7582ac064a"},
+    {file = "complexipy-5.3.0-pp38-pypy38_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:58e6d3b8990b460316d522075209f4cab5afbc0ba7d2338f7b62a588b6b8a186"},
+    {file = "complexipy-5.3.0-pp39-pypy39_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:11c9e44a7a9603e7d83345220f363fc298a5bfddf3e479279a352494ba360dbc"},
+    {file = "complexipy-5.3.0-pp39-pypy39_pp73-manylinux2014_armv7l.manylinux_2_17_armv7l.whl", hash = "sha256:41b663586702b04e3c1fdb23717b94c3dcf41f1ee48457ae1e886978a0850a6d"},
+    {file = "complexipy-5.3.0-pp39-pypy39_pp73-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e104096a676d753f17fe0b0b588158386afb609f2ce25f4d96627791334d8c2"},
+    {file = "complexipy-5.3.0-pp39-pypy39_pp73-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dbd66d11cc04398ff09e6c9694d820c0824221c0ddee70897ba1bc2aa1f924f5"},
+    {file = "complexipy-5.3.0.tar.gz", hash = "sha256:b60b60c24b5f4e4eca1dd18f145f41f428c607c40477305b4f8302726b3e1eb6"},
 ]
 
 [package.dependencies]
 tomli = ">=2.2.1"
 typer = ">=0.12.5"
+
+[package.extras]
+dev = ["ruff (>=0.9.0)", "ty (>=0.0.1a1)"]
 
 [[package]]
 name = "coverage"
@@ -811,68 +815,75 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "47.0.0"
+version = "46.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main"]
 files = [
-    {file = "cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8"},
-    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318"},
-    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001"},
-    {file = "cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203"},
-    {file = "cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa"},
-    {file = "cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7"},
-    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52"},
-    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd"},
-    {file = "cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63"},
-    {file = "cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b"},
-    {file = "cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe"},
-    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31"},
-    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7"},
-    {file = "cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310"},
-    {file = "cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8"},
-    {file = "cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb"},
+    {file = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e"},
+    {file = "cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457"},
+    {file = "cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"},
+    {file = "cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb"},
+    {file = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e"},
+    {file = "cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246"},
+    {file = "cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4"},
+    {file = "cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"},
 ]
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
 
 [package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox[uv] (>=2024.4.15)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
+sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dbus-fast"
@@ -1141,14 +1152,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.49"
+version = "3.1.47"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c"},
-    {file = "gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1"},
+    {file = "gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905"},
+    {file = "gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd"},
 ]
 
 [package.dependencies]
@@ -1808,14 +1819,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "26.1"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "docs", "test"]
 files = [
-    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
-    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
+    {file = "packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"},
+    {file = "packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"},
 ]
 
 [[package]]
@@ -1836,14 +1847,14 @@ lint = ["black"]
 
 [[package]]
 name = "pathspec"
-version = "1.1.1"
+version = "1.1.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
 groups = ["docs"]
 files = [
-    {file = "pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"},
-    {file = "pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"},
+    {file = "pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42"},
+    {file = "pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080"},
 ]
 
 [package.extras]
@@ -2745,13 +2756,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.7"
+version = "0.6.5"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_clearance-0.6.7-py3-none-any.whl", hash = "sha256:463dfaebfbb8408f4f9b1cb327edba0f5c75f16a0dfce8750ffe2c174724ee7f"},
+    {file = "terok_clearance-0.6.5-py3-none-any.whl", hash = "sha256:620d5a20aae27737af268510e7a0a2db842e59b6af2bd083d7b202aeed746932"},
 ]
 
 [package.dependencies]
@@ -2761,18 +2772,17 @@ pyyaml = ">=6.0,<7.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.5/terok_clearance-0.6.5-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.105"
+version = "0.0.103"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.105-py3-none-any.whl", hash = "sha256:ae5e855d7f6a55d2d51090ef86d64858f79c26a4132b0768402166ed96c5b447"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -2780,22 +2790,24 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.5/terok_clearance-0.6.5-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.33/terok_shield-0.6.33-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/codex-shared-oauth-vault"
+resolved_reference = "394ba8c8f775d5db5fc245c97c93d68af21264b4"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.35"
+version = "0.6.33"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.35-py3-none-any.whl", hash = "sha256:611c7756a54658131c172d115de9bc7f315320c7ee0dd223af1219acc27c4933"},
+    {file = "terok_shield-0.6.33-py3-none-any.whl", hash = "sha256:37498a7911131065ed2474c3b69269a65e3402761df004cf770907913609660c"},
 ]
 
 [package.dependencies]
@@ -2804,7 +2816,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.33/terok_shield-0.6.33-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -2911,20 +2923,20 @@ telegram = ["requests"]
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.24.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
-    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
+    {file = "typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8"},
+    {file = "typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 click = ">=8.2.1"
-rich = ">=13.8.0"
+rich = ">=12.3.0"
 shellingham = ">=1.3.0"
 
 [[package]]
@@ -2974,14 +2986,14 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtualenv"
-version = "21.3.0"
+version = "21.2.4"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7"},
-    {file = "virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e"},
+    {file = "virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac"},
+    {file = "virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada"},
 ]
 
 [package.dependencies]
@@ -3203,4 +3215,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "6df78b4d5d4d234a6bf778a8b80514b31d76f2ce711d179b7972d3b8e3bea6dd"
+content-hash = "9152d278f929b8a6d49390b590b367525340e9db5417fc90e4de540c028e19c9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.126"
+version = "0.0.127"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ python = ">=3.12,<4.0"
 # DEV-TIME BRANCH PIN — tracks the sandbox branch for the shared Codex
 # vaulted-OAuth fix until that PR lands and a wheel ships.  The release
 # chain flips this back to a wheel URL.
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/codex-shared-oauth-vault"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,15 +24,10 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-# DEV-TIME BRANCH PIN — tracks terok-sandbox's feat/drop-bridge-phase,
-# which deletes the bridge install phase + PodmanInspector now that
-# the shield reader resolves the orchestrator dossier at emit time.
-# Executor and terok must agree on the same sandbox tip during the
-# in-flight dossier-in-events chain (a wheel URL pin here would
-# otherwise conflict with terok's git pin on the branch).  Release
-# script flips back to the wheel URL when the next sandbox release
-# ships.
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"}
+# DEV-TIME BRANCH PIN — tracks the sandbox branch for the shared Codex
+# vaulted-OAuth fix until that PR lands and a wheel ships.  The release
+# chain flips this back to a wheel URL.
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/codex-shared-oauth-vault"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -125,6 +125,14 @@ class ContainerEnvSpec:
     """When ``True``, scan shared mounts for real credential files and emit
     warnings.  Standalone mode defaults to off; terok enables this."""
 
+    enabled_vault_patch_providers: frozenset[str] | None = None
+    """Provider subset whose shared config patches should be applied.
+
+    ``None`` means "all providers with patches".  An empty set disables
+    vault config patching entirely.  terok uses this to gate experimental
+    OAuth routing without affecting standalone executor defaults.
+    """
+
     # -- Permissions -------------------------------------------------------
 
     unrestricted: bool = True
@@ -272,7 +280,11 @@ def assemble_container_env(
     #     tier 3) are safe because they have no shared_config_patch.
     from terok_executor.credentials.vault_config import apply_shared_config_patches
 
-    apply_shared_config_patches(roster, mounts_base)
+    apply_shared_config_patches(
+        roster,
+        mounts_base,
+        providers=spec.enabled_vault_patch_providers,
+    )
 
     # 9. Vault
     if not caller_manages_vault:

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -133,6 +133,10 @@ class ContainerEnvSpec:
     OAuth routing without affecting standalone executor defaults.
     """
 
+    disabled_vault_patch_providers: frozenset[str] | None = None
+    """Provider subset whose previously managed config patch values should
+    be removed if still owned by terok.  ``None`` removes nothing."""
+
     # -- Permissions -------------------------------------------------------
 
     unrestricted: bool = True
@@ -284,6 +288,7 @@ def assemble_container_env(
         roster,
         mounts_base,
         providers=spec.enabled_vault_patch_providers,
+        disabled_providers=spec.disabled_vault_patch_providers,
     )
 
     # 9. Vault

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -459,7 +459,7 @@ def _claude_oauth_mount_writer(
             raise FileNotFoundError(f"No .credentials.json in {auth_dir}")
         dest_dir = mounts_base / "_claude-config"
         dest_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dest_dir / ".credentials.json")
+        _write_bytes_nofollow(dest_dir / ".credentials.json", src.read_bytes())
         print("Real .credentials.json copied to shared Claude config mount.")
         print(
             "\nNote: Claude OAuth token is EXPOSED in the shared mount."
@@ -502,7 +502,7 @@ def _codex_oauth_mount_writer(
         src = auth_dir / "auth.json"
         if not src.is_file():
             raise FileNotFoundError(f"No auth.json in {auth_dir}")
-        shutil.copy2(src, dest_file)
+        _write_bytes_nofollow(dest_file, src.read_bytes())
         print("Real auth.json copied to shared Codex config mount.")
         print(
             "\nNote: Codex OAuth token is EXPOSED in the shared mount."
@@ -539,11 +539,9 @@ def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
     """Write a shared synthetic ``auth.json`` without real bearer tokens.
 
     Codex's ``TokenData`` serde contract (codex-rs/login/src/token_data.rs)
-    requires ``id_token`` to be a parseable JWT string.  Codex reads a
-    small subset of claims from it (plan tier, workspace id, email) but
-    does not verify the signature.  We therefore synthesize a minimal JWT
-    that preserves those non-secret claims while dropping the original
-    opaque token body entirely.
+    requires ``id_token`` to be a parseable JWT string.  We synthesize a
+    minimal JWT that preserves non-PII account metadata while dropping the
+    original opaque token body entirely.
 
     The access/refresh tokens are the actual bearer secrets; both are
     replaced with the Codex-specific shared vault marker.  Inference
@@ -565,7 +563,7 @@ def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
         "tokens": tokens,
         "last_refresh": _CODEX_PHANTOM_LAST_REFRESH,
     }
-    dest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    _write_bytes_nofollow(dest, (json.dumps(payload, indent=2) + "\n").encode("utf-8"))
 
 
 def _build_codex_shared_id_token(raw_jwt: str) -> str:
@@ -588,18 +586,9 @@ def _build_codex_shared_id_token(raw_jwt: str) -> str:
         return parsed if isinstance(parsed, dict) else {}
 
     payload = _jwt_payload(raw_jwt)
-    profile = payload.get("https://api.openai.com/profile")
     auth = payload.get("https://api.openai.com/auth")
 
-    email = payload.get("email")
-    if not email and isinstance(profile, dict):
-        email = profile.get("email")
-
     safe_payload: dict[str, object] = {"exp": 253402300799}
-    if email:
-        safe_payload["email"] = email
-        safe_payload["https://api.openai.com/profile"] = {"email": email}
-
     if isinstance(auth, dict):
         safe_auth = {
             key: auth[key]
@@ -616,6 +605,29 @@ def _build_codex_shared_id_token(raw_jwt: str) -> str:
             safe_payload["https://api.openai.com/auth"] = safe_auth
 
     return ".".join((_b64url({"alg": "none", "typ": "JWT"}), _b64url(safe_payload), "terok"))
+
+
+def _write_bytes_nofollow(path: Path, data: bytes) -> None:
+    """Atomically write *data* without following a pre-existing target symlink."""
+    import os
+    import uuid
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(tmp, flags, 0o600)
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
 
 
 #: Maps provider name → post-capture mount reconciler.  OAuth-capable
@@ -654,8 +666,9 @@ def _write_claude_credentials_file(cred_data: dict, mounts_base: Path) -> None:
             "rateLimitTier": cred_data.get("rate_limit_tier"),
         }
     }
-    (claude_dir / ".credentials.json").write_text(
-        json.dumps(creds, indent=2) + "\n", encoding="utf-8"
+    _write_bytes_nofollow(
+        claude_dir / ".credentials.json",
+        (json.dumps(creds, indent=2) + "\n").encode("utf-8"),
     )
 
 
@@ -701,7 +714,7 @@ def _apply_post_capture_state(
             continue  # already up to date
 
         state.update(patch)
-        path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+        _write_bytes_nofollow(path, (json.dumps(state, indent=2) + "\n").encode("utf-8"))
 
 
 def _api_key_command(cfg: AuthKeyConfig) -> list[str]:

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -26,7 +26,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from terok_sandbox import PHANTOM_CREDENTIALS_MARKER
+from terok_sandbox import CODEX_SHARED_OAUTH_MARKER, PHANTOM_CREDENTIALS_MARKER
 
 from terok_executor._util import podman_userns_args
 
@@ -486,14 +486,14 @@ def _codex_oauth_mount_writer(
     - **Exposed** (``expose_token=True``): copy the real ``auth.json``
       verbatim so the in-container Codex reads the live OAuth token
       (tier 3, unsafe — every task container can read it).
-    - **Default**: drop a phantom ``auth.json`` — the real ``id_token``
-      JWT (for plan-tier + workspace UI, public claims only) and
-      ``account_id`` survive, but ``access_token`` and ``refresh_token``
-      are replaced with `PHANTOM_CREDENTIALS_MARKER`.  The vault
-      translates the marker back to the real token on inference
-      requests; the CLI itself never sees the live bearer.  This is the
-      fallback for tier 2 (proxied) and also a no-harm default for
-      tier 1 (vault stores creds but nothing wires the proxy yet).
+    - **Default**: drop a shared synthetic ``auth.json`` — the real
+      ``id_token`` JWT (for plan-tier + workspace UI, public claims only)
+      and ``account_id`` survive, but ``access_token`` and ``refresh_token``
+      are replaced with `CODEX_SHARED_OAUTH_MARKER`.  The vault translates
+      the marker back to the real token on inference requests; the CLI
+      itself never sees the live bearer.  This is the fallback for tier 2
+      (proxied) and also a no-harm default for tier 1 (vault stores creds
+      but nothing wires the proxy yet).
     """
     dest_dir = mounts_base / "_codex-config"
     dest_file = dest_dir / "auth.json"
@@ -515,8 +515,10 @@ def _codex_oauth_mount_writer(
         print(
             "\nNote: Codex OAuth credential is shared across all task containers."
             "\n      API calls are routed through the vault — the real"
-            "\n      access/refresh tokens stay on the host.  Enable"
-            "\n      agent.codex.allow_oauth to wire the proxy routing."
+            "\n      OAuth tokens stay on the host.  Standalone executor"
+            "\n      uses the shared Codex config rewrite directly;"
+            "\n      terok project mode gates that rewrite via"
+            "\n      agent.codex.allow_oauth."
         )
 
 
@@ -534,22 +536,25 @@ _CODEX_PHANTOM_LAST_REFRESH = "9999-01-01T00:00:00Z"
 
 
 def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
-    """Write a phantom ``auth.json`` preserving public id_token claims only.
+    """Write a shared synthetic ``auth.json`` without real bearer tokens.
 
     Codex's ``TokenData`` serde contract (codex-rs/login/src/token_data.rs)
-    requires ``id_token`` to be a parseable JWT string — the CLI base64-
-    decodes it to read workspace/plan claims but never verifies the
-    signature, so the real id_token rides into the container unchanged.
-    The access/refresh tokens are the bearer secrets; both are replaced
-    with the vault's phantom marker — inference rides through the vault,
-    which substitutes the live access token.
+    requires ``id_token`` to be a parseable JWT string.  Codex reads a
+    small subset of claims from it (plan tier, workspace id, email) but
+    does not verify the signature.  We therefore synthesize a minimal JWT
+    that preserves those non-secret claims while dropping the original
+    opaque token body entirely.
+
+    The access/refresh tokens are the actual bearer secrets; both are
+    replaced with the Codex-specific shared vault marker.  Inference
+    rides through the vault, which substitutes the live access token.
     """
     import json
 
     tokens: dict = {
-        "id_token": cred_data.get("id_token", ""),
-        "access_token": PHANTOM_CREDENTIALS_MARKER,
-        "refresh_token": PHANTOM_CREDENTIALS_MARKER,
+        "id_token": _build_codex_shared_id_token(cred_data.get("id_token", "")),
+        "access_token": CODEX_SHARED_OAUTH_MARKER,
+        "refresh_token": CODEX_SHARED_OAUTH_MARKER,
     }
     account_id = cred_data.get("account_id")
     if account_id:
@@ -561,6 +566,56 @@ def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
         "last_refresh": _CODEX_PHANTOM_LAST_REFRESH,
     }
     dest.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _build_codex_shared_id_token(raw_jwt: str) -> str:
+    """Return a synthetic JWT with only the Codex-local claims we need."""
+    import base64
+    import json
+
+    def _b64url(data: dict) -> str:
+        encoded = json.dumps(data, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return base64.urlsafe_b64encode(encoded).decode("ascii").rstrip("=")
+
+    def _jwt_payload(token: str) -> dict:
+        try:
+            _header, payload, _sig = token.split(".", 2)
+            padded = payload + "=" * (-len(payload) % 4)
+            decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+            parsed = json.loads(decoded)
+        except (ValueError, json.JSONDecodeError, UnicodeDecodeError, base64.binascii.Error):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+    payload = _jwt_payload(raw_jwt)
+    profile = payload.get("https://api.openai.com/profile")
+    auth = payload.get("https://api.openai.com/auth")
+
+    email = payload.get("email")
+    if not email and isinstance(profile, dict):
+        email = profile.get("email")
+
+    safe_payload: dict[str, object] = {"exp": 253402300799}
+    if email:
+        safe_payload["email"] = email
+        safe_payload["https://api.openai.com/profile"] = {"email": email}
+
+    if isinstance(auth, dict):
+        safe_auth = {
+            key: auth[key]
+            for key in (
+                "chatgpt_plan_type",
+                "chatgpt_user_id",
+                "user_id",
+                "chatgpt_account_id",
+                "chatgpt_account_is_fedramp",
+            )
+            if key in auth
+        }
+        if safe_auth:
+            safe_payload["https://api.openai.com/auth"] = safe_auth
+
+    return ".".join((_b64url({"alg": "none", "typ": "JWT"}), _b64url(safe_payload), "terok"))
 
 
 #: Maps provider name → post-capture mount reconciler.  OAuth-capable

--- a/src/terok_executor/credentials/extractors.py
+++ b/src/terok_executor/credentials/extractors.py
@@ -77,10 +77,10 @@ def extract_claude_oauth(base_dir: Path) -> dict:
 def extract_codex_oauth(base_dir: Path) -> dict:
     """Extract Codex (OpenAI) OAuth tokens from ``auth.json``.
 
-    Also preserves the ``id_token`` JWT and ``account_id`` when present —
-    the phantom auth.json the proxied tier writes into task containers
-    needs to carry the real id_token so Codex's plan-tier and workspace
-    UI keeps working without leaking the access/refresh tokens.
+    Also preserves the source ``id_token`` JWT and ``account_id`` when
+    present — the shared synthetic auth.json writer derives a safe
+    claim-only JWT from it so Codex's plan-tier and workspace UI keeps
+    working without leaking the real OAuth tokens.
     """
     cred_file = base_dir / "auth.json"
     data = _try_read_json(cred_file)

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -94,6 +94,7 @@ def _is_injected_codex_auth_file(path: Path) -> bool:
         return (
             tokens.get("access_token") == CODEX_SHARED_OAUTH_MARKER
             and tokens.get("refresh_token") == CODEX_SHARED_OAUTH_MARKER
+            and not data.get("OPENAI_API_KEY")
         )
     except (json.JSONDecodeError, OSError, ValueError):
         return False

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -66,6 +66,8 @@ def _is_injected_credentials_file(path: Path) -> bool:
 
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return False
         oauth = data.get("claudeAiOauth", {})
         if not isinstance(oauth, dict):
             return False
@@ -84,6 +86,8 @@ def _is_injected_codex_auth_file(path: Path) -> bool:
 
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return False
         tokens = data.get("tokens", {})
         if not isinstance(tokens, dict):
             return False

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -20,16 +20,21 @@ if TYPE_CHECKING:
     from terok_sandbox import SandboxConfig
 
 
+def _ensure_routes(cfg: SandboxConfig | None = None) -> Path:
+    """Generate routes.json from the YAML agent roster."""
+    from terok_executor.roster.loader import ensure_vault_routes
+
+    return ensure_vault_routes(cfg=cfg)
+
+
 def _handle_start(*, cfg: SandboxConfig | None = None) -> None:
     """Generate routes and start the vault daemon."""
     from terok_sandbox import is_vault_running, start_vault
 
-    from terok_executor.roster.loader import ensure_vault_routes
-
     if is_vault_running(cfg=cfg):
         print("Vault is already running.")
         sys.exit(1)
-    ensure_vault_routes(cfg=cfg)
+    _ensure_routes(cfg=cfg)
     start_vault(cfg=cfg)
     print("Vault started.")
 
@@ -71,6 +76,25 @@ def _is_injected_credentials_file(path: Path) -> bool:
         return False
 
 
+def _is_injected_codex_auth_file(path: Path) -> bool:
+    """Check whether *path* is a terok-injected shared Codex ``auth.json``."""
+    import json
+
+    from terok_sandbox import CODEX_SHARED_OAUTH_MARKER
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        tokens = data.get("tokens", {})
+        if not isinstance(tokens, dict):
+            return False
+        return (
+            tokens.get("access_token") == CODEX_SHARED_OAUTH_MARKER
+            and tokens.get("refresh_token") == CODEX_SHARED_OAUTH_MARKER
+        )
+    except (json.JSONDecodeError, OSError, ValueError):
+        return False
+
+
 def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     """Return ``(provider, host_path)`` for credential files found in shared mounts.
 
@@ -107,7 +131,9 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
             # Ensure resolved path stays within the mounts base
             if base_resolved not in path.resolve(strict=True).parents:
                 continue
-            if st.st_size > 0 and not _is_injected_credentials_file(path):
+            if st.st_size > 0 and not (
+                _is_injected_credentials_file(path) or _is_injected_codex_auth_file(path)
+            ):
                 leaked.append((name, path))
         except (OSError, TypeError):
             continue
@@ -171,9 +197,7 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
 
 def _handle_install(*, cfg: SandboxConfig | None = None) -> None:
     """Generate routes and install systemd socket activation."""
-    from terok_sandbox import VaultManager, is_vault_systemd_available
-
-    from terok_executor.roster.loader import ensure_vault_routes
+    from terok_sandbox import install_vault_systemd, is_vault_systemd_available
 
     if not is_vault_systemd_available():
         print(
@@ -181,27 +205,25 @@ def _handle_install(*, cfg: SandboxConfig | None = None) -> None:
             "Use 'start' to run the vault without systemd."
         )
         sys.exit(1)
-    ensure_vault_routes(cfg=cfg)
-    VaultManager(cfg).install_systemd_units()
+    _ensure_routes(cfg=cfg)
+    install_vault_systemd(cfg=cfg)
     print("Vault installed via systemd socket activation.")
 
 
 def _handle_uninstall(*, cfg: SandboxConfig | None = None) -> None:
     """Remove vault systemd units."""
-    from terok_sandbox import VaultManager, is_vault_systemd_available
+    from terok_sandbox import is_vault_systemd_available, uninstall_vault_systemd
 
     if not is_vault_systemd_available():
         print("Error: systemd user services are not available. Nothing to uninstall.")
         sys.exit(1)
-    VaultManager(cfg).uninstall_systemd_units()
+    uninstall_vault_systemd(cfg=cfg)
     print("Vault systemd units removed.")
 
 
 def _handle_routes(*, cfg: SandboxConfig | None = None) -> None:
     """Regenerate routes.json from the YAML agent roster."""
-    from terok_executor.roster.loader import ensure_vault_routes
-
-    path = ensure_vault_routes(cfg=cfg)
+    path = _ensure_routes(cfg=cfg)
     if path:
         print(f"Routes written to {path}")
 

--- a/src/terok_executor/credentials/vault_config.py
+++ b/src/terok_executor/credentials/vault_config.py
@@ -87,18 +87,31 @@ def write_vault_config(provider_name: str) -> None:
 
     if "yaml_set" in patch:
         _apply_yaml_patch(config_path, patch, location)
-    elif "toml_table" in patch:
+    elif "toml_set" in patch:
         _apply_toml_patch(config_path, patch, location)
 
     print(f"Vault config written to {config_path}")
 
 
-def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
-    """Re-apply every ``shared_config_patch`` for the whole roster.
+def apply_shared_config_patches(
+    roster: AgentRoster,
+    mounts_base: Path,
+    *,
+    providers: frozenset[str] | None = None,
+) -> None:
+    """Re-apply ``shared_config_patch`` for the selected providers.
 
     Called during task start so shared mount directories (which may have
     been recreated empty) always contain the correct vault addresses.
     Idempotent: safe to call on every launch.
+
+    Args:
+        roster: Loaded agent roster.
+        mounts_base: Shared config mount root.
+        providers:
+            ``None`` means "all providers with a patch".  An empty set
+            disables patching entirely.  A non-empty set restricts
+            patching to that provider subset.
 
     Raises [`ConfigPatchError`][terok_executor.credentials.vault_config.ConfigPatchError] on failure — callers must not start
     the container if vault routing cannot be established.
@@ -106,6 +119,8 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
     location = resolve_vault_location()
 
     for name, route in roster.vault_routes.items():
+        if providers is not None and name not in providers:
+            continue
         if not route.shared_config_patch:
             continue
         auth_info = roster.auth_providers.get(name)
@@ -120,7 +135,7 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
 
             if "yaml_set" in patch:
                 _apply_yaml_patch(config_path, patch, location)
-            elif "toml_table" in patch:
+            elif "toml_set" in patch:
                 _apply_toml_patch(config_path, patch, location)
             _logger.debug("Applied config patch for %s → %s", name, config_path)
         except ConfigPatchError:
@@ -244,7 +259,7 @@ def _substitute(value: object, location: VaultLocation) -> object:
 
 
 def _apply_toml_patch(config_path: Path, patch: dict, location: VaultLocation) -> None:
-    """Patch a TOML array-of-tables entry."""
+    """Patch top-level TOML keys or an array-of-tables entry."""
     import tomllib
 
     raw = _read_nofollow(config_path)
@@ -261,20 +276,23 @@ def _apply_toml_patch(config_path: Path, patch: dict, location: VaultLocation) -
     else:
         existing = {}
 
-    table_key = patch["toml_table"]
-    match_criteria = patch["toml_match"]
     values = {k: _substitute(v, location) for k, v in patch["toml_set"].items()}
-
-    entries = existing.get(table_key, [])
-    target = next(
-        (e for e in entries if all(e.get(k) == v for k, v in match_criteria.items())),
-        None,
-    )
-    if target:
-        target.update(values)
+    if "toml_table" not in patch:
+        existing.update(values)
     else:
-        entries.append({**match_criteria, **values})
-        existing[table_key] = entries
+        table_key = patch["toml_table"]
+        match_criteria = patch["toml_match"]
+
+        entries = existing.get(table_key, [])
+        target = next(
+            (e for e in entries if all(e.get(k) == v for k, v in match_criteria.items())),
+            None,
+        )
+        if target:
+            target.update(values)
+        else:
+            entries.append({**match_criteria, **values})
+            existing[table_key] = entries
 
     import tomli_w
 

--- a/src/terok_executor/credentials/vault_config.py
+++ b/src/terok_executor/credentials/vault_config.py
@@ -21,6 +21,7 @@ resolved centrally — agent YAMLs only need to reference the tokens.
 from __future__ import annotations
 
 import errno
+import json
 import logging
 import os
 import sys
@@ -32,6 +33,12 @@ if TYPE_CHECKING:
     from terok_executor.roster.loader import AgentRoster
 
 _logger = logging.getLogger(__name__)
+
+_MANAGED_CONFIG_FILENAME = ".terok-managed-config.json"
+"""Sidecar file that records config values last written by terok."""
+
+_MANAGED_CONFIG_VERSION = 1
+"""Schema version for :data:`_MANAGED_CONFIG_FILENAME`."""
 
 
 class ConfigPatchError(RuntimeError):
@@ -98,12 +105,16 @@ def apply_shared_config_patches(
     mounts_base: Path,
     *,
     providers: frozenset[str] | None = None,
+    disabled_providers: frozenset[str] | None = None,
 ) -> None:
-    """Re-apply ``shared_config_patch`` for the selected providers.
+    """Reconcile ``shared_config_patch`` for enabled and disabled providers.
 
     Called during task start so shared mount directories (which may have
     been recreated empty) always contain the correct vault addresses.
-    Idempotent: safe to call on every launch.
+    Idempotent: safe to call on every launch.  Disabled providers have
+    previously managed values removed only when the live config still
+    matches the sidecar value terok wrote last time; user-edited values
+    are preserved and ownership is dropped.
 
     Args:
         roster: Loaded agent roster.
@@ -112,17 +123,43 @@ def apply_shared_config_patches(
             ``None`` means "all providers with a patch".  An empty set
             disables patching entirely.  A non-empty set restricts
             patching to that provider subset.
+        disabled_providers:
+            Provider subset whose previously managed patch values should
+            be reconciled away.  ``None`` removes nothing; callers pass an
+            explicit set when a feature mode disables provider routing.
 
     Raises [`ConfigPatchError`][terok_executor.credentials.vault_config.ConfigPatchError] on failure — callers must not start
     the container if vault routing cannot be established.
     """
+    patched_routes = {
+        name: route
+        for name, route in roster.vault_routes.items()
+        if route.shared_config_patch and (providers is None or name in providers)
+    }
+    disabled_routes = {
+        name: route
+        for name, route in roster.vault_routes.items()
+        if route.shared_config_patch and disabled_providers and name in disabled_providers
+    }
+
+    for name in disabled_routes:
+        auth_info = roster.auth_providers.get(name)
+        if not auth_info:
+            continue
+        try:
+            _remove_managed_patch_values(mounts_base / auth_info.host_dir_name, name)
+            _logger.debug("Removed managed config patch for disabled provider %s", name)
+        except ConfigPatchError:
+            raise
+        except Exception as exc:
+            raise ConfigPatchError(f"Failed to remove vault config patch for {name}") from exc
+
+    if not patched_routes:
+        return
+
     location = resolve_vault_location()
 
-    for name, route in roster.vault_routes.items():
-        if providers is not None and name not in providers:
-            continue
-        if not route.shared_config_patch:
-            continue
+    for name, route in patched_routes.items():
         auth_info = roster.auth_providers.get(name)
         if not auth_info:
             continue
@@ -134,9 +171,12 @@ def apply_shared_config_patches(
             config_path = _safe_config_path(shared_dir, patch["file"])
 
             if "yaml_set" in patch:
-                _apply_yaml_patch(config_path, patch, location)
+                records = _apply_yaml_patch(config_path, patch, location)
             elif "toml_set" in patch:
-                _apply_toml_patch(config_path, patch, location)
+                records = _apply_toml_patch(config_path, patch, location)
+            else:
+                records = []
+            _record_managed_patch_values(shared_dir, name, patch["file"], records)
             _logger.debug("Applied config patch for %s → %s", name, config_path)
         except ConfigPatchError:
             raise
@@ -251,6 +291,16 @@ def _write_nofollow(path: Path, data: bytes) -> None:
         os.close(fd)
 
 
+def _delete_nofollow(path: Path) -> None:
+    """Delete *path* without following symlinks; ignore missing files."""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except IsADirectoryError as exc:
+        raise ConfigPatchError(f"refusing to delete directory at {path}") from exc
+
+
 def _substitute(value: object, location: VaultLocation) -> object:
     """Expand ``{vault_url}`` / ``{vault_socket}`` tokens in a patch value."""
     if not isinstance(value, str):
@@ -258,48 +308,196 @@ def _substitute(value: object, location: VaultLocation) -> object:
     return value.replace("{vault_url}", location.url).replace("{vault_socket}", location.socket)
 
 
-def _apply_toml_patch(config_path: Path, patch: dict, location: VaultLocation) -> None:
-    """Patch top-level TOML keys or an array-of-tables entry."""
+def _empty_metadata() -> dict:
+    """Return an empty managed-config sidecar payload."""
+    return {"version": _MANAGED_CONFIG_VERSION, "files": {}}
+
+
+def _managed_config_path(shared_dir: Path) -> Path:
+    """Return the safe sidecar path inside *shared_dir*."""
+    return _safe_config_path(shared_dir, _MANAGED_CONFIG_FILENAME)
+
+
+def _load_metadata(shared_dir: Path) -> dict:
+    """Load the managed-config sidecar, falling back to an empty payload."""
+    path = _managed_config_path(shared_dir)
+    raw = _read_nofollow(path)
+    if raw is None:
+        return _empty_metadata()
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        print(
+            f"Warning [vault-config]: failed to parse managed sidecar {path}: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return _empty_metadata()
+    if not isinstance(data, dict) or not isinstance(data.get("files"), dict):
+        return _empty_metadata()
+    data["version"] = _MANAGED_CONFIG_VERSION
+    return data
+
+
+def _write_metadata(shared_dir: Path, metadata: dict) -> None:
+    """Persist the managed-config sidecar, removing it when empty."""
+    files = metadata.get("files")
+    path = _managed_config_path(shared_dir)
+    if not files:
+        _delete_nofollow(path)
+        return
+    payload = {"version": _MANAGED_CONFIG_VERSION, "files": files}
+    encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8") + b"\n"
+    _write_nofollow(path, encoded)
+
+
+def _record_managed_patch_values(
+    shared_dir: Path, provider: str, filename: str, records: list[dict]
+) -> None:
+    """Remember which values *provider* owns in *filename*."""
+    metadata = _load_metadata(shared_dir)
+    files = metadata.setdefault("files", {})
+    file_info = files.get(filename)
+    if not isinstance(file_info, dict):
+        file_info = {"providers": {}}
+        files[filename] = file_info
+    providers = file_info.get("providers")
+    if not isinstance(providers, dict):
+        providers = {}
+        file_info["providers"] = providers
+    if records:
+        providers[provider] = records
+    else:
+        providers.pop(provider, None)
+    if not providers:
+        files.pop(filename, None)
+    _write_metadata(shared_dir, metadata)
+
+
+def _remove_managed_patch_values(shared_dir: Path, provider: str) -> None:
+    """Remove sidecar-owned config values for *provider* when still unchanged."""
+    metadata = _load_metadata(shared_dir)
+    files = metadata.setdefault("files", {})
+
+    for filename, file_info in list(files.items()):
+        if not isinstance(file_info, dict):
+            files.pop(filename, None)
+            continue
+        providers = file_info.get("providers")
+        if not isinstance(providers, dict) or provider not in providers:
+            continue
+        records = providers[provider]
+        if isinstance(records, list):
+            config_path = _safe_config_path(shared_dir, filename)
+            if not _remove_records_from_config(config_path, records):
+                continue
+        providers.pop(provider, None)
+        if not providers:
+            files.pop(filename, None)
+
+    _write_metadata(shared_dir, metadata)
+
+
+def _read_toml_mapping(config_path: Path, *, warn_on_error: bool) -> dict | None:
+    """Read TOML as a dict; return ``None`` on parse failure when requested."""
     import tomllib
 
     raw = _read_nofollow(config_path)
-    if raw is not None:
-        try:
-            existing = tomllib.loads(raw.decode("utf-8"))
-        except Exception as exc:
+    if raw is None:
+        return {}
+    try:
+        parsed = tomllib.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        if warn_on_error:
             print(
                 f"Warning [vault-config]: failed to parse {config_path}: "
                 f"{type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
-            existing = {}
-    else:
-        existing = {}
+            return {}
+        print(
+            f"Warning [vault-config]: cannot remove managed values from {config_path}: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _read_yaml_mapping(config_path: Path, *, warn_on_error: bool) -> dict | None:
+    """Read YAML as a dict; return ``None`` on parse failure when requested."""
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    raw = _read_nofollow(config_path)
+    if raw is None:
+        return {}
+    try:
+        parsed = yaml.load(raw)
+    except Exception as exc:
+        if warn_on_error:
+            print(
+                f"Warning [vault-config]: failed to parse {config_path}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            return {}
+        print(
+            f"Warning [vault-config]: cannot remove managed values from {config_path}: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return None
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _apply_toml_patch(config_path: Path, patch: dict, location: VaultLocation) -> list[dict]:
+    """Patch top-level TOML keys or an array-of-tables entry."""
+    existing = _read_toml_mapping(config_path, warn_on_error=True) or {}
 
     values = {k: _substitute(v, location) for k, v in patch["toml_set"].items()}
     if "toml_table" not in patch:
         existing.update(values)
+        records = [{"kind": "toml_top", "values": values}]
     else:
         table_key = patch["toml_table"]
         match_criteria = patch["toml_match"]
 
         entries = existing.get(table_key, [])
+        if not isinstance(entries, list):
+            entries = []
         target = next(
-            (e for e in entries if all(e.get(k) == v for k, v in match_criteria.items())),
+            (
+                e
+                for e in entries
+                if isinstance(e, dict) and all(e.get(k) == v for k, v in match_criteria.items())
+            ),
             None,
         )
+        created = target is None
         if target:
             target.update(values)
         else:
             entries.append({**match_criteria, **values})
             existing[table_key] = entries
+        records = [
+            {
+                "kind": "toml_table",
+                "table": table_key,
+                "match": match_criteria,
+                "values": values,
+                "created": created,
+            }
+        ]
 
     import tomli_w
 
     _write_nofollow(config_path, tomli_w.dumps(existing).encode("utf-8"))
+    return records
 
 
-def _apply_yaml_patch(config_path: Path, patch: dict, location: VaultLocation) -> None:
+def _apply_yaml_patch(config_path: Path, patch: dict, location: VaultLocation) -> list[dict]:
     """Set top-level keys in a YAML config file."""
     import io
 
@@ -307,25 +505,102 @@ def _apply_yaml_patch(config_path: Path, patch: dict, location: VaultLocation) -
 
     yaml = YAML()
     yaml.preserve_quotes = True
-    raw = _read_nofollow(config_path)
-    if raw is not None:
-        try:
-            existing = yaml.load(raw)
-        except Exception as exc:
-            print(
-                f"Warning [vault-config]: failed to parse {config_path}: "
-                f"{type(exc).__name__}: {exc}",
-                file=sys.stderr,
-            )
-            existing = {}
-    else:
-        existing = {}
-    if not isinstance(existing, dict):
-        existing = {}
+    existing = _read_yaml_mapping(config_path, warn_on_error=True) or {}
 
-    for k, v in patch["yaml_set"].items():
-        existing[k] = _substitute(v, location)
+    values = {k: _substitute(v, location) for k, v in patch["yaml_set"].items()}
+    for k in patch["yaml_set"]:
+        existing[k] = values[k]
 
     buf = io.BytesIO()
     yaml.dump(existing, buf)
     _write_nofollow(config_path, buf.getvalue())
+    return [{"kind": "yaml_top", "values": values}]
+
+
+def _remove_records_from_config(config_path: Path, records: list[dict]) -> bool:
+    """Remove managed records from *config_path* when live values still match."""
+    toml_records = [record for record in records if str(record.get("kind", "")).startswith("toml")]
+    yaml_records = [record for record in records if str(record.get("kind", "")).startswith("yaml")]
+    ok = True
+    if toml_records:
+        ok = _remove_toml_records(config_path, toml_records) and ok
+    if yaml_records:
+        ok = _remove_yaml_records(config_path, yaml_records) and ok
+    return ok
+
+
+def _remove_toml_records(config_path: Path, records: list[dict]) -> bool:
+    """Remove TOML sidecar-owned values if the current values still match."""
+    existing = _read_toml_mapping(config_path, warn_on_error=False)
+    if existing is None:
+        return False
+    changed = False
+
+    for record in records:
+        kind = record.get("kind")
+        if kind == "toml_top":
+            for key, value in dict(record.get("values", {})).items():
+                if existing.get(key) == value:
+                    existing.pop(key, None)
+                    changed = True
+        elif kind == "toml_table":
+            table_key = record.get("table")
+            match = dict(record.get("match", {}))
+            values = dict(record.get("values", {}))
+            entries = existing.get(table_key)
+            if not isinstance(table_key, str) or not isinstance(entries, list):
+                continue
+            target = next(
+                (
+                    entry
+                    for entry in entries
+                    if isinstance(entry, dict)
+                    and all(entry.get(key) == value for key, value in match.items())
+                ),
+                None,
+            )
+            if target is None:
+                continue
+            for key, value in values.items():
+                if target.get(key) == value:
+                    target.pop(key, None)
+                    changed = True
+            if record.get("created") and target == match:
+                entries.remove(target)
+                changed = True
+            if not entries:
+                existing.pop(table_key, None)
+
+    if changed:
+        import tomli_w
+
+        _write_nofollow(config_path, tomli_w.dumps(existing).encode("utf-8"))
+    return True
+
+
+def _remove_yaml_records(config_path: Path, records: list[dict]) -> bool:
+    """Remove YAML sidecar-owned top-level values when unchanged."""
+    import io
+
+    from ruamel.yaml import YAML
+
+    existing = _read_yaml_mapping(config_path, warn_on_error=False)
+    if existing is None:
+        return False
+    changed = False
+
+    for record in records:
+        if record.get("kind") != "yaml_top":
+            continue
+        for key, value in dict(record.get("values", {})).items():
+            if existing.get(key) == value:
+                existing.pop(key, None)
+                changed = True
+
+    if changed:
+        yaml = YAML()
+        yaml.preserve_quotes = True
+        buf = io.BytesIO()
+        yaml.dump(existing, buf)
+        _write_nofollow(config_path, buf.getvalue())
+    return True

--- a/src/terok_executor/resources/agents/claude.yaml
+++ b/src/terok_executor/resources/agents/claude.yaml
@@ -40,6 +40,8 @@ vault:
   # credential type stored in the DB.
   auth_header: dynamic
   auth_prefix: ""
+  oauth_extra_headers:
+    anthropic-beta: oauth-2025-04-20
   credential_type: oauth
   credential_file: .credentials.json
   # OAuth token refresh -- endpoint and client_id extracted from Claude Code

--- a/src/terok_executor/resources/agents/codex.yaml
+++ b/src/terok_executor/resources/agents/codex.yaml
@@ -28,13 +28,17 @@ capabilities:
 vault:
   route_prefix: codex
   upstream: https://api.openai.com
+  path_upstreams:
+    /backend-api/: https://chatgpt.com
   auth_header: Authorization
   auth_prefix: "Bearer "
   credential_type: oauth
   credential_file: auth.json
-  phantom_env:
-    OPENAI_API_KEY: true
-  base_url_env: OPENAI_BASE_URL
+  shared_config_patch:
+    file: config.toml
+    toml_set:
+      openai_base_url: "{vault_url}/v1"
+      chatgpt_base_url: "{vault_url}/backend-api/"
   # OAuth refresh -- endpoint, client_id, and grant shape extracted from the
   # Codex CLI source (codex-rs/login/src/auth/manager.rs v0.123.0).  The CLI
   # itself can be redirected at its own refresh attempts via the

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -858,17 +858,27 @@ def _to_vault_route(name: str, data: dict) -> VaultRoute | None:
             f"Agent {name!r}: 'socket_path' is no longer configurable — "
             "remove it; the env builder resolves the vault socket path centrally"
         )
-    path_upstreams = cp.get("path_upstreams") or {}
-    if not isinstance(path_upstreams, dict):
+    raw_path_upstreams = cp.get("path_upstreams")
+    if raw_path_upstreams is None:
+        path_upstreams = {}
+    elif not isinstance(raw_path_upstreams, dict):
         raise ValueError(
-            f"Agent {name!r}: path_upstreams must be a mapping, got {type(path_upstreams).__name__}"
+            f"Agent {name!r}: path_upstreams must be a mapping, "
+            f"got {type(raw_path_upstreams).__name__}"
         )
-    oauth_extra_headers = cp.get("oauth_extra_headers") or {}
-    if not isinstance(oauth_extra_headers, dict):
+    else:
+        path_upstreams = raw_path_upstreams
+
+    raw_oauth_extra_headers = cp.get("oauth_extra_headers")
+    if raw_oauth_extra_headers is None:
+        oauth_extra_headers = {}
+    elif not isinstance(raw_oauth_extra_headers, dict):
         raise ValueError(
             f"Agent {name!r}: oauth_extra_headers must be a mapping, "
-            f"got {type(oauth_extra_headers).__name__}"
+            f"got {type(raw_oauth_extra_headers).__name__}"
         )
+    else:
+        oauth_extra_headers = raw_oauth_extra_headers
     return VaultRoute(
         provider=name,
         route_prefix=cp["route_prefix"],

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -84,6 +84,9 @@ class VaultRoute:
     upstream: str
     """Upstream API base URL (e.g. ``"https://api.anthropic.com"``)."""
 
+    path_upstreams: dict[str, str] = field(default_factory=dict)
+    """Optional request-path prefix → upstream-base overrides."""
+
     auth_header: str = "Authorization"
     """HTTP header name for the real credential."""
 
@@ -368,6 +371,8 @@ class AgentRoster:
                 "auth_header": route.auth_header,
                 "auth_prefix": route.auth_prefix,
             }
+            if route.path_upstreams:
+                entry["path_upstreams"] = route.path_upstreams
             if route.oauth_refresh:
                 entry["oauth_refresh"] = route.oauth_refresh
             routes[route.provider] = entry
@@ -848,10 +853,16 @@ def _to_vault_route(name: str, data: dict) -> VaultRoute | None:
             f"Agent {name!r}: 'socket_path' is no longer configurable — "
             "remove it; the env builder resolves the vault socket path centrally"
         )
+    path_upstreams = cp.get("path_upstreams") or {}
+    if not isinstance(path_upstreams, dict):
+        raise ValueError(
+            f"Agent {name!r}: path_upstreams must be a mapping, got {type(path_upstreams).__name__}"
+        )
     return VaultRoute(
         provider=name,
         route_prefix=cp["route_prefix"],
         upstream=cp["upstream"],
+        path_upstreams=dict(path_upstreams),
         auth_header=cp.get("auth_header", "Authorization"),
         auth_prefix=cp.get("auth_prefix", "Bearer "),
         credential_type=cp.get("credential_type", "api_key"),

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -87,6 +87,9 @@ class VaultRoute:
     path_upstreams: dict[str, str] = field(default_factory=dict)
     """Optional request-path prefix → upstream-base overrides."""
 
+    oauth_extra_headers: dict[str, str] = field(default_factory=dict)
+    """Provider-specific headers added only when forwarding OAuth credentials."""
+
     auth_header: str = "Authorization"
     """HTTP header name for the real credential."""
 
@@ -373,6 +376,8 @@ class AgentRoster:
             }
             if route.path_upstreams:
                 entry["path_upstreams"] = route.path_upstreams
+            if route.oauth_extra_headers:
+                entry["oauth_extra_headers"] = route.oauth_extra_headers
             if route.oauth_refresh:
                 entry["oauth_refresh"] = route.oauth_refresh
             routes[route.provider] = entry
@@ -858,11 +863,18 @@ def _to_vault_route(name: str, data: dict) -> VaultRoute | None:
         raise ValueError(
             f"Agent {name!r}: path_upstreams must be a mapping, got {type(path_upstreams).__name__}"
         )
+    oauth_extra_headers = cp.get("oauth_extra_headers") or {}
+    if not isinstance(oauth_extra_headers, dict):
+        raise ValueError(
+            f"Agent {name!r}: oauth_extra_headers must be a mapping, "
+            f"got {type(oauth_extra_headers).__name__}"
+        )
     return VaultRoute(
         provider=name,
         route_prefix=cp["route_prefix"],
         upstream=cp["upstream"],
         path_upstreams=dict(path_upstreams),
+        oauth_extra_headers={str(k): str(v) for k, v in oauth_extra_headers.items()},
         auth_header=cp.get("auth_header", "Authorization"),
         auth_prefix=cp.get("auth_prefix", "Bearer "),
         credential_type=cp.get("credential_type", "api_key"),

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -34,6 +34,13 @@ def _fake_jwt(payload: dict | None = None) -> str:
     return ".".join((_b64url(header), _b64url(data), "test"))
 
 
+def _jwt_payload(token: str) -> dict:
+    """Decode the unsigned JWT payload used in tests."""
+    _header, payload, _sig = token.split(".", 2)
+    padded = payload + "=" * (-len(payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(padded.encode("ascii")))
+
+
 class TestCaptureCredentials:
     """Verify _capture_credentials stores extracted credentials in the DB."""
 
@@ -171,6 +178,23 @@ class TestWriteClaudeCredentialsFile:
         target = tmp_path / "nested" / "mounts"
         _write_claude_credentials_file({"type": "oauth"}, target)
         assert (target / "_claude-config" / ".credentials.json").is_file()
+
+    def test_replaces_symlink_without_touching_target(self, tmp_path: Path) -> None:
+        """No-follow writes replace a hostile mount symlink instead of following it."""
+        victim = tmp_path / "victim.json"
+        victim.write_text("do not overwrite")
+        cred_dir = tmp_path / "_claude-config"
+        cred_dir.mkdir()
+        dest = cred_dir / ".credentials.json"
+        dest.symlink_to(victim)
+
+        _write_claude_credentials_file({"type": "oauth"}, tmp_path)
+
+        assert victim.read_text() == "do not overwrite"
+        assert not dest.is_symlink()
+        assert json.loads(dest.read_text())["claudeAiOauth"]["accessToken"] == (
+            PHANTOM_CREDENTIALS_MARKER
+        )
 
 
 class TestApplyPostCaptureState:
@@ -520,6 +544,10 @@ class TestCodexOAuthMountWriter:
         tokens = data["tokens"]
         assert tokens["id_token"] != real_id_token
         assert len(tokens["id_token"].split(".")) == 3
+        synthetic_claims = _jwt_payload(tokens["id_token"])
+        assert "email" not in synthetic_claims
+        assert "https://api.openai.com/profile" not in synthetic_claims
+        assert synthetic_claims["https://api.openai.com/auth"]["chatgpt_account_id"] == "org-42"
         assert tokens["account_id"] == "org-42"
         assert tokens["access_token"] == CODEX_SHARED_OAUTH_MARKER
         assert tokens["refresh_token"] == CODEX_SHARED_OAUTH_MARKER
@@ -541,6 +569,27 @@ class TestCodexOAuthMountWriter:
 
         data = json.loads((codex_dir / "auth.json").read_text())
         assert data["tokens"]["access_token"] == CODEX_SHARED_OAUTH_MARKER
+
+    def test_expose_replaces_symlink_without_touching_target(self, tmp_path: Path) -> None:
+        """Exposed copy mode writes through the same no-follow destination helper."""
+        auth_dir = tmp_path / "auth"
+        auth_dir.mkdir()
+        payload = {"tokens": {"access_token": "sk-oai", "refresh_token": "rt"}}
+        (auth_dir / "auth.json").write_text(json.dumps(payload))
+
+        mounts = tmp_path / "mounts"
+        codex_dir = mounts / "_codex-config"
+        codex_dir.mkdir(parents=True)
+        victim = tmp_path / "victim.json"
+        victim.write_text("do not overwrite")
+        dest = codex_dir / "auth.json"
+        dest.symlink_to(victim)
+
+        _codex_oauth_mount_writer(auth_dir, mounts, payload, expose_token=True)
+
+        assert victim.read_text() == "do not overwrite"
+        assert not dest.is_symlink()
+        assert json.loads(dest.read_text()) == payload
 
     def test_expose_raises_when_file_missing(self, tmp_path: Path) -> None:
         """Raises FileNotFoundError when exposed and no auth.json."""

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -5,12 +5,14 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 from unittest.mock import patch
 
+from terok_sandbox import CODEX_SHARED_OAUTH_MARKER, PHANTOM_CREDENTIALS_MARKER
+
 from terok_executor.credentials.auth import (
-    PHANTOM_CREDENTIALS_MARKER,
     _apply_post_capture_state,
     _capture_credentials,
     _claude_oauth_mount_writer,
@@ -18,6 +20,18 @@ from terok_executor.credentials.auth import (
     _write_claude_credentials_file,
     store_api_key,
 )
+
+
+def _fake_jwt(payload: dict | None = None) -> str:
+    """Return a syntactically valid unsigned JWT for tests."""
+    header = {"alg": "none", "typ": "JWT"}
+    data = payload or {"email": "codex@example.com"}
+
+    def _b64url(obj: dict) -> str:
+        encoded = json.dumps(obj, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return base64.urlsafe_b64encode(encoded).decode("ascii").rstrip("=")
+
+    return ".".join((_b64url(header), _b64url(data), "test"))
 
 
 class TestCaptureCredentials:
@@ -408,13 +422,22 @@ class TestCaptureWritesCredentialsFile:
 
     def test_capture_codex_default_writes_phantom(self, tmp_path: Path) -> None:
         """Codex OAuth capture without expose writes a phantom auth.json."""
+        real_id_token = _fake_jwt(
+            {
+                "email": "coder@example.com",
+                "https://api.openai.com/auth": {
+                    "chatgpt_plan_type": "pro",
+                    "chatgpt_account_id": "org-42",
+                },
+            }
+        )
         (tmp_path / "auth.json").write_text(
             json.dumps(
                 {
                     "tokens": {
                         "access_token": "sk-oai",
                         "refresh_token": "rt",
-                        "id_token": "id.token.jwt",
+                        "id_token": real_id_token,
                     }
                 }
             )
@@ -429,10 +452,10 @@ class TestCaptureWritesCredentialsFile:
         phantom = mounts / "_codex-config" / "auth.json"
         assert phantom.is_file()
         data = json.loads(phantom.read_text())
-        assert data["tokens"]["access_token"] == PHANTOM_CREDENTIALS_MARKER
-        assert data["tokens"]["refresh_token"] == PHANTOM_CREDENTIALS_MARKER
-        # The real id_token rides in — the CLI parses claims from it.
-        assert data["tokens"]["id_token"] == "id.token.jwt"
+        assert data["tokens"]["access_token"] == CODEX_SHARED_OAUTH_MARKER
+        assert data["tokens"]["refresh_token"] == CODEX_SHARED_OAUTH_MARKER
+        # The file carries a synthetic JWT, not the original opaque id_token.
+        assert data["tokens"]["id_token"] != real_id_token
 
 
 class TestClaudeOAuthMountWriter:
@@ -478,18 +501,28 @@ class TestCodexOAuthMountWriter:
         assert json.loads(dest.read_text()) == payload
 
     def test_default_writes_phantom_preserving_id_token(self, tmp_path: Path) -> None:
-        """expose_token=False writes a phantom auth.json with real id_token claims."""
+        """expose_token=False writes a phantom auth.json with synthetic id_token claims."""
         mounts = tmp_path / "mounts"
-        cred = {"id_token": "real.jwt.string", "account_id": "org-42"}
+        real_id_token = _fake_jwt(
+            {
+                "email": "coder@example.com",
+                "https://api.openai.com/auth": {
+                    "chatgpt_plan_type": "pro",
+                    "chatgpt_account_id": "org-42",
+                },
+            }
+        )
+        cred = {"id_token": real_id_token, "account_id": "org-42"}
 
         _codex_oauth_mount_writer(tmp_path, mounts, cred, expose_token=False)
 
         data = json.loads((mounts / "_codex-config" / "auth.json").read_text())
         tokens = data["tokens"]
-        assert tokens["id_token"] == "real.jwt.string"
+        assert tokens["id_token"] != real_id_token
+        assert len(tokens["id_token"].split(".")) == 3
         assert tokens["account_id"] == "org-42"
-        assert tokens["access_token"] == PHANTOM_CREDENTIALS_MARKER
-        assert tokens["refresh_token"] == PHANTOM_CREDENTIALS_MARKER
+        assert tokens["access_token"] == CODEX_SHARED_OAUTH_MARKER
+        assert tokens["refresh_token"] == CODEX_SHARED_OAUTH_MARKER
         assert data["OPENAI_API_KEY"] is None
         # last_refresh is pinned far in the future so the CLI's 8-day
         # staleness check never fires an in-container refresh attempt.
@@ -507,7 +540,7 @@ class TestCodexOAuthMountWriter:
         _codex_oauth_mount_writer(tmp_path, mounts, {}, expose_token=False)
 
         data = json.loads((codex_dir / "auth.json").read_text())
-        assert data["tokens"]["access_token"] == PHANTOM_CREDENTIALS_MARKER
+        assert data["tokens"]["access_token"] == CODEX_SHARED_OAUTH_MARKER
 
     def test_expose_raises_when_file_missing(self, tmp_path: Path) -> None:
         """Raises FileNotFoundError when exposed and no auth.json."""

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -795,6 +795,8 @@ class TestSharedConfigPatches:
         # Create the host mount dir that _shared_config_mounts would create.
         vibe_dir = tmp_path / "_vibe-config"
         vibe_dir.mkdir()
+        codex_dir = tmp_path / "_codex-config"
+        codex_dir.mkdir()
 
         with (
             patch("terok_sandbox.SandboxConfig"),
@@ -813,6 +815,10 @@ class TestSharedConfigPatches:
         assert mistral is not None, "config.toml must contain a mistral provider entry"
         assert "host.containers.internal:18731" in mistral["api_base"]
 
+        codex_cfg = tomllib.loads((codex_dir / "config.toml").read_text())
+        assert codex_cfg["openai_base_url"] == "http://host.containers.internal:18731/v1"
+        assert codex_cfg["chatgpt_base_url"] == "http://host.containers.internal:18731/backend-api/"
+
     def test_assemble_env_calls_patches_with_and_without_bypass(self, workspace, envs_dir, roster):
         """assemble_container_env invokes patches regardless of caller_manages_vault."""
         for bypass in (True, False):
@@ -823,7 +829,11 @@ class TestSharedConfigPatches:
                     spec=_spec(workspace, envs_dir), roster=roster, caller_manages_vault=bypass
                 )
 
-            m_patches.assert_called_once_with(roster, envs_dir)
+            m_patches.assert_called_once_with(
+                roster,
+                envs_dir,
+                providers=None,
+            )
 
     def test_patches_idempotent(self, roster, tmp_path):
         """Calling apply_shared_config_patches twice must not duplicate entries."""
@@ -848,6 +858,22 @@ class TestSharedConfigPatches:
         providers = data.get("providers", [])
         mistral_entries = [p for p in providers if p.get("name") == "mistral"]
         assert len(mistral_entries) == 1, "idempotent: must have exactly one mistral entry"
+
+    def test_patches_can_be_limited_to_selected_providers(self, roster, tmp_path):
+        """Provider filtering can skip Codex while still patching others."""
+        from terok_executor.credentials.vault_config import apply_shared_config_patches
+
+        (tmp_path / "_vibe-config").mkdir()
+        (tmp_path / "_codex-config").mkdir()
+
+        with (
+            patch("terok_sandbox.SandboxConfig"),
+            patch("terok_sandbox.get_token_broker_port", return_value=18731),
+        ):
+            apply_shared_config_patches(roster, tmp_path, providers=frozenset({"vibe"}))
+
+        assert (tmp_path / "_vibe-config" / "config.toml").exists()
+        assert not (tmp_path / "_codex-config" / "config.toml").exists()
 
 
 class TestConfigPatchSecurity:

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -833,6 +833,7 @@ class TestSharedConfigPatches:
                 roster,
                 envs_dir,
                 providers=None,
+                disabled_providers=None,
             )
 
     def test_patches_idempotent(self, roster, tmp_path):
@@ -874,6 +875,109 @@ class TestSharedConfigPatches:
 
         assert (tmp_path / "_vibe-config" / "config.toml").exists()
         assert not (tmp_path / "_codex-config" / "config.toml").exists()
+
+    def test_patches_write_managed_sidecar(self, roster, tmp_path):
+        """Applied patches record the exact values terok owns."""
+        from terok_executor.credentials.vault_config import apply_shared_config_patches
+
+        (tmp_path / "_codex-config").mkdir()
+
+        with (
+            patch("terok_sandbox.SandboxConfig"),
+            patch("terok_sandbox.get_token_broker_port", return_value=18731),
+        ):
+            apply_shared_config_patches(roster, tmp_path, providers=frozenset({"codex"}))
+
+        import json
+
+        sidecar = json.loads(
+            (tmp_path / "_codex-config" / ".terok-managed-config.json").read_text()
+        )
+        codex_records = sidecar["files"]["config.toml"]["providers"]["codex"]
+        assert codex_records == [
+            {
+                "kind": "toml_top",
+                "values": {
+                    "openai_base_url": "http://host.containers.internal:18731/v1",
+                    "chatgpt_base_url": "http://host.containers.internal:18731/backend-api/",
+                },
+            }
+        ]
+
+    def test_disabled_provider_removes_owned_top_level_toml(self, roster, tmp_path):
+        """Disabled providers remove stale top-level TOML keys that terok owns."""
+        from terok_executor.credentials.vault_config import apply_shared_config_patches
+
+        (tmp_path / "_codex-config").mkdir()
+
+        with (
+            patch("terok_sandbox.SandboxConfig"),
+            patch("terok_sandbox.get_token_broker_port", return_value=18731),
+        ):
+            apply_shared_config_patches(roster, tmp_path, providers=frozenset({"codex"}))
+
+        apply_shared_config_patches(
+            roster,
+            tmp_path,
+            providers=frozenset(),
+            disabled_providers=frozenset({"codex"}),
+        )
+
+        import tomllib
+
+        config = tomllib.loads((tmp_path / "_codex-config" / "config.toml").read_text())
+        assert "openai_base_url" not in config
+        assert "chatgpt_base_url" not in config
+        assert not (tmp_path / "_codex-config" / ".terok-managed-config.json").exists()
+
+    def test_disabled_provider_preserves_user_modified_value(self, roster, tmp_path):
+        """A value changed after terok wrote it becomes user-owned and survives removal."""
+        from terok_executor.credentials.vault_config import apply_shared_config_patches
+
+        codex_dir = tmp_path / "_codex-config"
+        codex_dir.mkdir()
+
+        with (
+            patch("terok_sandbox.SandboxConfig"),
+            patch("terok_sandbox.get_token_broker_port", return_value=18731),
+        ):
+            apply_shared_config_patches(roster, tmp_path, providers=frozenset({"codex"}))
+
+        config_path = codex_dir / "config.toml"
+        config_path.write_text(
+            'openai_base_url = "https://user.example/v1"\n'
+            'chatgpt_base_url = "http://host.containers.internal:18731/backend-api/"\n'
+        )
+
+        apply_shared_config_patches(
+            roster,
+            tmp_path,
+            providers=frozenset(),
+            disabled_providers=frozenset({"codex"}),
+        )
+
+        import tomllib
+
+        config = tomllib.loads(config_path.read_text())
+        assert config == {"openai_base_url": "https://user.example/v1"}
+        assert not (codex_dir / ".terok-managed-config.json").exists()
+
+    def test_disabled_provider_does_not_resolve_vault_location(self, roster, tmp_path):
+        """Pure removal does not require the vault to have an address."""
+        from terok_executor.credentials.vault_config import apply_shared_config_patches
+
+        (tmp_path / "_codex-config").mkdir()
+
+        with patch(
+            "terok_sandbox.get_token_broker_port",
+            side_effect=AssertionError("vault location should not be resolved"),
+        ):
+            apply_shared_config_patches(
+                roster,
+                tmp_path,
+                providers=frozenset(),
+                disabled_providers=frozenset({"codex"}),
+            )
 
 
 class TestConfigPatchSecurity:

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -504,6 +504,21 @@ class TestScanSkipsInjectedFile:
 
         assert scan_leaked_credentials(tmp_path) == []
 
+    def test_malformed_codex_auth_json_is_suspicious_not_crashing(self, tmp_path: Path) -> None:
+        """Non-object auth.json roots are treated as leaks, not parser crashes."""
+        from terok_executor import get_roster
+        from terok_executor.credentials.vault_commands import scan_leaked_credentials
+
+        roster = get_roster()
+        auth = roster.auth_providers["codex"]
+        route = roster.vault_routes["codex"]
+
+        cred_dir = tmp_path / auth.host_dir_name
+        cred_dir.mkdir()
+        (cred_dir / route.credential_file).write_text(json.dumps(["not", "an", "object"]))
+
+        assert scan_leaked_credentials(tmp_path) == [("codex", cred_dir / route.credential_file)]
+
 
 class TestCleanSkipsInjectedFile:
     """Verify the clean handler preserves injected .credentials.json."""
@@ -660,6 +675,23 @@ class TestToVaultRoute:
 
         assert _to_vault_route("test", {}) is None
         assert _to_vault_route("test", {"vault": {}}) is None
+
+    @pytest.mark.parametrize("field", ["path_upstreams", "oauth_extra_headers"])
+    def test_optional_vault_maps_reject_falsy_non_mappings(self, field: str) -> None:
+        """Falsy lists/strings must not be silently treated as absent maps."""
+        from terok_executor.roster.loader import _to_vault_route
+
+        with pytest.raises(ValueError, match=f"{field} must be a mapping"):
+            _to_vault_route(
+                "test",
+                {
+                    "vault": {
+                        "route_prefix": "test",
+                        "upstream": "https://example.com",
+                        field: [],
+                    }
+                },
+            )
 
 
 class TestEnsureVaultRoutes:

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -31,11 +31,13 @@ class TestVaultRoutesParsed:
         assert route.socket_env == "ANTHROPIC_UNIX_SOCKET"
 
     def test_codex_route_exists(self) -> None:
-        """Codex has a vault route with OpenAI upstream."""
+        """Codex has a vault route with OpenAI + ChatGPT upstreams."""
         route = get_roster().vault_routes.get("codex")
         assert route is not None
         assert route.upstream == "https://api.openai.com"
-        assert "OPENAI_API_KEY" in route.phantom_env
+        assert route.path_upstreams == {"/backend-api/": "https://chatgpt.com"}
+        assert route.shared_config_patch is not None
+        assert route.shared_config_patch["file"] == "config.toml"
 
     def test_gh_route_exists(self) -> None:
         """GitHub CLI has a vault route with token-style auth."""
@@ -108,6 +110,7 @@ class TestGenerateRoutesJson:
         assert "claude" in routes
         assert routes["claude"]["upstream"] == "https://api.anthropic.com"
         assert routes["claude"]["auth_header"] == "dynamic"
+        assert routes["codex"]["path_upstreams"] == {"/backend-api/": "https://chatgpt.com"}
 
     def test_all_routes_have_upstream(self) -> None:
         """Every route in the JSON has an upstream field."""
@@ -229,7 +232,7 @@ class TestVaultCommandHandlers:
     """Verify vault CLI command handlers."""
 
     @patch("terok_sandbox.start_vault")
-    @patch("terok_executor.roster.loader.ensure_vault_routes")
+    @patch("terok_executor.credentials.vault_commands._ensure_routes")
     @patch("terok_sandbox.is_vault_running", return_value=False)
     def test_start_generates_routes_and_starts(self, _running, _routes, _start, capsys) -> None:
         """start generates routes then starts the daemon."""
@@ -287,8 +290,8 @@ class TestVaultCommandHandlers:
         assert "running" in out
         assert "claude" in out
 
-    @patch("terok_sandbox.VaultManager.install_systemd_units")
-    @patch("terok_executor.roster.loader.ensure_vault_routes")
+    @patch("terok_sandbox.install_vault_systemd")
+    @patch("terok_executor.credentials.vault_commands._ensure_routes")
     @patch("terok_sandbox.is_vault_systemd_available", return_value=True)
     def test_install_generates_routes_and_installs(self, _sd, _routes, _install, capsys) -> None:
         """install generates routes then installs systemd units."""
@@ -307,7 +310,7 @@ class TestVaultCommandHandlers:
         with pytest.raises(SystemExit):
             _handle_install()
 
-    @patch("terok_sandbox.VaultManager.uninstall_systemd_units")
+    @patch("terok_sandbox.uninstall_vault_systemd")
     @patch("terok_sandbox.is_vault_systemd_available", return_value=True)
     def test_uninstall_removes_units(self, _sd, _uninstall, capsys) -> None:
         """uninstall removes systemd units."""
@@ -326,7 +329,7 @@ class TestVaultCommandHandlers:
             _handle_uninstall()
 
     @patch(
-        "terok_executor.roster.loader.ensure_vault_routes",
+        "terok_executor.credentials.vault_commands._ensure_routes",
         return_value=Path("/tmp/routes.json"),
     )
     def test_routes_prints_path(self, _routes, capsys) -> None:
@@ -472,6 +475,30 @@ class TestScanSkipsInjectedFile:
         leaked = scan_leaked_credentials(tmp_path)
         assert len(leaked) == 1
         assert leaked[0][0] == "claude"
+
+    def test_skips_injected_codex_auth_json(self, tmp_path: Path) -> None:
+        """Injected shared Codex auth.json is NOT flagged as leaked."""
+        from terok_sandbox import CODEX_SHARED_OAUTH_MARKER
+
+        from terok_executor import get_roster
+        from terok_executor.credentials.vault_commands import scan_leaked_credentials
+
+        roster = get_roster()
+        auth = roster.auth_providers["codex"]
+        route = roster.vault_routes["codex"]
+
+        cred_dir = tmp_path / auth.host_dir_name
+        cred_dir.mkdir()
+        cred = {
+            "tokens": {
+                "access_token": CODEX_SHARED_OAUTH_MARKER,
+                "refresh_token": CODEX_SHARED_OAUTH_MARKER,
+                "id_token": "dummy.dummy.dummy",
+            }
+        }
+        (cred_dir / route.credential_file).write_text(json.dumps(cred))
+
+        assert scan_leaked_credentials(tmp_path) == []
 
 
 class TestCleanSkipsInjectedFile:

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -504,6 +504,31 @@ class TestScanSkipsInjectedFile:
 
         assert scan_leaked_credentials(tmp_path) == []
 
+    def test_codex_auth_json_with_live_api_key_is_still_leaked(self, tmp_path: Path) -> None:
+        """Marker tokens do not hide a live top-level OPENAI_API_KEY."""
+        from terok_sandbox import CODEX_SHARED_OAUTH_MARKER
+
+        from terok_executor import get_roster
+        from terok_executor.credentials.vault_commands import scan_leaked_credentials
+
+        roster = get_roster()
+        auth = roster.auth_providers["codex"]
+        route = roster.vault_routes["codex"]
+
+        cred_dir = tmp_path / auth.host_dir_name
+        cred_dir.mkdir()
+        cred = {
+            "OPENAI_API_KEY": "sk-real-leak",
+            "tokens": {
+                "access_token": CODEX_SHARED_OAUTH_MARKER,
+                "refresh_token": CODEX_SHARED_OAUTH_MARKER,
+                "id_token": "dummy.dummy.dummy",
+            },
+        }
+        (cred_dir / route.credential_file).write_text(json.dumps(cred))
+
+        assert scan_leaked_credentials(tmp_path) == [("codex", cred_dir / route.credential_file)]
+
     def test_malformed_codex_auth_json_is_suspicious_not_crashing(self, tmp_path: Path) -> None:
         """Non-object auth.json roots are treated as leaks, not parser crashes."""
         from terok_executor import get_roster

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -25,6 +25,7 @@ class TestVaultRoutesParsed:
         assert route.route_prefix == "claude"
         assert route.upstream == "https://api.anthropic.com"
         assert route.auth_header == "dynamic"
+        assert route.oauth_extra_headers == {"anthropic-beta": "oauth-2025-04-20"}
         assert "ANTHROPIC_API_KEY" in route.phantom_env
         assert "CLAUDE_CODE_OAUTH_TOKEN" in route.oauth_phantom_env
         assert route.base_url_env == "ANTHROPIC_BASE_URL"
@@ -36,6 +37,7 @@ class TestVaultRoutesParsed:
         assert route is not None
         assert route.upstream == "https://api.openai.com"
         assert route.path_upstreams == {"/backend-api/": "https://chatgpt.com"}
+        assert route.oauth_extra_headers == {}
         assert route.shared_config_patch is not None
         assert route.shared_config_patch["file"] == "config.toml"
 
@@ -110,7 +112,9 @@ class TestGenerateRoutesJson:
         assert "claude" in routes
         assert routes["claude"]["upstream"] == "https://api.anthropic.com"
         assert routes["claude"]["auth_header"] == "dynamic"
+        assert routes["claude"]["oauth_extra_headers"] == {"anthropic-beta": "oauth-2025-04-20"}
         assert routes["codex"]["path_upstreams"] == {"/backend-api/": "https://chatgpt.com"}
+        assert "oauth_extra_headers" not in routes["codex"]
 
     def test_all_routes_have_upstream(self) -> None:
         """Every route in the JSON has an upstream field."""


### PR DESCRIPTION
## Summary
- apply shared agent config patches through a managed sidecar so terok can later remove only values it still owns
- teach container env assembly about enabled and disabled vault patch providers, preserving user-edited config values while reconciling stale managed ones
- move Claude's Anthropic OAuth beta header into route metadata and parse `oauth_extra_headers` from roster YAML
- harden shared OAuth mount writes against symlink tricks, avoid PII in synthetic Codex JWTs, and tighten leaked Codex auth detection
- document the shared vault config patch lifecycle

## Depends on
- terok-ai/terok-sandbox#221

## Testing
- `make lint`
- `poetry run pytest tests/unit/test_auth_capture.py tests/unit/test_env_builder.py tests/unit/test_vault_routes.py tests/unit/test_error_surfacing.py tests/unit/test_vault_config_symlink.py -q`
- `poetry run pytest tests/unit/test_vault_routes.py -q`

Podman/Docker-dependent tests were intentionally not run in this container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Codex routing configuration with improved base URL handling
  * Added support for path-based upstream routing
  * Improved OAuth credential handling with secure token synthesis
  * Added configuration management with sidecar tracking for preserving user-edited settings

* **Bug Fixes**
  * Strengthened symlink safety for credential files

* **Documentation**
  * Updated configuration documentation for vault setup and Codex routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->