### PR TITLE
feat(roster): add OpenRouter agent backed by OpenCode

### DIFF
--- a/src/terok_executor/resources/agents/openrouter.yaml
+++ b/src/terok_executor/resources/agents/openrouter.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+roster_version: 1
+
+kind: opencode
+label: OpenRouter
+binary: openrouter
+
+git_identity:
+  name: OpenRouter
+  email: noreply@openrouter.ai
+
+headless:
+  subcommand: run
+  prompt_flag: ""
+
+auto_approve:
+  env:
+    OPENCODE_PERMISSION: '{"*":"allow"}'
+
+session:
+  supports_resume: true
+  resume_flag: "--session"
+  continue_flag: "--continue"
+  session_file: openrouter-session.txt
+
+capabilities:
+  log_format: plain
+
+vault:
+  route_prefix: openrouter
+  upstream: https://openrouter.ai
+  auth_header: Authorization
+  auth_prefix: "Bearer "
+  credential_type: api_key
+  credential_file: config.json
+  phantom_env:
+    OPENROUTER_API_KEY: true
+
+opencode:
+  display_name: OpenRouter
+  base_url: https://openrouter.ai/api/v1
+  preferred_model: anthropic/claude-sonnet-4.5
+  fallback_model: anthropic/claude-3.5-sonnet
+  env_var_prefix: OPENROUTER
+  config_dir: .openrouter
+  auth_key_url: https://openrouter.ai/keys
+  api_key_hint: |-
+    Create an API key at:
+      https://openrouter.ai/keys
+    OpenRouter exposes ~300 models from Anthropic, OpenAI, Google,
+    Meta, DeepSeek and others through a single OpenAI-compatible
+    endpoint; usage is billed against your OpenRouter credits.
+
+# OpenCode runtime mounts are defined in opencode.yaml and deduplicated
+# by the registry — no need to repeat them here.
+
+install:
+  # All openrouter wrappers are symlinks to the opencode-provider family;
+  # selecting openrouter transitively pulls opencode in.
+  depends_on: [opencode]
+  run_as_root: |
+    RUN set -eux; \
+        ln -sf opencode-provider     /usr/local/bin/openrouter; \
+        ln -sf opencode-provider-acp /usr/local/bin/openrouter-acp; \
+        ln -sf opencode-toad         /usr/local/bin/openroutertoad
+
+help:
+  label: '  \033[36mopenrouter\033[0m - OpenCode with OpenRouter (\033[2m~300 models\033[0m)'

--- a/src/terok_executor/resources/agents/openrouter.yaml
+++ b/src/terok_executor/resources/agents/openrouter.yaml
@@ -49,16 +49,14 @@ opencode:
   api_key_hint: |-
     Create an API key at:
       https://openrouter.ai/keys
-    OpenRouter exposes ~300 models from Anthropic, OpenAI, Google,
-    Meta, DeepSeek and others through a single OpenAI-compatible
-    endpoint; usage is billed against your OpenRouter credits.
+    OpenRouter is an OpenAI-compatible aggregator covering models from
+    Anthropic, OpenAI, Google, Meta, DeepSeek and others; usage is
+    billed against your OpenRouter credits.
 
 # OpenCode runtime mounts are defined in opencode.yaml and deduplicated
 # by the registry — no need to repeat them here.
 
 install:
-  # All openrouter wrappers are symlinks to the opencode-provider family;
-  # selecting openrouter transitively pulls opencode in.
   depends_on: [opencode]
   run_as_root: |
     RUN set -eux; \
@@ -67,4 +65,4 @@ install:
         ln -sf opencode-toad         /usr/local/bin/openroutertoad
 
 help:
-  label: '  \033[36mopenrouter\033[0m - OpenCode with OpenRouter (\033[2m~300 models\033[0m)'
+  label: '  \033[36mopenrouter\033[0m - OpenCode with OpenRouter'

--- a/tests/unit/test_headless_providers.py
+++ b/tests/unit/test_headless_providers.py
@@ -51,8 +51,8 @@ def _all_wrappers(*, has_agents: bool = False) -> str:
 class TestAgentProviderRegistry:
     """Tests for the AGENT_PROVIDERS registry."""
 
-    def test_all_eight_providers_exist(self) -> None:
-        """Registry contains exactly the eight expected providers."""
+    def test_registry_contains_expected_providers(self) -> None:
+        """Registry contains exactly the expected set of bundled providers."""
         expected = {
             "claude",
             "codex",

--- a/tests/unit/test_headless_providers.py
+++ b/tests/unit/test_headless_providers.py
@@ -51,9 +51,18 @@ def _all_wrappers(*, has_agents: bool = False) -> str:
 class TestAgentProviderRegistry:
     """Tests for the AGENT_PROVIDERS registry."""
 
-    def test_all_seven_providers_exist(self) -> None:
-        """Registry contains exactly the seven expected providers."""
-        expected = {"claude", "codex", "copilot", "vibe", "blablador", "opencode", "kisski"}
+    def test_all_eight_providers_exist(self) -> None:
+        """Registry contains exactly the eight expected providers."""
+        expected = {
+            "claude",
+            "codex",
+            "copilot",
+            "vibe",
+            "blablador",
+            "opencode",
+            "kisski",
+            "openrouter",
+        }
         assert set(AGENT_PROVIDERS.keys()) == expected
 
     def test_provider_names_tuple(self) -> None:

--- a/tests/unit/test_headless_providers.py
+++ b/tests/unit/test_headless_providers.py
@@ -137,7 +137,7 @@ class TestGenerateAgentWrapper:
 
     def test_session_resume_uses_explicit_id(self) -> None:
         """Providers with session_file use --session/--resume with explicit ID."""
-        for name in ("vibe", "opencode", "blablador", "kisski"):
+        for name in ("vibe", "opencode", "blablador", "kisski", "openrouter"):
             p = AGENT_PROVIDERS[name]
             wrapper = _provider_wrapper(name)
             assert p.resume_flag in wrapper, f"{name} missing resume flag"

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -451,6 +451,7 @@ class TestLoadRegistry:
         env = reg.collect_opencode_provider_env()
         assert any(k.startswith("TEROK_OC_BLABLADOR_") for k in env)
         assert any(k.startswith("TEROK_OC_KISSKI_") for k in env)
+        assert any(k.startswith("TEROK_OC_OPENROUTER_") for k in env)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -53,6 +53,7 @@ class TestLoadBundledAgents:
             "blablador",
             "kisski",
             "opencode",
+            "openrouter",
             "sonar",
             "toad",
             "vibe",
@@ -362,7 +363,16 @@ class TestLoadRegistry:
 
     def test_loads_all_agents(self) -> None:
         reg = load_roster()
-        expected_agents = {"claude", "codex", "copilot", "vibe", "blablador", "kisski", "opencode"}
+        expected_agents = {
+            "claude",
+            "codex",
+            "copilot",
+            "vibe",
+            "blablador",
+            "kisski",
+            "opencode",
+            "openrouter",
+        }
         assert set(reg.agent_names) == expected_agents
 
     def test_all_names_includes_tools(self) -> None:


### PR DESCRIPTION
## Summary

- Adds `openrouter.yaml` to the bundled agent roster, mirroring the Blablador/KISSKI pattern (`kind: opencode`, vault-routed Bearer auth, symlinks to the shared `opencode-provider` launcher).
- No new wrapper code required — the generic provider script already drives any OpenAI-compatible upstream from YAML configuration.
- Defaults: `anthropic/claude-sonnet-4.5` (preferred), `anthropic/claude-3.5-sonnet` (fallback). The launcher auto-falls-back to the first available model if both disappear from the catalog.

## Why

OpenRouter unifies access to ~300 models (Anthropic, OpenAI, Google, Meta, DeepSeek, Qwen, …) under a single OpenAI-compatible endpoint and one billing relationship — useful for users who want to swap models freely without juggling per-vendor keys.

## Notes

- The full ~300-model catalog will be written into `opencode.json` on first run. Follow-up: #243 will introduce an optional `model_filter` field on `opencode:` to curate the catalog (skipped here to keep v0 minimal).
- Updated three count/list-style tests (`test_loads_all_bundled_agents`, `test_loads_all_agents`, `test_all_seven_providers_exist` → renamed to `test_all_eight_providers_exist`).

## Test plan

- [x] `make check` (lint, unit tests, tach, security, docstrings, deadcode, reuse) — all green
- [ ] Smoke test on a test machine: build L1 image, set `OPENROUTER_API_KEY` via `terok auth`, run `openrouter --list-models` inside a task container, then run a task with `--provider openrouter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated OpenRouter as a new AI provider with API-key configuration, model listing/help, headless "run" support and resumable sessions (resume/continue).
  * Installer now exposes OpenRouter runtime entrypoints for user commands.

* **Tests**
  * Updated test suite to validate OpenRouter provider registration, bundled agent availability, and session/resume behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->