### PR TITLE
fix(l1): wire help banner into family-specific bashrc (Fedora regression)

### DIFF
--- a/src/terok_executor/resources/scripts/terok-env.sh
+++ b/src/terok_executor/resources/scripts/terok-env.sh
@@ -5,7 +5,7 @@
 
 # Core terok container environment — sourced by ALL shell modes:
 #   - Non-interactive (bash -c): via BASH_ENV
-#   - Interactive:               via /etc/bash.bashrc
+#   - Interactive:               via /etc/bash.bashrc (Debian) or /etc/bashrc (Fedora)
 #   - Login:                     via /etc/profile.d/
 #
 # Guard against redundant sourcing.  Login shells hit both profile.d and

--- a/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
@@ -50,15 +50,17 @@ RUN set -eux; \
 # Shell environment: terok-env.sh is the single source of truth for PATH,
 # git identity helpers, gh/glab wrappers, and per-project agent wrappers.
 # It lives in /etc/profile.d/ and is sourced by all three shell modes.
+#
+# For interactive non-login shells we hook the system-wide bashrc.  Debian
+# patches bash to source /etc/bash.bashrc; Fedora's bash never reads that
+# path and instead sources /etc/bashrc indirectly via the per-user .bashrc
+# from /etc/skel.  Pick the right file per family or the help banner is
+# silently dropped on Fedora.
 COPY scripts/terok-env.sh /etc/profile.d/terok-env.sh
 RUN chmod +x /etc/profile.d/terok-env.sh; \
-    if [ -f /etc/bash.bashrc ]; then \
-      printf '\n# terok environment (PATH, git identity, agent wrappers)\n. /etc/profile.d/terok-env.sh\n' >> /etc/bash.bashrc; \
-    else \
-      printf '# terok environment (PATH, git identity, agent wrappers)\n. /etc/profile.d/terok-env.sh\n' > /etc/bash.bashrc; \
-    fi; \
-    # Interactive-only: help banner (login shells only)
-    printf '\n# Help banner (interactive login only)\nif [ -t 1 ] && [ -z "$_TEROK_BANNER_SHOWN" ]; then\n  export _TEROK_BANNER_SHOWN=1\n  _TEROK_LOGIN=1 hilfe --kurz 2>/dev/null || true\nfi\n' >> /etc/bash.bashrc
+    bashrc={% if family == "deb" %}/etc/bash.bashrc{% else %}/etc/bashrc{% endif %}; \
+    printf '\n# terok environment (PATH, git identity, agent wrappers)\n. /etc/profile.d/terok-env.sh\n' >> "$bashrc"; \
+    printf '\n# Help banner (interactive login only)\nif [ -t 1 ] && [ -z "$_TEROK_BANNER_SHOWN" ]; then\n  export _TEROK_BANNER_SHOWN=1\n  _TEROK_LOGIN=1 hilfe --kurz 2>/dev/null || true\nfi\n' >> "$bashrc"
 
 # Symlink for per-task agent wrappers (resolved at runtime via mount).
 RUN mkdir -p /usr/local/share/terok && \

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -515,6 +515,17 @@ class TestTemplateRendering:
         assert "opencode.ai/install" in content
         assert 'LABEL ai.terok.agents="blablador,opencode"' in content
 
+    def test_l1_banner_targets_family_specific_bashrc(self) -> None:
+        # Debian patches bash to source /etc/bash.bashrc; Fedora's bash never
+        # reads that path and instead sources /etc/bashrc.  Wiring the help
+        # banner into the wrong file silently drops it on the other family.
+        deb = render_l1("terok-l0:test", family="deb")
+        rpm = render_l1("terok-l0:test", family="rpm")
+        assert "bashrc=/etc/bash.bashrc" in deb
+        assert "bashrc=/etc/bashrc" in rpm
+        assert "_TEROK_LOGIN=1 hilfe --kurz" in deb
+        assert "_TEROK_LOGIN=1 hilfe --kurz" in rpm
+
     def test_l1_unknown_agent_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown roster entries"):
             render_l1("terok-l0:test", family="deb", agents=("not-a-real-agent",))


### PR DESCRIPTION
## Summary

On Fedora-based L1 images, \`hilfe --kurz\` was silently dropped from the login banner because the build was writing the help-banner snippet to \`/etc/bash.bashrc\` — a Debian-only convention. Fedora's bash never reads that path; the system-wide bashrc on RPM distros is \`/etc/bashrc\`, sourced indirectly via the per-user \`.bashrc\` shipped from \`/etc/skel\`.

Pick the right file per family at template render time, so:

- \`family == \"deb\"\` → write to \`/etc/bash.bashrc\` (existing behaviour, unchanged)
- \`family == \"rpm\"\` → write to \`/etc/bashrc\` (was being created and then ignored)

The same fix applies to the \`terok-env.sh\` source line that lives next to the banner block.

## Test plan

- [x] New \`test_l1_banner_targets_family_specific_bashrc\` asserts both branches render to the expected paths.
- [x] \`make lint\` clean
- [x] \`make tach\` clean
- [x] \`make docstrings\` 99.4% (no regression)
- [x] \`make reuse\` compliant
- [x] \`pytest tests/unit/test_build.py\` 132/132 passing
- [ ] Manual smoke: build an L1 image with a Fedora base (e.g. \`fedora:40\`), \`terok login\` into a task, confirm the \`hilfe --kurz\` banner now appears.

(The 4 \`test_preflight\` failures observed locally pre-exist on master and are caused by \`nft\` not being installed in the build environment — unrelated to this change.)