### PR TITLE
docs: migrate Sphinx RST roles to mkdocs-autorefs syntax

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,12 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
+          inventories:
+            - https://docs.python.org/3/objects.inv
+            - https://terok-ai.github.io/terok/objects.inv
+            - https://terok-ai.github.io/terok-sandbox/objects.inv
+            - https://terok-ai.github.io/terok-shield/objects.inv
+            - https://terok-ai.github.io/terok-clearance/objects.inv
           options:
             docstring_style: google
             show_source: true
@@ -46,6 +52,7 @@ plugins:
             show_root_full_path: false
             show_symbol_type_heading: true
             show_symbol_type_toc: true
+            show_if_no_docstring: true
             members_order: source
             merge_init_into_class: true
   - terok:

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -9,10 +9,10 @@ lifecycle of one AI coding agent at a time.  Designed for standalone use
 
 The public surface is ``__all__`` below.  Key entry points:
 
-- [`AgentRunner`][] — launch agents in containers
-- [`authenticate`][] / [`store_api_key`][] — credential flows
-- [`build_base_images`][] — image construction
-- [`get_roster`][] — YAML agent registry
+- [`AgentRunner`][terok_executor.AgentRunner] — launch agents in containers
+- [`authenticate`][terok_executor.authenticate] / [`store_api_key`][terok_executor.store_api_key] — credential flows
+- [`build_base_images`][terok_executor.build_base_images] — image construction
+- [`get_roster`][terok_executor.get_roster] — YAML agent registry
 """
 
 __version__: str = "0.0.0"  # placeholder; replaced at build time

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -9,10 +9,10 @@ lifecycle of one AI coding agent at a time.  Designed for standalone use
 
 The public surface is ``__all__`` below.  Key entry points:
 
-- :class:`AgentRunner` — launch agents in containers
-- :func:`authenticate` / :func:`store_api_key` — credential flows
-- :func:`build_base_images` — image construction
-- :func:`get_roster` — YAML agent registry
+- [`AgentRunner`][] — launch agents in containers
+- [`authenticate`][] / [`store_api_key`][] — credential flows
+- [`build_base_images`][] — image construction
+- [`get_roster`][] — YAML agent registry
 """
 
 __version__: str = "0.0.0"  # placeholder; replaced at build time

--- a/src/terok_executor/cli.py
+++ b/src/terok_executor/cli.py
@@ -4,7 +4,7 @@
 
 """CLI entry point for terok-executor.
 
-Built from the command registry in :mod:`terok_executor.commands`.
+Built from the command registry in [`terok_executor.commands`][].
 No command logic lives here — just argument wiring and dispatch.
 """
 
@@ -58,7 +58,7 @@ def main() -> None:
 
 
 def _wire_command(sub: argparse._SubParsersAction, cmd: CommandDef) -> None:
-    """Add a :class:`CommandDef` to an argparse subparser group."""
+    """Add a [`CommandDef`][] to an argparse subparser group."""
     p = sub.add_parser(cmd.name, help=cmd.help)
     for arg in cmd.args:
         kwargs: dict = {}

--- a/src/terok_executor/cli.py
+++ b/src/terok_executor/cli.py
@@ -4,7 +4,7 @@
 
 """CLI entry point for terok-executor.
 
-Built from the command registry in [`terok_executor.commands`][].
+Built from the command registry in [`terok_executor.commands`][terok_executor.commands].
 No command logic lives here — just argument wiring and dispatch.
 """
 
@@ -58,7 +58,7 @@ def main() -> None:
 
 
 def _wire_command(sub: argparse._SubParsersAction, cmd: CommandDef) -> None:
-    """Add a [`CommandDef`][] to an argparse subparser group."""
+    """Add a [`CommandDef`][terok_executor.cli.CommandDef] to an argparse subparser group."""
     p = sub.add_parser(cmd.name, help=cmd.help)
     for arg in cmd.args:
         kwargs: dict = {}

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -52,7 +52,7 @@ class CommandDef:
 def _setup_verdict_or_exit(*, skip: bool) -> None:
     """Cheap stamp-based gate that runs before live preflight.
 
-    Reads [`terok_sandbox.needs_setup`][] and bounces the user with
+    Reads [`terok_sandbox.needs_setup`][terok_sandbox.needs_setup] and bounces the user with
     a structured exit code when the install is missing or stale:
 
     - ``OK`` → return; live preflight proceeds.

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -52,7 +52,7 @@ class CommandDef:
 def _setup_verdict_or_exit(*, skip: bool) -> None:
     """Cheap stamp-based gate that runs before live preflight.
 
-    Reads :func:`terok_sandbox.needs_setup` and bounces the user with
+    Reads [`terok_sandbox.needs_setup`][] and bounces the user with
     a structured exit code when the install is missing or stale:
 
     - ``OK`` → return; live preflight proceeds.

--- a/src/terok_executor/config_schema.py
+++ b/src/terok_executor/config_schema.py
@@ -6,15 +6,15 @@
 terok-executor owns one top-level section in the shared config:
 ``image:`` (base image, agent roster, Dockerfile snippets).  This
 module defines that section's strict schema and composes it with
-sandbox's :class:`~terok_sandbox.config_schema.SandboxConfigView`.
+sandbox's [`SandboxConfigView`][terok_sandbox.config_schema.SandboxConfigView].
 
 Standalone executor consumers (``terok-executor run``) validate the
-file against :class:`ExecutorConfigView`.  Sandbox-owned and
+file against [`ExecutorConfigView`][].  Sandbox-owned and
 executor-owned sections are strict on their own keys; unknown
 top-level sections (terok's ``tui:``, ``logs:`` …) pass through
 silently because the view is itself ``extra="allow"``.
 
-Higher layers (terok) inherit from :class:`ExecutorConfigView` and
+Higher layers (terok) inherit from [`ExecutorConfigView`][] and
 flip the top level to ``extra="forbid"`` because they know the full
 ecosystem set.
 """
@@ -70,7 +70,7 @@ class ExecutorConfigView(SandboxConfigView):
     """The slice of ``config.yml`` executor owns + sandbox owns (transitively).
 
     Inherits all eight sandbox-owned sections from
-    :class:`~terok_sandbox.config_schema.SandboxConfigView` and adds
+    [`SandboxConfigView`][terok_sandbox.config_schema.SandboxConfigView] and adds
     the executor-owned ``image:`` section.  ``extra="allow"`` keeps the
     view tolerant of foreign top-level keys (terok's ``tui:`` /
     ``logs:`` / ``tasks:`` / ``git:`` / ``hooks:``) — standalone

--- a/src/terok_executor/config_schema.py
+++ b/src/terok_executor/config_schema.py
@@ -9,12 +9,12 @@ module defines that section's strict schema and composes it with
 sandbox's [`SandboxConfigView`][terok_sandbox.config_schema.SandboxConfigView].
 
 Standalone executor consumers (``terok-executor run``) validate the
-file against [`ExecutorConfigView`][].  Sandbox-owned and
+file against [`ExecutorConfigView`][terok_executor.config_schema.ExecutorConfigView].  Sandbox-owned and
 executor-owned sections are strict on their own keys; unknown
 top-level sections (terok's ``tui:``, ``logs:`` …) pass through
 silently because the view is itself ``extra="allow"``.
 
-Higher layers (terok) inherit from [`ExecutorConfigView`][] and
+Higher layers (terok) inherit from [`ExecutorConfigView`][terok_executor.config_schema.ExecutorConfigView] and
 flip the top level to ``extra="forbid"`` because they know the full
 ecosystem set.
 """

--- a/src/terok_executor/container/__init__.py
+++ b/src/terok_executor/container/__init__.py
@@ -3,7 +3,7 @@
 
 """Container lifecycle — image building, environment assembly, agent launch.
 
-Delegates to [`.build`][] for Dockerfile rendering and ``podman build``,
-[`.env`][] for container environment and volume assembly, and
-[`.runner`][] for the high-level agent runner that composes all three.
+Delegates to `.build` for Dockerfile rendering and ``podman build``,
+`.env` for container environment and volume assembly, and
+`.runner` for the high-level agent runner that composes all three.
 """

--- a/src/terok_executor/container/__init__.py
+++ b/src/terok_executor/container/__init__.py
@@ -3,7 +3,7 @@
 
 """Container lifecycle — image building, environment assembly, agent launch.
 
-Delegates to :mod:`.build` for Dockerfile rendering and ``podman build``,
-:mod:`.env` for container environment and volume assembly, and
-:mod:`.runner` for the high-level agent runner that composes all three.
+Delegates to [`.build`][] for Dockerfile rendering and ``podman build``,
+[`.env`][] for container environment and volume assembly, and
+[`.runner`][] for the high-level agent runner that composes all three.
 """

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -29,7 +29,7 @@ Usage as a library::
 
 The L0/L1 templates select between Debian/Ubuntu (``apt``) and Fedora-like
 (``dnf``) package managers via a ``family`` Jinja2 variable resolved by
-:func:`detect_family` from the base image name (or an explicit override).
+[`detect_family`][] from the base image name (or an explicit override).
 
 L1 is roster-driven: each agent's install steps live in its YAML file
 (``install.run_as_root`` / ``install.run_as_dev``), and the L1 template
@@ -67,7 +67,7 @@ INSTALLED_ENV_PATH = "/etc/terok/installed.env"
 """In-container env file that scripts source to learn what's installed."""
 
 _HELP_SECTION_FILES: dict[str, str] = {"agent": "agents.txt", "dev_tool": "dev-tools.txt"}
-"""Maps each :class:`~terok_executor.roster.loader.HelpSection` to its fragment filename."""
+"""Maps each [`HelpSection`][terok_executor.roster.loader.HelpSection] to its fragment filename."""
 
 _ESCAPE_RE = re.compile(r"\\(?:[0-7]{1,3}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|[nrtbfav\\'\"])")
 """Backslash escapes recognised in roster ``help.label`` strings.
@@ -97,8 +97,8 @@ _MAX_TAG_LEN = 120
 """Cap on the tag portion of an OCI image reference.
 
 OCI spec allows 128; the extra headroom absorbs future suffix changes
-without rebuilding history.  Both :func:`_base_tag` (for the L0 tag)
-and :func:`l1_image_tag` (for the L1 base+agents tag) respect this.
+without rebuilding history.  Both [`_base_tag`][] (for the L0 tag)
+and [`l1_image_tag`][] (for the L1 base+agents tag) respect this.
 """
 
 _AGENT_DIGEST_LEN = 12
@@ -169,7 +169,7 @@ def detect_family(base_image: str, override: str | None = None) -> str:
     (Ubuntu/Debian, Fedora, the official Podman container, NVIDIA CUDA/HPC
     SDK).  NVIDIA images are inspected at the tag level so UBI variants
     (e.g. ``…:13.0.0-devel-ubi9``) resolve to ``rpm`` while Ubuntu
-    variants resolve to ``deb``.  Unknown images raise :class:`BuildError`
+    variants resolve to ``deb``.  Unknown images raise [`BuildError`][]
     with a hint to set ``family:`` explicitly.
     """
     if override is not None:
@@ -201,7 +201,7 @@ def build_project_image(
     """Build an OCI image from a pre-rendered Dockerfile.
 
     The thin ``podman build`` invoker that the three opinionated factories
-    in this module (:func:`build_base_images`, :func:`build_sidecar_image`,
+    in this module ([`build_base_images`][], [`build_sidecar_image`][],
     and terok's project/L2 build) share.  Callers own Dockerfile
     rendering, tag naming, label computation, and build-context staging —
     this function only assembles flags and shells out.
@@ -263,7 +263,7 @@ def build_base_images(
     Args:
         base_image: Base OS image (e.g. ``ubuntu:24.04``, ``nvidia/cuda:...``).
         family: Override for the package family (``"deb"`` or ``"rpm"``).
-            ``None`` means detect from *base_image* via :func:`detect_family`.
+            ``None`` means detect from *base_image* via [`detect_family`][].
         agents: Roster entries to install, as the literal string ``"all"``
             (every entry) or a tuple of names (transitively expanded by
             ``depends_on``).  Same selection drives the OCI label, the L1
@@ -273,7 +273,7 @@ def build_base_images(
         build_dir: Build context directory (must be empty or absent).
 
     Returns:
-        :class:`ImageSet` with the L0 and L1 image tags.
+        [`ImageSet`][] with the L0 and L1 image tags.
 
     Raises:
         BuildError: If podman is missing, the family cannot be resolved,
@@ -374,7 +374,7 @@ def build_sidecar_image(
     Args:
         base_image: Base OS image (passed through to L0 build).
         family: Override for the package family (``"deb"`` or ``"rpm"``).
-            ``None`` means detect from *base_image* via :func:`detect_family`.
+            ``None`` means detect from *base_image* via [`detect_family`][].
         tool_name: Tool to install (selects Jinja2 conditional in template).
         rebuild: Force rebuild with cache bust.
         full_rebuild: Force rebuild with ``--no-cache``.
@@ -454,7 +454,7 @@ def prepare_build_context(dest: Path) -> None:
     - ``tmux/``        — container tmux config
 
     Dockerfiles themselves are **not** written here — they are rendered
-    and placed by :func:`build_base_images` (which calls this function
+    and placed by [`build_base_images`][] (which calls this function
     internally).
     """
     dest.mkdir(parents=True, exist_ok=True)
@@ -472,7 +472,7 @@ def render_l0(base_image: str = DEFAULT_BASE_IMAGE, *, family: str | None = None
     The *base_image* is normalised before rendering so that blank or
     whitespace-only values produce a valid Dockerfile.  *family*
     (``"deb"`` or ``"rpm"``) selects the package-manager branch of the
-    template; ``None`` resolves it via :func:`detect_family`.
+    template; ``None`` resolves it via [`detect_family`][].
     """
     base_image = _normalize_base_image(base_image)
     fam = detect_family(base_image, override=family)
@@ -495,7 +495,7 @@ def render_l1(
     (``"deb"`` or ``"rpm"``) selects the package-manager branch and is
     required — there is no L0 reference to detect from at this point, so
     callers must supply the value resolved at the L0 level (typically via
-    :func:`detect_family`).  Each roster install snippet is itself rendered
+    [`detect_family`][]).  Each roster install snippet is itself rendered
     as a Jinja template with ``family`` in scope, so snippets can carry
     ``{% if family == "deb" %}…{% else %}…{% endif %}`` branches for
     package-manager-specific commands.  *agents* is a tuple of
@@ -649,10 +649,10 @@ def l1_image_tag(base_image: str, agents: tuple[str, ...] | None = None) -> str:
     sanitiser to keep the final tag within the OCI tag charset
     (``[A-Za-z0-9_.-]``).
 
-    The full tag (after ``:``) is bounded by :data:`_MAX_TAG_LEN`.  When
+    The full tag (after ``:``) is bounded by [`_MAX_TAG_LEN`][].  When
     the readable ``base-a-b-c`` form would overflow, the agent portion
     is replaced with a SHA1 digest of the sorted selection — same
-    collision-resistant fallback pattern :func:`_base_tag` uses
+    collision-resistant fallback pattern [`_base_tag`][] uses
     internally for overlong image names.
     """
     base_tag = _base_tag(base_image)
@@ -787,7 +787,7 @@ def _clean_packaging_artifacts(dest: Path) -> None:
 
 
 def _check_podman() -> None:
-    """Raise :class:`BuildError` if podman is not on PATH."""
+    """Raise [`BuildError`][] if podman is not on PATH."""
     if shutil.which("podman") is None:
         raise BuildError("podman not found; please install podman")
 

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -29,7 +29,7 @@ Usage as a library::
 
 The L0/L1 templates select between Debian/Ubuntu (``apt``) and Fedora-like
 (``dnf``) package managers via a ``family`` Jinja2 variable resolved by
-[`detect_family`][] from the base image name (or an explicit override).
+[`detect_family`][terok_executor.container.build.detect_family] from the base image name (or an explicit override).
 
 L1 is roster-driven: each agent's install steps live in its YAML file
 (``install.run_as_root`` / ``install.run_as_dev``), and the L1 template
@@ -97,8 +97,8 @@ _MAX_TAG_LEN = 120
 """Cap on the tag portion of an OCI image reference.
 
 OCI spec allows 128; the extra headroom absorbs future suffix changes
-without rebuilding history.  Both [`_base_tag`][] (for the L0 tag)
-and [`l1_image_tag`][] (for the L1 base+agents tag) respect this.
+without rebuilding history.  Both `_base_tag` (for the L0 tag)
+and [`l1_image_tag`][terok_executor.container.build.l1_image_tag] (for the L1 base+agents tag) respect this.
 """
 
 _AGENT_DIGEST_LEN = 12
@@ -169,7 +169,7 @@ def detect_family(base_image: str, override: str | None = None) -> str:
     (Ubuntu/Debian, Fedora, the official Podman container, NVIDIA CUDA/HPC
     SDK).  NVIDIA images are inspected at the tag level so UBI variants
     (e.g. ``…:13.0.0-devel-ubi9``) resolve to ``rpm`` while Ubuntu
-    variants resolve to ``deb``.  Unknown images raise [`BuildError`][]
+    variants resolve to ``deb``.  Unknown images raise [`BuildError`][terok_executor.container.build.BuildError]
     with a hint to set ``family:`` explicitly.
     """
     if override is not None:
@@ -201,7 +201,7 @@ def build_project_image(
     """Build an OCI image from a pre-rendered Dockerfile.
 
     The thin ``podman build`` invoker that the three opinionated factories
-    in this module ([`build_base_images`][], [`build_sidecar_image`][],
+    in this module ([`build_base_images`][terok_executor.container.build.build_base_images], [`build_sidecar_image`][terok_executor.container.build.build_sidecar_image],
     and terok's project/L2 build) share.  Callers own Dockerfile
     rendering, tag naming, label computation, and build-context staging —
     this function only assembles flags and shells out.
@@ -263,7 +263,7 @@ def build_base_images(
     Args:
         base_image: Base OS image (e.g. ``ubuntu:24.04``, ``nvidia/cuda:...``).
         family: Override for the package family (``"deb"`` or ``"rpm"``).
-            ``None`` means detect from *base_image* via [`detect_family`][].
+            ``None`` means detect from *base_image* via [`detect_family`][terok_executor.container.build.detect_family].
         agents: Roster entries to install, as the literal string ``"all"``
             (every entry) or a tuple of names (transitively expanded by
             ``depends_on``).  Same selection drives the OCI label, the L1
@@ -273,7 +273,7 @@ def build_base_images(
         build_dir: Build context directory (must be empty or absent).
 
     Returns:
-        [`ImageSet`][] with the L0 and L1 image tags.
+        [`ImageSet`][terok_executor.container.build.ImageSet] with the L0 and L1 image tags.
 
     Raises:
         BuildError: If podman is missing, the family cannot be resolved,
@@ -374,7 +374,7 @@ def build_sidecar_image(
     Args:
         base_image: Base OS image (passed through to L0 build).
         family: Override for the package family (``"deb"`` or ``"rpm"``).
-            ``None`` means detect from *base_image* via [`detect_family`][].
+            ``None`` means detect from *base_image* via [`detect_family`][terok_executor.container.build.detect_family].
         tool_name: Tool to install (selects Jinja2 conditional in template).
         rebuild: Force rebuild with cache bust.
         full_rebuild: Force rebuild with ``--no-cache``.
@@ -454,7 +454,7 @@ def prepare_build_context(dest: Path) -> None:
     - ``tmux/``        — container tmux config
 
     Dockerfiles themselves are **not** written here — they are rendered
-    and placed by [`build_base_images`][] (which calls this function
+    and placed by [`build_base_images`][terok_executor.container.build.build_base_images] (which calls this function
     internally).
     """
     dest.mkdir(parents=True, exist_ok=True)
@@ -472,7 +472,7 @@ def render_l0(base_image: str = DEFAULT_BASE_IMAGE, *, family: str | None = None
     The *base_image* is normalised before rendering so that blank or
     whitespace-only values produce a valid Dockerfile.  *family*
     (``"deb"`` or ``"rpm"``) selects the package-manager branch of the
-    template; ``None`` resolves it via [`detect_family`][].
+    template; ``None`` resolves it via [`detect_family`][terok_executor.container.build.detect_family].
     """
     base_image = _normalize_base_image(base_image)
     fam = detect_family(base_image, override=family)
@@ -495,7 +495,7 @@ def render_l1(
     (``"deb"`` or ``"rpm"``) selects the package-manager branch and is
     required — there is no L0 reference to detect from at this point, so
     callers must supply the value resolved at the L0 level (typically via
-    [`detect_family`][]).  Each roster install snippet is itself rendered
+    [`detect_family`][terok_executor.container.build.detect_family]).  Each roster install snippet is itself rendered
     as a Jinja template with ``family`` in scope, so snippets can carry
     ``{% if family == "deb" %}…{% else %}…{% endif %}`` branches for
     package-manager-specific commands.  *agents* is a tuple of
@@ -649,10 +649,10 @@ def l1_image_tag(base_image: str, agents: tuple[str, ...] | None = None) -> str:
     sanitiser to keep the final tag within the OCI tag charset
     (``[A-Za-z0-9_.-]``).
 
-    The full tag (after ``:``) is bounded by [`_MAX_TAG_LEN`][].  When
+    The full tag (after ``:``) is bounded by `_MAX_TAG_LEN`.  When
     the readable ``base-a-b-c`` form would overflow, the agent portion
     is replaced with a SHA1 digest of the sorted selection — same
-    collision-resistant fallback pattern [`_base_tag`][] uses
+    collision-resistant fallback pattern `_base_tag` uses
     internally for overlong image names.
     """
     base_tag = _base_tag(base_image)
@@ -787,7 +787,7 @@ def _clean_packaging_artifacts(dest: Path) -> None:
 
 
 def _check_podman() -> None:
-    """Raise [`BuildError`][] if podman is not on PATH."""
+    """Raise [`BuildError`][terok_executor.container.build.BuildError] if podman is not on PATH."""
     if shutil.which("podman") is None:
         raise BuildError("podman not found; please install podman")
 

--- a/src/terok_executor/container/cache.py
+++ b/src/terok_executor/container/cache.py
@@ -9,7 +9,7 @@ host.  Copying that cache into the task workspace before container
 launch replaces the slow in-container ``git clone`` with a fast file
 copy followed by a lightweight ``git fetch + reset``.
 
-The public entry point is [`seed_workspace_from_clone_cache`][].
+The public entry point is [`seed_workspace_from_clone_cache`][terok_executor.container.cache.seed_workspace_from_clone_cache].
 """
 
 from __future__ import annotations
@@ -88,7 +88,7 @@ def _resolve_cache_dir(scope: str, cfg: SandboxConfig | None) -> Path | None:
 def _copy_tree(src: Path, dst: Path) -> None:
     """Copy *src* into *dst* using ``cp --reflink=auto`` for CoW speed.
 
-    Falls back to [`shutil.copytree`][] when ``cp`` is unavailable.
+    Falls back to [`shutil.copytree`][shutil.copytree] when ``cp`` is unavailable.
     """
     try:
         subprocess.run(

--- a/src/terok_executor/container/cache.py
+++ b/src/terok_executor/container/cache.py
@@ -9,7 +9,7 @@ host.  Copying that cache into the task workspace before container
 launch replaces the slow in-container ``git clone`` with a fast file
 copy followed by a lightweight ``git fetch + reset``.
 
-The public entry point is :func:`seed_workspace_from_clone_cache`.
+The public entry point is [`seed_workspace_from_clone_cache`][].
 """
 
 from __future__ import annotations
@@ -88,7 +88,7 @@ def _resolve_cache_dir(scope: str, cfg: SandboxConfig | None) -> Path | None:
 def _copy_tree(src: Path, dst: Path) -> None:
     """Copy *src* into *dst* using ``cp --reflink=auto`` for CoW speed.
 
-    Falls back to :func:`shutil.copytree` when ``cp`` is unavailable.
+    Falls back to [`shutil.copytree`][] when ``cp`` is unavailable.
     """
     try:
         subprocess.run(

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -33,7 +33,7 @@ from terok_sandbox import Sharing, VolumeSpec
 from terok_executor._util import detect_host_timezone
 
 _CONTAINER_RUNTIME_DIR = "/run/terok"
-"""Container-side mount point — must match :data:`terok_sandbox.CONTAINER_RUNTIME_DIR`."""
+"""Container-side mount point — must match [`terok_sandbox.CONTAINER_RUNTIME_DIR`][]."""
 
 CONTAINER_PROTOCOL = 1
 """Version of the host↔container env/script contract.
@@ -60,7 +60,7 @@ _logger = logging.getLogger(__name__)
 class ContainerEnvSpec:
     """Specification for container environment assembly.
 
-    All fields use primitives or :class:`~pathlib.Path` — no terok-specific
+    All fields use primitives or [`Path`][pathlib.Path] — no terok-specific
     types.  Callers pre-resolve domain-specific decisions (security class,
     authorship mode, SSH mount, gate mirror creation) and pass results here.
     """
@@ -115,7 +115,7 @@ class ContainerEnvSpec:
 
     vault_transport: Literal["direct", "socket"] = "direct"
     """Vault transport mode: ``"direct"`` (HTTP base URL) or ``"socket"``
-    (Unix socket path via :attr:`~VaultRoute.socket_env`)."""
+    (Unix socket path via [`socket_env`][VaultRoute.socket_env])."""
 
     vault_required: bool = False
     """When ``True``, raise ``SystemExit`` if the vault is
@@ -136,7 +136,7 @@ class ContainerEnvSpec:
     """IANA timezone name propagated to the container as ``TZ``.
 
     ``None`` (the default) means *detect the host's timezone* via
-    :func:`terok_executor._util.detect_host_timezone` — the container
+    [`terok_executor._util.detect_host_timezone`][] — the container
     then follows the host.  Pass an explicit string (``"UTC"``,
     ``"Europe/Prague"``) to override, including to pin the container to
     UTC for reproducible runs.  If neither detection nor an override
@@ -161,7 +161,7 @@ class ContainerEnvSpec:
     """Host-side task directory.  A temp dir is created if ``None``."""
 
     envs_dir: Path | None = None
-    """Base directory for shared config mounts.  Uses :func:`paths.mounts_dir`
+    """Base directory for shared config mounts.  Uses [`paths.mounts_dir`][]
     if ``None``."""
 
     # -- Caller-specific mounts --------------------------------------------

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -33,7 +33,7 @@ from terok_sandbox import Sharing, VolumeSpec
 from terok_executor._util import detect_host_timezone
 
 _CONTAINER_RUNTIME_DIR = "/run/terok"
-"""Container-side mount point — must match [`terok_sandbox.CONTAINER_RUNTIME_DIR`][]."""
+"""Container-side mount point — must match [`terok_sandbox.CONTAINER_RUNTIME_DIR`][terok_sandbox.CONTAINER_RUNTIME_DIR]."""
 
 CONTAINER_PROTOCOL = 1
 """Version of the host↔container env/script contract.
@@ -115,7 +115,7 @@ class ContainerEnvSpec:
 
     vault_transport: Literal["direct", "socket"] = "direct"
     """Vault transport mode: ``"direct"`` (HTTP base URL) or ``"socket"``
-    (Unix socket path via [`socket_env`][VaultRoute.socket_env])."""
+    (Unix socket path via [`socket_env`][terok_executor.VaultRoute.socket_env])."""
 
     vault_required: bool = False
     """When ``True``, raise ``SystemExit`` if the vault is
@@ -136,7 +136,7 @@ class ContainerEnvSpec:
     """IANA timezone name propagated to the container as ``TZ``.
 
     ``None`` (the default) means *detect the host's timezone* via
-    [`terok_executor._util.detect_host_timezone`][] — the container
+    `terok_executor._util.detect_host_timezone` — the container
     then follows the host.  Pass an explicit string (``"UTC"``,
     ``"Europe/Prague"``) to override, including to pin the container to
     UTC for reproducible runs.  If neither detection nor an override
@@ -161,7 +161,7 @@ class ContainerEnvSpec:
     """Host-side task directory.  A temp dir is created if ``None``."""
 
     envs_dir: Path | None = None
-    """Base directory for shared config mounts.  Uses [`paths.mounts_dir`][]
+    """Base directory for shared config mounts.  Uses [`paths.mounts_dir`][terok_executor.paths.mounts_dir]
     if ``None``."""
 
     # -- Caller-specific mounts --------------------------------------------

--- a/src/terok_executor/container/inject.py
+++ b/src/terok_executor/container/inject.py
@@ -5,7 +5,7 @@
 
 In sealed isolation mode, the container has no bind mounts — files must be
 injected via ``podman cp``.  These helpers complement
-:func:`~terok_executor.provider.agents.prepare_agent_config_dir` which prepares
+[`prepare_agent_config_dir`][terok_executor.provider.agents.prepare_agent_config_dir] which prepares
 the files on the host side.
 """
 
@@ -19,7 +19,7 @@ def inject_agent_config(container_name: str, config_dir: Path) -> None:
     """Copy a prepared agent-config directory into a sealed container.
 
     The container must be in the *created* or *stopped* state.  Delegates
-    to :meth:`terok_sandbox.Sandbox.copy_to`.
+    to [`terok_sandbox.Sandbox.copy_to`][].
     """
     from terok_sandbox import Sandbox
 

--- a/src/terok_executor/container/inject.py
+++ b/src/terok_executor/container/inject.py
@@ -19,7 +19,7 @@ def inject_agent_config(container_name: str, config_dir: Path) -> None:
     """Copy a prepared agent-config directory into a sealed container.
 
     The container must be in the *created* or *stopped* state.  Delegates
-    to [`terok_sandbox.Sandbox.copy_to`][].
+    to [`terok_sandbox.Sandbox.copy_to`][terok_sandbox.Sandbox.copy_to].
     """
     from terok_sandbox import Sandbox
 

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -328,8 +328,8 @@ class AgentRunner:
         volume specs — e.g. the terok orchestrator, which computes
         project-specific env via ``build_task_env_and_volumes`` and owns
         the container naming policy.  For end-to-end runs from a repo and
-        prompt (CLI-style), use :meth:`run_headless`, :meth:`run_interactive`,
-        or :meth:`run_web` instead.
+        prompt (CLI-style), use [`run_headless`][], [`run_interactive`][],
+        or [`run_web`][] instead.
 
         In sealed isolation mode (*sealed=True*), the sandbox splits the
         launch into ``create`` → ``copy_to`` → ``start`` instead of a
@@ -391,22 +391,22 @@ class AgentRunner:
     ) -> int:
         """Block until *container_name* exits; return its exit code.
 
-        Raises :class:`TimeoutError` when *timeout* elapses before the
+        Raises [`TimeoutError`][] when *timeout* elapses before the
         container exits — signalled out of band so a container that
         legitimately exits with code 124 (the ``timeout(1)`` convention)
         is returned unambiguously as its real exit code, not conflated
         with the wait timing out.
 
-        Raises :class:`RuntimeError` when ``podman wait`` itself fails
+        Raises [`RuntimeError`][] when ``podman wait`` itself fails
         (non-zero returncode, e.g. unknown container) or returns output
         that is not a container exit code — the podman error is never
         impersonated as the container's exit code, which would let a
         "no such container" diagnostic leak out as exit code 125.
 
-        Raises :class:`FileNotFoundError` when ``podman`` is not on PATH.
+        Raises [`FileNotFoundError`][] when ``podman`` is not on PATH.
         Intentionally re-implements the wait loop instead of delegating
-        to :meth:`Sandbox.wait_for_exit`, which swallows
-        :class:`subprocess.TimeoutExpired` and returns the 124 sentinel
+        to [`Sandbox.wait_for_exit`][], which swallows
+        [`subprocess.TimeoutExpired`][] and returns the 124 sentinel
         — fine for fire-and-forget generic waits, lossy for task-level
         callers that need to record the real exit code.
         """
@@ -451,12 +451,12 @@ class AgentRunner:
         """Return the container's logged output as a single string.
 
         One-shot retrieval for the "just show me what ran" case.  For live
-        streaming (human watching), use :meth:`stream_logs_process`; for
-        archival, use :meth:`capture_logs`.
+        streaming (human watching), use [`stream_logs_process`][]; for
+        archival, use [`capture_logs`][].
 
-        Raises :class:`RuntimeError` when ``podman logs`` returns a non-zero
+        Raises [`RuntimeError`][] when ``podman logs`` returns a non-zero
         status (e.g. unknown container) — the diagnostic is surfaced rather
-        than impersonated as empty output.  :class:`FileNotFoundError`
+        than impersonated as empty output.  [`FileNotFoundError`][]
         propagates when ``podman`` is not on PATH.
         """
         import subprocess
@@ -542,7 +542,7 @@ class AgentRunner:
         (matches ``subprocess.STDOUT``); otherwise stderr is a separate
         pipe the caller can drain.
 
-        :class:`FileNotFoundError` propagates when ``podman`` is not on
+        [`FileNotFoundError`][] propagates when ``podman`` is not on
         PATH — callers handle it (usually as a user-facing "podman not
         installed" error).
         """
@@ -869,7 +869,7 @@ class AgentRunner:
     ) -> Path:
         """Prepare the agent-config directory for a task.
 
-        *project_root* is passed to :func:`resolve_instructions` so that
+        *project_root* is passed to [`resolve_instructions`][] so that
         ``<repo>/instructions.md`` is appended when present.
         """
         from terok_executor.provider.agents import AgentConfigSpec, prepare_agent_config_dir
@@ -945,8 +945,8 @@ def _build_logs_cmd(
 ) -> list[str]:
     """Assemble a ``podman logs`` command with the given flags.
 
-    Shared builder so the three log entry points (:meth:`AgentRunner.logs`,
-    :meth:`AgentRunner.capture_logs`, :meth:`AgentRunner.stream_logs_process`)
+    Shared builder so the three log entry points ([`AgentRunner.logs`][],
+    [`AgentRunner.capture_logs`][], [`AgentRunner.stream_logs_process`][])
     agree on flag order and naming.
     """
     cmd = ["podman", "logs"]

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -328,8 +328,8 @@ class AgentRunner:
         volume specs — e.g. the terok orchestrator, which computes
         project-specific env via ``build_task_env_and_volumes`` and owns
         the container naming policy.  For end-to-end runs from a repo and
-        prompt (CLI-style), use [`run_headless`][], [`run_interactive`][],
-        or [`run_web`][] instead.
+        prompt (CLI-style), use [`run_headless`][terok_executor.container.runner.AgentRunner.run_headless], [`run_interactive`][terok_executor.container.runner.AgentRunner.run_interactive],
+        or [`run_web`][terok_executor.container.runner.AgentRunner.run_web] instead.
 
         In sealed isolation mode (*sealed=True*), the sandbox splits the
         launch into ``create`` → ``copy_to`` → ``start`` instead of a
@@ -391,22 +391,22 @@ class AgentRunner:
     ) -> int:
         """Block until *container_name* exits; return its exit code.
 
-        Raises [`TimeoutError`][] when *timeout* elapses before the
+        Raises [`TimeoutError`][TimeoutError] when *timeout* elapses before the
         container exits — signalled out of band so a container that
         legitimately exits with code 124 (the ``timeout(1)`` convention)
         is returned unambiguously as its real exit code, not conflated
         with the wait timing out.
 
-        Raises [`RuntimeError`][] when ``podman wait`` itself fails
+        Raises [`RuntimeError`][RuntimeError] when ``podman wait`` itself fails
         (non-zero returncode, e.g. unknown container) or returns output
         that is not a container exit code — the podman error is never
         impersonated as the container's exit code, which would let a
         "no such container" diagnostic leak out as exit code 125.
 
-        Raises [`FileNotFoundError`][] when ``podman`` is not on PATH.
+        Raises [`FileNotFoundError`][FileNotFoundError] when ``podman`` is not on PATH.
         Intentionally re-implements the wait loop instead of delegating
-        to [`Sandbox.wait_for_exit`][], which swallows
-        [`subprocess.TimeoutExpired`][] and returns the 124 sentinel
+        to `Sandbox.wait_for_exit`, which swallows
+        [`subprocess.TimeoutExpired`][subprocess.TimeoutExpired] and returns the 124 sentinel
         — fine for fire-and-forget generic waits, lossy for task-level
         callers that need to record the real exit code.
         """
@@ -451,12 +451,12 @@ class AgentRunner:
         """Return the container's logged output as a single string.
 
         One-shot retrieval for the "just show me what ran" case.  For live
-        streaming (human watching), use [`stream_logs_process`][]; for
-        archival, use [`capture_logs`][].
+        streaming (human watching), use [`stream_logs_process`][terok_executor.container.runner.AgentRunner.stream_logs_process]; for
+        archival, use [`capture_logs`][terok_executor.container.runner.AgentRunner.capture_logs].
 
-        Raises [`RuntimeError`][] when ``podman logs`` returns a non-zero
+        Raises [`RuntimeError`][RuntimeError] when ``podman logs`` returns a non-zero
         status (e.g. unknown container) — the diagnostic is surfaced rather
-        than impersonated as empty output.  [`FileNotFoundError`][]
+        than impersonated as empty output.  [`FileNotFoundError`][FileNotFoundError]
         propagates when ``podman`` is not on PATH.
         """
         import subprocess
@@ -542,7 +542,7 @@ class AgentRunner:
         (matches ``subprocess.STDOUT``); otherwise stderr is a separate
         pipe the caller can drain.
 
-        [`FileNotFoundError`][] propagates when ``podman`` is not on
+        [`FileNotFoundError`][FileNotFoundError] propagates when ``podman`` is not on
         PATH — callers handle it (usually as a user-facing "podman not
         installed" error).
         """
@@ -869,7 +869,7 @@ class AgentRunner:
     ) -> Path:
         """Prepare the agent-config directory for a task.
 
-        *project_root* is passed to [`resolve_instructions`][] so that
+        *project_root* is passed to [`resolve_instructions`][terok_executor.resolve_instructions] so that
         ``<repo>/instructions.md`` is appended when present.
         """
         from terok_executor.provider.agents import AgentConfigSpec, prepare_agent_config_dir
@@ -945,8 +945,8 @@ def _build_logs_cmd(
 ) -> list[str]:
     """Assemble a ``podman logs`` command with the given flags.
 
-    Shared builder so the three log entry points ([`AgentRunner.logs`][],
-    [`AgentRunner.capture_logs`][], [`AgentRunner.stream_logs_process`][])
+    Shared builder so the three log entry points ([`AgentRunner.logs`][terok_executor.container.runner.AgentRunner.logs],
+    [`AgentRunner.capture_logs`][terok_executor.container.runner.AgentRunner.capture_logs], [`AgentRunner.stream_logs_process`][terok_executor.container.runner.AgentRunner.stream_logs_process])
     agree on flag order and naming.
     """
     cmd = ["podman", "logs"]

--- a/src/terok_executor/credentials/__init__.py
+++ b/src/terok_executor/credentials/__init__.py
@@ -3,8 +3,8 @@
 
 """Authenticates agents and vaults their credentials into sandboxed containers.
 
-Delegates to :mod:`.auth` for auth provider registry and container-based
-auth flows, :mod:`.extractors` for per-provider credential file parsing,
-:mod:`.vault_commands` for vault CLI lifecycle, and :mod:`.vault_config`
+Delegates to [`.auth`][] for auth provider registry and container-based
+auth flows, [`.extractors`][] for per-provider credential file parsing,
+[`.vault_commands`][] for vault CLI lifecycle, and [`.vault_config`][]
 for post-auth config file patching.
 """

--- a/src/terok_executor/credentials/__init__.py
+++ b/src/terok_executor/credentials/__init__.py
@@ -3,8 +3,8 @@
 
 """Authenticates agents and vaults their credentials into sandboxed containers.
 
-Delegates to [`.auth`][] for auth provider registry and container-based
-auth flows, [`.extractors`][] for per-provider credential file parsing,
-[`.vault_commands`][] for vault CLI lifecycle, and [`.vault_config`][]
+Delegates to `.auth` for auth provider registry and container-based
+auth flows, `.extractors` for per-provider credential file parsing,
+`.vault_commands` for vault CLI lifecycle, and `.vault_config`
 for post-auth config file patching.
 """

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -354,7 +354,7 @@ def _capture_credentials(
 ) -> None:
     """Extract credentials from *auth_dir* and store in the credential DB.
 
-    Uses the per-provider extractors from :mod:`credential_extractors`.
+    Uses the per-provider extractors from [`credential_extractors`][].
     If extraction fails (no credential file, malformed), prints a warning
     but does not raise — the auth flow succeeded, the user can retry.
 
@@ -489,7 +489,7 @@ def _codex_oauth_mount_writer(
     - **Default**: drop a phantom ``auth.json`` — the real ``id_token``
       JWT (for plan-tier + workspace UI, public claims only) and
       ``account_id`` survive, but ``access_token`` and ``refresh_token``
-      are replaced with :data:`PHANTOM_CREDENTIALS_MARKER`.  The vault
+      are replaced with [`PHANTOM_CREDENTIALS_MARKER`][].  The vault
       translates the marker back to the real token on inference
       requests; the CLI itself never sees the live bearer.  This is the
       fallback for tier 2 (proxied) and also a no-harm default for
@@ -565,7 +565,7 @@ def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
 
 #: Maps provider name → post-capture mount reconciler.  OAuth-capable
 #: providers register here to share the expose/proxy dispatch in
-#: :func:`_capture_credentials`.
+#: [`_capture_credentials`][].
 _OAUTH_MOUNT_WRITERS: dict[str, Callable[[Path, Path, dict, bool], None]] = {
     "claude": _claude_oauth_mount_writer,
     "codex": _codex_oauth_mount_writer,

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -354,7 +354,7 @@ def _capture_credentials(
 ) -> None:
     """Extract credentials from *auth_dir* and store in the credential DB.
 
-    Uses the per-provider extractors from [`credential_extractors`][].
+    Uses the per-provider extractors from `credential_extractors`.
     If extraction fails (no credential file, malformed), prints a warning
     but does not raise — the auth flow succeeded, the user can retry.
 
@@ -489,7 +489,7 @@ def _codex_oauth_mount_writer(
     - **Default**: drop a phantom ``auth.json`` — the real ``id_token``
       JWT (for plan-tier + workspace UI, public claims only) and
       ``account_id`` survive, but ``access_token`` and ``refresh_token``
-      are replaced with [`PHANTOM_CREDENTIALS_MARKER`][].  The vault
+      are replaced with `PHANTOM_CREDENTIALS_MARKER`.  The vault
       translates the marker back to the real token on inference
       requests; the CLI itself never sees the live bearer.  This is the
       fallback for tier 2 (proxied) and also a no-harm default for
@@ -565,7 +565,7 @@ def _write_codex_phantom_auth_json(cred_data: dict, dest: Path) -> None:
 
 #: Maps provider name → post-capture mount reconciler.  OAuth-capable
 #: providers register here to share the expose/proxy dispatch in
-#: [`_capture_credentials`][].
+#: `_capture_credentials`.
 _OAUTH_MOUNT_WRITERS: dict[str, Callable[[Path, Path, dict, bool], None]] = {
     "claude": _claude_oauth_mount_writer,
     "codex": _codex_oauth_mount_writer,

--- a/src/terok_executor/credentials/extractors.py
+++ b/src/terok_executor/credentials/extractors.py
@@ -5,7 +5,7 @@
 
 Each extractor reads a vendor-specific credential file from a temporary
 auth container mount and returns a normalized dict suitable for storage
-in :class:`~terok_sandbox.CredentialDB`.  The dict must contain at least
+in [`CredentialDB`][terok_sandbox.CredentialDB].  The dict must contain at least
 one of ``access_token``, ``token``, or ``key`` --- the vault server
 uses these fields to inject the real auth header.
 

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -50,7 +50,7 @@ def _is_injected_credentials_file(path: Path) -> bool:
 
     Returns ``True`` only when **all** of these hold:
 
-    - ``claudeAiOauth.accessToken`` equals [`PHANTOM_CREDENTIALS_MARKER`][]
+    - ``claudeAiOauth.accessToken`` equals `PHANTOM_CREDENTIALS_MARKER`
     - ``claudeAiOauth.refreshToken`` is empty or absent
 
     Any parse error or unexpected structure → ``False`` (treat as real leak).
@@ -79,7 +79,7 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     into containers.  This function checks each routed provider's mount for
     credential files that would leak real tokens alongside phantom ones.
 
-    Files injected by [`_write_claude_credentials_file`][terok_executor.auth._write_claude_credentials_file]
+    Files injected by `_write_claude_credentials_file`
     are recognised by their dummy ``accessToken`` marker and skipped.
 
     Symlinks are rejected to prevent a container from tricking the scan into

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -50,7 +50,7 @@ def _is_injected_credentials_file(path: Path) -> bool:
 
     Returns ``True`` only when **all** of these hold:
 
-    - ``claudeAiOauth.accessToken`` equals :data:`PHANTOM_CREDENTIALS_MARKER`
+    - ``claudeAiOauth.accessToken`` equals [`PHANTOM_CREDENTIALS_MARKER`][]
     - ``claudeAiOauth.refreshToken`` is empty or absent
 
     Any parse error or unexpected structure → ``False`` (treat as real leak).
@@ -79,7 +79,7 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     into containers.  This function checks each routed provider's mount for
     credential files that would leak real tokens alongside phantom ones.
 
-    Files injected by :func:`~terok_executor.auth._write_claude_credentials_file`
+    Files injected by [`_write_claude_credentials_file`][terok_executor.auth._write_claude_credentials_file]
     are recognised by their dummy ``accessToken`` marker and skipped.
 
     Symlinks are rejected to prevent a container from tricking the scan into

--- a/src/terok_executor/credentials/vault_config.py
+++ b/src/terok_executor/credentials/vault_config.py
@@ -100,7 +100,7 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
     been recreated empty) always contain the correct vault addresses.
     Idempotent: safe to call on every launch.
 
-    Raises :class:`ConfigPatchError` on failure — callers must not start
+    Raises [`ConfigPatchError`][] on failure — callers must not start
     the container if vault routing cannot be established.
     """
     location = resolve_vault_location()
@@ -168,12 +168,12 @@ def resolve_vault_location() -> VaultLocation:
 def _safe_config_path(shared_dir: Path, filename: str) -> Path:
     """Resolve *filename* inside *shared_dir*, rejecting traversal attempts.
 
-    Raises :class:`ConfigPatchError` if the resolved path escapes the
+    Raises [`ConfigPatchError`][] if the resolved path escapes the
     intended directory (absolute paths, ``..`` components, symlinks).
 
     Note: this check is TOCTOU-racy against a container that can plant
     symlinks between the check here and the subsequent write.  Callers
-    MUST use :func:`_read_nofollow` / :func:`_write_nofollow` to open
+    MUST use [`_read_nofollow`][] / [`_write_nofollow`][] to open
     the final file, so a symlink planted in the race window is rejected
     at open() time (``ELOOP``) instead of being silently followed.
     """
@@ -193,7 +193,7 @@ def _read_nofollow(path: Path) -> bytes | None:
 
     The shared config directories are bind-mounted read-write into task
     containers, so an attacker can plant a symlink between the
-    :func:`_safe_config_path` check and this read.  ``O_NOFOLLOW``
+    [`_safe_config_path`][] check and this read.  ``O_NOFOLLOW``
     rejects that at open() time.
     """
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
@@ -217,7 +217,7 @@ def _read_nofollow(path: Path) -> bytes | None:
 def _write_nofollow(path: Path, data: bytes) -> None:
     """Write *data* to *path* refusing to follow symlinks.
 
-    A planted symlink at *path* is rejected with :class:`ConfigPatchError`
+    A planted symlink at *path* is rejected with [`ConfigPatchError`][]
     (via ``ELOOP``) rather than silently followed — protecting against a
     compromised container redirecting the executor's write to an
     arbitrary operator-owned file (CWE-367 / CWE-59).

--- a/src/terok_executor/credentials/vault_config.py
+++ b/src/terok_executor/credentials/vault_config.py
@@ -100,7 +100,7 @@ def apply_shared_config_patches(roster: AgentRoster, mounts_base: Path) -> None:
     been recreated empty) always contain the correct vault addresses.
     Idempotent: safe to call on every launch.
 
-    Raises [`ConfigPatchError`][] on failure — callers must not start
+    Raises [`ConfigPatchError`][terok_executor.credentials.vault_config.ConfigPatchError] on failure — callers must not start
     the container if vault routing cannot be established.
     """
     location = resolve_vault_location()
@@ -168,12 +168,12 @@ def resolve_vault_location() -> VaultLocation:
 def _safe_config_path(shared_dir: Path, filename: str) -> Path:
     """Resolve *filename* inside *shared_dir*, rejecting traversal attempts.
 
-    Raises [`ConfigPatchError`][] if the resolved path escapes the
+    Raises [`ConfigPatchError`][terok_executor.credentials.vault_config.ConfigPatchError] if the resolved path escapes the
     intended directory (absolute paths, ``..`` components, symlinks).
 
     Note: this check is TOCTOU-racy against a container that can plant
     symlinks between the check here and the subsequent write.  Callers
-    MUST use [`_read_nofollow`][] / [`_write_nofollow`][] to open
+    MUST use `_read_nofollow` / `_write_nofollow` to open
     the final file, so a symlink planted in the race window is rejected
     at open() time (``ELOOP``) instead of being silently followed.
     """
@@ -193,7 +193,7 @@ def _read_nofollow(path: Path) -> bytes | None:
 
     The shared config directories are bind-mounted read-write into task
     containers, so an attacker can plant a symlink between the
-    [`_safe_config_path`][] check and this read.  ``O_NOFOLLOW``
+    `_safe_config_path` check and this read.  ``O_NOFOLLOW``
     rejects that at open() time.
     """
     flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
@@ -217,7 +217,7 @@ def _read_nofollow(path: Path) -> bytes | None:
 def _write_nofollow(path: Path, data: bytes) -> None:
     """Write *data* to *path* refusing to follow symlinks.
 
-    A planted symlink at *path* is rejected with [`ConfigPatchError`][]
+    A planted symlink at *path* is rejected with [`ConfigPatchError`][terok_executor.credentials.vault_config.ConfigPatchError]
     (via ``ELOOP``) rather than silently followed — protecting against a
     compromised container redirecting the executor's write to an
     arbitrary operator-owned file (CWE-367 / CWE-59).

--- a/src/terok_executor/doctor.py
+++ b/src/terok_executor/doctor.py
@@ -8,7 +8,7 @@ Contributes domain-specific checks to the layered doctor protocol
 integrity in shared mounts, and phantom token / base URL verification
 for the vault.
 
-The checks are returned as [`DoctorCheck`][] specs — probe commands
+The checks are returned as `DoctorCheck` specs — probe commands
 + evaluate callables — that the top-level orchestrator (``terok sickbay``)
 executes inside containers via ``podman exec``.
 """
@@ -65,7 +65,7 @@ def agent_doctor_checks(
             derive the expected host.
 
     Returns:
-        List of [`DoctorCheck`][] instances ready for orchestration.
+        List of `DoctorCheck` instances ready for orchestration.
     """
     socket_mode = token_broker_port is None
     checks: list[DoctorCheck] = [

--- a/src/terok_executor/doctor.py
+++ b/src/terok_executor/doctor.py
@@ -8,7 +8,7 @@ Contributes domain-specific checks to the layered doctor protocol
 integrity in shared mounts, and phantom token / base URL verification
 for the vault.
 
-The checks are returned as :class:`DoctorCheck` specs — probe commands
+The checks are returned as [`DoctorCheck`][] specs — probe commands
 + evaluate callables — that the top-level orchestrator (``terok sickbay``)
 executes inside containers via ``podman exec``.
 """
@@ -65,7 +65,7 @@ def agent_doctor_checks(
             derive the expected host.
 
     Returns:
-        List of :class:`DoctorCheck` instances ready for orchestration.
+        List of [`DoctorCheck`][] instances ready for orchestration.
     """
     socket_mode = token_broker_port is None
     checks: list[DoctorCheck] = [

--- a/src/terok_executor/paths.py
+++ b/src/terok_executor/paths.py
@@ -3,7 +3,7 @@
 
 """Resolves filesystem paths for executor state and bind-mount directories.
 
-Delegates to :func:`terok_sandbox.paths.namespace_state_dir` for the
+Delegates to [`terok_sandbox.paths.namespace_state_dir`][] for the
 shared XDG/FHS resolution logic — no vendored copy of the platform
 detection code.
 """

--- a/src/terok_executor/paths.py
+++ b/src/terok_executor/paths.py
@@ -3,7 +3,7 @@
 
 """Resolves filesystem paths for executor state and bind-mount directories.
 
-Delegates to [`terok_sandbox.paths.namespace_state_dir`][] for the
+Delegates to [`terok_sandbox.paths.namespace_state_dir`][terok_sandbox.paths.namespace_state_dir] for the
 shared XDG/FHS resolution logic — no vendored copy of the platform
 detection code.
 """

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -280,7 +280,7 @@ def _confirm(prompt: str, *, assume_yes: bool = False) -> bool:
 
 
 def _fix_sandbox_services() -> bool:
-    """Self-heal missing sandbox services via [`ensure_sandbox_ready`][].
+    """Self-heal missing sandbox services via [`ensure_sandbox_ready`][terok_executor.ensure_sandbox_ready].
 
     Always per-user — the interactive preflight never escalates to
     sudo behind the operator's back.  ``--root`` is the explicit

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -280,7 +280,7 @@ def _confirm(prompt: str, *, assume_yes: bool = False) -> bool:
 
 
 def _fix_sandbox_services() -> bool:
-    """Self-heal missing sandbox services via :func:`ensure_sandbox_ready`.
+    """Self-heal missing sandbox services via [`ensure_sandbox_ready`][].
 
     Always per-user — the interactive preflight never escalates to
     sudo behind the operator's back.  ``--root`` is the explicit

--- a/src/terok_executor/provider/__init__.py
+++ b/src/terok_executor/provider/__init__.py
@@ -3,10 +3,10 @@
 
 """AI provider behavior — provider definitions, headless modes, wrapper generation, instructions.
 
-Delegates to [`.providers`][] for the agent provider registry and environment
-collection, [`.wrappers`][] for shell wrapper generation, [`.headless`][]
-for headless command construction and config resolution, [`.config`][] for
-provider-aware config value extraction, [`.instructions`][] for per-provider
-instruction resolution, and [`.agents`][] for agent config directory
+Delegates to `.providers` for the agent provider registry and environment
+collection, `.wrappers` for shell wrapper generation, `.headless`
+for headless command construction and config resolution, `.config` for
+provider-aware config value extraction, `.instructions` for per-provider
+instruction resolution, and `.agents` for agent config directory
 preparation and wrapper scripts.
 """

--- a/src/terok_executor/provider/__init__.py
+++ b/src/terok_executor/provider/__init__.py
@@ -3,10 +3,10 @@
 
 """AI provider behavior — provider definitions, headless modes, wrapper generation, instructions.
 
-Delegates to :mod:`.providers` for the agent provider registry and environment
-collection, :mod:`.wrappers` for shell wrapper generation, :mod:`.headless`
-for headless command construction and config resolution, :mod:`.config` for
-provider-aware config value extraction, :mod:`.instructions` for per-provider
-instruction resolution, and :mod:`.agents` for agent config directory
+Delegates to [`.providers`][] for the agent provider registry and environment
+collection, [`.wrappers`][] for shell wrapper generation, [`.headless`][]
+for headless command construction and config resolution, [`.config`][] for
+provider-aware config value extraction, [`.instructions`][] for per-provider
+instruction resolution, and [`.agents`][] for agent config directory
 preparation and wrapper scripts.
 """

--- a/src/terok_executor/provider/agents.py
+++ b/src/terok_executor/provider/agents.py
@@ -91,7 +91,7 @@ def prepare_agent_config_dir(spec: AgentConfigSpec) -> Path:
       OpenCode and Blablador configs
 
     Args:
-        spec: All agent-config parameters bundled in an [`AgentConfigSpec`][].
+        spec: All agent-config parameters bundled in an [`AgentConfigSpec`][terok_executor.provider.agents.AgentConfigSpec].
 
     Returns the agent_config_dir path.
     """
@@ -274,7 +274,7 @@ def _inject_opencode_instructions(config_path: Path) -> None:
     file is left untouched (idempotent).
 
     Uses the same inter-process file lock + atomic-replace pattern as
-    [`_write_session_hook`][] for concurrency safety.
+    `_write_session_hook` for concurrency safety.
     """
     try:
         import fcntl

--- a/src/terok_executor/provider/agents.py
+++ b/src/terok_executor/provider/agents.py
@@ -91,7 +91,7 @@ def prepare_agent_config_dir(spec: AgentConfigSpec) -> Path:
       OpenCode and Blablador configs
 
     Args:
-        spec: All agent-config parameters bundled in an :class:`AgentConfigSpec`.
+        spec: All agent-config parameters bundled in an [`AgentConfigSpec`][].
 
     Returns the agent_config_dir path.
     """
@@ -274,7 +274,7 @@ def _inject_opencode_instructions(config_path: Path) -> None:
     file is left untouched (idempotent).
 
     Uses the same inter-process file lock + atomic-replace pattern as
-    :func:`_write_session_hook` for concurrency safety.
+    [`_write_session_hook`][] for concurrency safety.
     """
     try:
         import fcntl

--- a/src/terok_executor/provider/headless.py
+++ b/src/terok_executor/provider/headless.py
@@ -4,8 +4,8 @@
 
 """Headless (autopilot) command construction and config resolution.
 
-Provider definitions live in [`providers`][], shell wrapper generation
-lives in [`wrappers`][].
+Provider definitions live in [`providers`][terok_executor.provider.providers], shell wrapper generation
+lives in [`wrappers`][terok_executor.provider.wrappers].
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from .providers import AgentProvider
 class ProviderConfig:
     """Resolved per-run config for a headless provider.
 
-    Produced by [`apply_provider_config`][] after best-effort feature mapping.
+    Produced by [`apply_provider_config`][terok_executor.provider.headless.apply_provider_config] after best-effort feature mapping.
     """
 
     model: str | None
@@ -74,7 +74,7 @@ def apply_provider_config(
     features that have no analogue.
 
     Args:
-        config: Merged agent config dict (from [`resolve_agent_config`][]).
+        config: Merged agent config dict (from `resolve_agent_config`).
         overrides: CLI flag overrides (model, max_turns, timeout, instructions).
     """
     if overrides is None:

--- a/src/terok_executor/provider/headless.py
+++ b/src/terok_executor/provider/headless.py
@@ -4,8 +4,8 @@
 
 """Headless (autopilot) command construction and config resolution.
 
-Provider definitions live in :mod:`providers`, shell wrapper generation
-lives in :mod:`wrappers`.
+Provider definitions live in [`providers`][], shell wrapper generation
+lives in [`wrappers`][].
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from .providers import AgentProvider
 class ProviderConfig:
     """Resolved per-run config for a headless provider.
 
-    Produced by :func:`apply_provider_config` after best-effort feature mapping.
+    Produced by [`apply_provider_config`][] after best-effort feature mapping.
     """
 
     model: str | None
@@ -74,7 +74,7 @@ def apply_provider_config(
     features that have no analogue.
 
     Args:
-        config: Merged agent config dict (from :func:`resolve_agent_config`).
+        config: Merged agent config dict (from [`resolve_agent_config`][]).
         overrides: CLI flag overrides (model, max_turns, timeout, instructions).
     """
     if overrides is None:

--- a/src/terok_executor/provider/instructions.py
+++ b/src/terok_executor/provider/instructions.py
@@ -38,7 +38,7 @@ def resolve_instructions(
 
     Supports:
     - Flat string: returned as-is
-    - Per-provider dict: uses [`resolve_provider_value`][], falls back to ``_default``
+    - Per-provider dict: uses [`resolve_provider_value`][terok_executor.resolve_provider_value], falls back to ``_default``
     - List (with ``_inherit``): splices bundled default at each ``_inherit`` sentinel
     - Absent/None: returns bundled default
 

--- a/src/terok_executor/provider/instructions.py
+++ b/src/terok_executor/provider/instructions.py
@@ -38,7 +38,7 @@ def resolve_instructions(
 
     Supports:
     - Flat string: returned as-is
-    - Per-provider dict: uses :func:`resolve_provider_value`, falls back to ``_default``
+    - Per-provider dict: uses [`resolve_provider_value`][], falls back to ``_default``
     - List (with ``_inherit``): splices bundled default at each ``_inherit`` sentinel
     - Absent/None: returns bundled default
 

--- a/src/terok_executor/provider/providers.py
+++ b/src/terok_executor/provider/providers.py
@@ -4,7 +4,7 @@
 
 """Agent provider registry: definitions, lookup, and environment collection.
 
-Each supported AI coding agent is described by an :class:`AgentProvider`
+Each supported AI coding agent is described by an [`AgentProvider`][]
 dataclass.  The ``AGENT_PROVIDERS`` dict maps short names to descriptors
 and is populated at package load time from the YAML roster.
 """
@@ -195,9 +195,9 @@ def resolve_provider(
 
 
 def get_provider(name: str | None, *, default_agent: str | None = None) -> AgentProvider:
-    """Resolve a provider name against the global :data:`AGENT_PROVIDERS` registry.
+    """Resolve a provider name against the global [`AGENT_PROVIDERS`][] registry.
 
-    Convenience wrapper around :func:`resolve_provider`.
+    Convenience wrapper around [`resolve_provider`][].
     """
     return resolve_provider(AGENT_PROVIDERS, name, default_agent=default_agent)
 

--- a/src/terok_executor/provider/providers.py
+++ b/src/terok_executor/provider/providers.py
@@ -4,7 +4,7 @@
 
 """Agent provider registry: definitions, lookup, and environment collection.
 
-Each supported AI coding agent is described by an [`AgentProvider`][]
+Each supported AI coding agent is described by an [`AgentProvider`][terok_executor.provider.providers.AgentProvider]
 dataclass.  The ``AGENT_PROVIDERS`` dict maps short names to descriptors
 and is populated at package load time from the YAML roster.
 """
@@ -195,9 +195,9 @@ def resolve_provider(
 
 
 def get_provider(name: str | None, *, default_agent: str | None = None) -> AgentProvider:
-    """Resolve a provider name against the global [`AGENT_PROVIDERS`][] registry.
+    """Resolve a provider name against the global [`AGENT_PROVIDERS`][terok_executor.provider.providers.AGENT_PROVIDERS] registry.
 
-    Convenience wrapper around [`resolve_provider`][].
+    Convenience wrapper around [`resolve_provider`][terok_executor.provider.providers.resolve_provider].
     """
     return resolve_provider(AGENT_PROVIDERS, name, default_agent=default_agent)
 

--- a/src/terok_executor/provider/wrappers.py
+++ b/src/terok_executor/provider/wrappers.py
@@ -52,7 +52,7 @@ def generate_agent_wrapper(
         claude_wrapper_fn: ``(cfg: WrapperConfig) -> str``.
             Required when ``provider.name == "claude"``.
 
-    See also [`generate_all_wrappers`][] which produces wrappers for every
+    See also [`generate_all_wrappers`][terok_executor.provider.wrappers.generate_all_wrappers] which produces wrappers for every
     registered provider in one file.
     """
     if provider.name == "claude":
@@ -76,7 +76,7 @@ def generate_all_wrappers(
     invoke any agent regardless of which provider was configured as default.
 
     A shared ``_terok_resume_or_fresh`` helper is emitted at the top of the
-    file for stale-session fallback (see [`_RESUME_FALLBACK_FN`][]).
+    file for stale-session fallback (see `_RESUME_FALLBACK_FN`).
 
     Args:
         claude_wrapper_fn: Required -- produces the Claude wrapper.

--- a/src/terok_executor/provider/wrappers.py
+++ b/src/terok_executor/provider/wrappers.py
@@ -52,7 +52,7 @@ def generate_agent_wrapper(
         claude_wrapper_fn: ``(cfg: WrapperConfig) -> str``.
             Required when ``provider.name == "claude"``.
 
-    See also :func:`generate_all_wrappers` which produces wrappers for every
+    See also [`generate_all_wrappers`][] which produces wrappers for every
     registered provider in one file.
     """
     if provider.name == "claude":
@@ -76,7 +76,7 @@ def generate_all_wrappers(
     invoke any agent regardless of which provider was configured as default.
 
     A shared ``_terok_resume_or_fresh`` helper is emitted at the top of the
-    file for stale-session fallback (see :data:`_RESUME_FALLBACK_FN`).
+    file for stale-session fallback (see [`_RESUME_FALLBACK_FN`][]).
 
     Args:
         claude_wrapper_fn: Required -- produces the Claude wrapper.

--- a/src/terok_executor/roster/__init__.py
+++ b/src/terok_executor/roster/__init__.py
@@ -3,8 +3,8 @@
 
 """Loads agent and tool definitions from layered YAML config into a queryable roster.
 
-Delegates to :mod:`.loader` for YAML deserialization and roster construction,
-and to :mod:`.config_stack` for generic layered config resolution.
+Delegates to [`.loader`][] for YAML deserialization and roster construction,
+and to [`.config_stack`][] for generic layered config resolution.
 """
 
 from .loader import (

--- a/src/terok_executor/roster/__init__.py
+++ b/src/terok_executor/roster/__init__.py
@@ -3,8 +3,8 @@
 
 """Loads agent and tool definitions from layered YAML config into a queryable roster.
 
-Delegates to [`.loader`][] for YAML deserialization and roster construction,
-and to [`.config_stack`][] for generic layered config resolution.
+Delegates to `.loader` for YAML deserialization and roster construction,
+and to `.config_stack` for generic layered config resolution.
 """
 
 from .loader import (

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -103,7 +103,7 @@ class VaultRoute:
     """Phantom env vars for OAuth credentials (e.g. ``{"CLAUDE_CODE_OAUTH_TOKEN": true}``).
 
     When the stored credential type is ``"oauth"`` and this is non-empty, these
-    env vars are injected *instead of* :attr:`phantom_env`.
+    env vars are injected *instead of* [`phantom_env`][].
     """
 
     base_url_env: str = ""
@@ -150,7 +150,7 @@ HelpSection = Literal["agent", "dev_tool"]
 """Section in the in-container help banner that an entry belongs to."""
 
 HELP_SECTIONS: tuple[HelpSection, ...] = get_args(HelpSection)
-"""All valid :data:`HelpSection` values, as a tuple (single source of truth)."""
+"""All valid [`HelpSection`][] values, as a tuple (single source of truth)."""
 
 
 @dataclass(frozen=True)
@@ -258,7 +258,7 @@ class AgentRoster:
         """Resolve a user-supplied selection into the full set of roster names to install.
 
         Accepts the literal string ``"all"`` (every roster entry that has an
-        :class:`InstallSpec`) or a tuple of names.  Expands ``depends_on``
+        [`InstallSpec`][]) or a tuple of names.  Expands ``depends_on``
         transitively.  Returns the names sorted alphabetically — the canonical
         order used for the OCI label, the tag suffix, and the in-container
         manifest.
@@ -410,7 +410,7 @@ def parse_agent_selection(raw: str) -> str | tuple[str, ...]:
     Accepts a comma-list (``"claude,codex"``) or the literal ``"all"``.
     Whitespace is stripped, empty / whitespace-only entries dropped,
     and case folded.  Empty or all-whitespace input collapses to
-    ``"all"`` — the same shape :meth:`AgentRoster.resolve_selection`
+    ``"all"`` — the same shape [`AgentRoster.resolve_selection`][]
     expects.  Unknown names are not checked here; ``resolve_selection``
     does that.
     """
@@ -538,7 +538,7 @@ def ensure_vault_routes(cfg: SandboxConfig | None = None) -> Path:
     """Generate ``routes.json`` from the YAML roster and write it to disk.
 
     The routes file is written to the path configured in
-    :class:`~terok_sandbox.SandboxConfig` (typically
+    [`SandboxConfig`][terok_sandbox.SandboxConfig] (typically
     ``~/.local/share/terok/vault/routes.json``).
 
     When *cfg* is ``None``, falls back to standalone defaults.
@@ -656,7 +656,7 @@ def _check_roster_version(name: str, data: dict, *, source: str) -> None:
     Missing or older versions still load silently — existing user overrides
     written before the marker existed must keep working, and older-but-still-
     understood roster files are the backward-compat path.  A declared
-    version strictly greater than :data:`ROSTER_VERSION` prints a warning,
+    version strictly greater than [`ROSTER_VERSION`][] prints a warning,
     because the host may not speak every field the file uses.
     """
     declared = data.pop("roster_version", None)
@@ -866,7 +866,7 @@ def _to_vault_route(name: str, data: dict) -> VaultRoute | None:
 
 
 def _to_sidecar_spec(name: str, data: dict) -> SidecarSpec | None:
-    """Parse the optional ``sidecar:`` YAML section into a :class:`SidecarSpec`."""
+    """Parse the optional ``sidecar:`` YAML section into a [`SidecarSpec`][]."""
     sc = data.get("sidecar")
     if not sc:
         return None
@@ -877,7 +877,7 @@ def _to_sidecar_spec(name: str, data: dict) -> SidecarSpec | None:
 
 
 def _to_install_spec(name: str, data: dict) -> InstallSpec | None:
-    """Parse the optional ``install:`` YAML section into an :class:`InstallSpec`.
+    """Parse the optional ``install:`` YAML section into an [`InstallSpec`][].
 
     Both snippet fields and ``depends_on`` are optional individually; the
     section as a whole is omitted only for entries that need no install
@@ -899,7 +899,7 @@ def _to_install_spec(name: str, data: dict) -> InstallSpec | None:
 
 
 def _to_help_spec(name: str, data: dict) -> HelpSpec | None:
-    """Parse the optional ``help:`` YAML section into a :class:`HelpSpec`."""
+    """Parse the optional ``help:`` YAML section into a [`HelpSpec`][]."""
     h = data.get("help")
     if not h:
         return None

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -103,7 +103,7 @@ class VaultRoute:
     """Phantom env vars for OAuth credentials (e.g. ``{"CLAUDE_CODE_OAUTH_TOKEN": true}``).
 
     When the stored credential type is ``"oauth"`` and this is non-empty, these
-    env vars are injected *instead of* [`phantom_env`][].
+    env vars are injected *instead of* [`phantom_env`][terok_executor.roster.loader.VaultRoute.phantom_env].
     """
 
     base_url_env: str = ""
@@ -150,7 +150,7 @@ HelpSection = Literal["agent", "dev_tool"]
 """Section in the in-container help banner that an entry belongs to."""
 
 HELP_SECTIONS: tuple[HelpSection, ...] = get_args(HelpSection)
-"""All valid [`HelpSection`][] values, as a tuple (single source of truth)."""
+"""All valid [`HelpSection`][terok_executor.roster.loader.HelpSection] values, as a tuple (single source of truth)."""
 
 
 @dataclass(frozen=True)
@@ -258,7 +258,7 @@ class AgentRoster:
         """Resolve a user-supplied selection into the full set of roster names to install.
 
         Accepts the literal string ``"all"`` (every roster entry that has an
-        [`InstallSpec`][]) or a tuple of names.  Expands ``depends_on``
+        [`InstallSpec`][terok_executor.roster.loader.InstallSpec]) or a tuple of names.  Expands ``depends_on``
         transitively.  Returns the names sorted alphabetically — the canonical
         order used for the OCI label, the tag suffix, and the in-container
         manifest.
@@ -410,7 +410,7 @@ def parse_agent_selection(raw: str) -> str | tuple[str, ...]:
     Accepts a comma-list (``"claude,codex"``) or the literal ``"all"``.
     Whitespace is stripped, empty / whitespace-only entries dropped,
     and case folded.  Empty or all-whitespace input collapses to
-    ``"all"`` — the same shape [`AgentRoster.resolve_selection`][]
+    ``"all"`` — the same shape [`AgentRoster.resolve_selection`][terok_executor.roster.loader.AgentRoster.resolve_selection]
     expects.  Unknown names are not checked here; ``resolve_selection``
     does that.
     """
@@ -656,7 +656,7 @@ def _check_roster_version(name: str, data: dict, *, source: str) -> None:
     Missing or older versions still load silently — existing user overrides
     written before the marker existed must keep working, and older-but-still-
     understood roster files are the backward-compat path.  A declared
-    version strictly greater than [`ROSTER_VERSION`][] prints a warning,
+    version strictly greater than [`ROSTER_VERSION`][terok_executor.roster.loader.ROSTER_VERSION] prints a warning,
     because the host may not speak every field the file uses.
     """
     declared = data.pop("roster_version", None)
@@ -866,7 +866,7 @@ def _to_vault_route(name: str, data: dict) -> VaultRoute | None:
 
 
 def _to_sidecar_spec(name: str, data: dict) -> SidecarSpec | None:
-    """Parse the optional ``sidecar:`` YAML section into a [`SidecarSpec`][]."""
+    """Parse the optional ``sidecar:`` YAML section into a [`SidecarSpec`][terok_executor.roster.loader.SidecarSpec]."""
     sc = data.get("sidecar")
     if not sc:
         return None
@@ -877,7 +877,7 @@ def _to_sidecar_spec(name: str, data: dict) -> SidecarSpec | None:
 
 
 def _to_install_spec(name: str, data: dict) -> InstallSpec | None:
-    """Parse the optional ``install:`` YAML section into an [`InstallSpec`][].
+    """Parse the optional ``install:`` YAML section into an [`InstallSpec`][terok_executor.roster.loader.InstallSpec].
 
     Both snippet fields and ``depends_on`` are optional individually; the
     section as a whole is omitted only for entries that need no install
@@ -899,7 +899,7 @@ def _to_install_spec(name: str, data: dict) -> InstallSpec | None:
 
 
 def _to_help_spec(name: str, data: dict) -> HelpSpec | None:
-    """Parse the optional ``help:`` YAML section into a [`HelpSpec`][]."""
+    """Parse the optional ``help:`` YAML section into a [`HelpSpec`][terok_executor.roster.loader.HelpSpec]."""
     h = data.get("help")
     if not h:
         return None

--- a/src/terok_executor/vault_addr.py
+++ b/src/terok_executor/vault_addr.py
@@ -6,7 +6,7 @@
 Two transports reach the vault from inside a task container:
 
 - **Socket mode** (default, preferred): the host's vault socket is
-  bind-mounted into the container at :data:`CONTAINER_VAULT_SOCKET`.
+  bind-mounted into the container at [`CONTAINER_VAULT_SOCKET`][].
   Clients that can speak HTTP-over-UNIX (``gh``, ``claude``) connect
   directly; everyone else goes through an in-container socat bridge that
   exposes the vault as plain TCP on ``localhost:LOOPBACK_VAULT_PORT``.
@@ -14,7 +14,7 @@ Two transports reach the vault from inside a task container:
 - **TCP mode** (legacy): the vault's token broker listens on a host TCP
   port (``host.containers.internal:<broker_port>``).  Socket-only
   clients reach it via a local socat bridge that presents a Unix socket
-  at :data:`LOOPBACK_BRIDGE_SOCKET`.
+  at [`LOOPBACK_BRIDGE_SOCKET`][].
 
 These paths and port numbers have to agree across the python builders,
 the shell bridge script, and the doctor probes — define them here so

--- a/src/terok_executor/vault_addr.py
+++ b/src/terok_executor/vault_addr.py
@@ -6,7 +6,7 @@
 Two transports reach the vault from inside a task container:
 
 - **Socket mode** (default, preferred): the host's vault socket is
-  bind-mounted into the container at [`CONTAINER_VAULT_SOCKET`][].
+  bind-mounted into the container at [`CONTAINER_VAULT_SOCKET`][terok_executor.vault_addr.CONTAINER_VAULT_SOCKET].
   Clients that can speak HTTP-over-UNIX (``gh``, ``claude``) connect
   directly; everyone else goes through an in-container socat bridge that
   exposes the vault as plain TCP on ``localhost:LOOPBACK_VAULT_PORT``.
@@ -14,7 +14,7 @@ Two transports reach the vault from inside a task container:
 - **TCP mode** (legacy): the vault's token broker listens on a host TCP
   port (``host.containers.internal:<broker_port>``).  Socket-only
   clients reach it via a local socat bridge that presents a Unix socket
-  at [`LOOPBACK_BRIDGE_SOCKET`][].
+  at [`LOOPBACK_BRIDGE_SOCKET`][terok_executor.vault_addr.LOOPBACK_BRIDGE_SOCKET].
 
 These paths and port numbers have to agree across the python builders,
 the shell bridge script, and the doctor probes — define them here so

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -826,7 +826,7 @@ class TestBuildSidecarImage:
 
 
 class TestSplitImageRef:
-    """Verify port-aware OCI ref parsing in :func:`_split_image_ref`."""
+    """Verify port-aware OCI ref parsing in [`_split_image_ref`][]."""
 
     @pytest.mark.parametrize(
         ("ref", "expected"),

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -826,7 +826,7 @@ class TestBuildSidecarImage:
 
 
 class TestSplitImageRef:
-    """Verify port-aware OCI ref parsing in [`_split_image_ref`][]."""
+    """Verify port-aware OCI ref parsing in `_split_image_ref`."""
 
     @pytest.mark.parametrize(
         ("ref", "expected"),

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -491,7 +491,7 @@ class TestWaitForExit:
             assert runner.wait_for_exit("terok-x") == 124
 
     def test_timeout_raises(self) -> None:
-        """``subprocess.TimeoutExpired`` surfaces as [`TimeoutError`][]
+        """``subprocess.TimeoutExpired`` surfaces as [`TimeoutError`][TimeoutError]
         so callers can signal the real exit code separately."""
         runner = AgentRunner(sandbox=_mock_sandbox())
         with patch(

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -355,7 +355,7 @@ class TestLaunchPrepared:
     ``launch_prepared`` is the public entry point terok uses to hand a
     caller-assembled env and volumes to the sandbox without reimplementing
     ``RunSpec`` construction.  Exercises the mapping from method args to
-    :class:`~terok_sandbox.RunSpec` fields.
+    [`RunSpec`][terok_sandbox.RunSpec] fields.
     """
 
     def test_returns_container_name(self, tmp_path: Path) -> None:
@@ -491,7 +491,7 @@ class TestWaitForExit:
             assert runner.wait_for_exit("terok-x") == 124
 
     def test_timeout_raises(self) -> None:
-        """``subprocess.TimeoutExpired`` surfaces as :class:`TimeoutError`
+        """``subprocess.TimeoutExpired`` surfaces as [`TimeoutError`][]
         so callers can signal the real exit code separately."""
         runner = AgentRunner(sandbox=_mock_sandbox())
         with patch(


### PR DESCRIPTION
## Summary
- Rewrites docstring cross-references from Sphinx RST domain roles (`:func:`, `:class:`, `:meth:`, `:attr:`, `:mod:`, `:data:`) to mkdocs-autorefs Markdown syntax so they actually render as links in the SPAI Reference docs.
- Tilde shortform handled: `:class:`~module.path.Name`` → `` [`Name`][module.path.Name] `` (display the last component, link to the full path).
- Pure text-level rewrite — every removed line contains an RST role and every added line contains an autoref; AST-parses cleanly.

## Why
Sphinx domain roles aren't understood by `mkdocstrings` / `mkdocs-autorefs`, so refs like `:func:`uninstall_desktop_entry`` were rendering as literal text in the generated docs.

## Test plan
- [ ] CI lint / docstr-coverage / tach pass
- [ ] `mkdocs build` succeeds and rendered API pages show working cross-links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docstring cross-references across the codebase for more reliable rendering and clearer symbol linking.
  * Configured documentation build to reference external inventories and to surface items even when no docstring is present.
  * Applied consistent documentation formatting for improved clarity and cross-module link resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->