### PR TITLE
docs: drop README Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,6 @@ systemd service lifecycle.
 | `stop` | Stop a running container |
 | `vault` | Vault management (start, stop, status, install, routes) |
 
-## Documentation
-
-- [Getting started](https://terok-ai.github.io/terok-executor/) — install, build, authenticate, first run
-- [Agents](https://terok-ai.github.io/terok-executor/agents/) — catalog, custom definitions, auth flows
-- [Launch modes](https://terok-ai.github.io/terok-executor/launch-modes/) — headless, interactive, web, tool
-- [Security](https://terok-ai.github.io/terok-executor/security/) — firewall, vault, restricted mode
-- [API Reference](https://terok-ai.github.io/terok-executor/reference/) — Python API docs
-
 ## Development
 
 See the [Developer Guide](https://terok-ai.github.io/terok-executor/developer/).


### PR DESCRIPTION
## Summary

Remove the **Documentation** section from `README.md`.  The deeper
docs are being audited across the ecosystem; don't advertise them
loudly until that pass completes.

The **Development** section is kept — it points contributors at the
developer guide, the one doc page that should still be reachable
from the README.

## Test plan

- [x] Doc-only change.
- [ ] CI green (lint, reuse, docstrings, tach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Documentation section from README that previously linked to getting started guides, agent resources, launch modes, security information, and API reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->