### PR TITLE
deps: pin terok-sandbox to feat/drop-bridge-phase for the chain

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2745,34 +2745,34 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.6"
+version = "0.6.7"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_clearance-0.6.7-py3-none-any.whl", hash = "sha256:463dfaebfbb8408f4f9b1cb327edba0f5c75f16a0dfce8750ffe2c174724ee7f"},
+]
 
 [package.dependencies]
-asyncvarlink = "^0.3.1"
+asyncvarlink = ">=0.3.1,<0.4.0"
 dbus-fast = ">=2.0,<5.0"
-pyyaml = "^6.0"
+pyyaml = ">=6.0,<7.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-clearance.git"
-reference = "feat/dossier-in-events"
-resolved_reference = "32f8942302d79bb43ea805facdab7a62566ea2f6"
+type = "url"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.104"
+version = "0.0.105"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.105-py3-none-any.whl", hash = "sha256:ae5e855d7f6a55d2d51090ef86d64858f79c26a4132b0768402166ed96c5b447"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -2780,34 +2780,31 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/dossier-in-events"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/dossier-in-events"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/drop-bridge-phase"
-resolved_reference = "35a463b93418852120722d50709485b734e98196"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.34"
+version = "0.6.35"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_shield-0.6.35-py3-none-any.whl", hash = "sha256:611c7756a54658131c172d115de9bc7f315320c7ee0dd223af1219acc27c4933"},
+]
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-shield.git"
-reference = "feat/dossier-in-events"
-resolved_reference = "0334200c5c4b9aef893dc7ed028026351781aae8"
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -3206,4 +3203,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "cc7d928f51e508b1c2e6578adb601e3f52554da831211ac51d01cd72d6545401"
+content-hash = "6df78b4d5d4d234a6bf778a8b80514b31d76f2ce711d179b7972d3b8e3bea6dd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2750,18 +2750,19 @@ description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_clearance-0.6.6-py3-none-any.whl", hash = "sha256:8452c25a84587893b2ad902a0b4357167f85dc26d056b3d032529779ccafe241"},
-]
+files = []
+develop = false
 
 [package.dependencies]
-asyncvarlink = ">=0.3.1,<0.4.0"
+asyncvarlink = "^0.3.1"
 dbus-fast = ">=2.0,<5.0"
-pyyaml = ">=6.0,<7.0"
+pyyaml = "^6.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.6/terok_clearance-0.6.6-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-clearance.git"
+reference = "feat/dossier-in-events"
+resolved_reference = "32f8942302d79bb43ea805facdab7a62566ea2f6"
 
 [[package]]
 name = "terok-sandbox"
@@ -2770,9 +2771,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.104-py3-none-any.whl", hash = "sha256:a85dd2cb3c7375e07a15ecd4127bf6fa3c8b23c85463d4452a95f81a268a7a85"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -2780,12 +2780,14 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.6/terok_clearance-0.6.6-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.34/terok_shield-0.6.34-py3-none-any.whl"}
+terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/dossier-in-events"}
+terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/dossier-in-events"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/drop-bridge-phase"
+resolved_reference = "35a463b93418852120722d50709485b734e98196"
 
 [[package]]
 name = "terok-shield"
@@ -2794,17 +2796,18 @@ description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_shield-0.6.34-py3-none-any.whl", hash = "sha256:a0545059d973f1f134241ef9f00f76e48625ca817d2f964fb5bfee42f26ca169"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.34/terok_shield-0.6.34-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-shield.git"
+reference = "feat/dossier-in-events"
+resolved_reference = "0334200c5c4b9aef893dc7ed028026351781aae8"
 
 [[package]]
 name = "tomli"
@@ -3203,4 +3206,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "97a978a34b9b141e2640f59baad74c6ff195a2b2cca4e959bff98a76ae9af49a"
+content-hash = "cc7d928f51e508b1c2e6578adb601e3f52554da831211ac51d01cd72d6545401"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.125"
+version = "0.0.126"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ python = ">=3.12,<4.0"
 # otherwise conflict with terok's git pin on the branch).  Release
 # script flips back to the wheel URL when the next sandbox release
 # ships.
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/drop-bridge-phase"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,15 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-# DEV-TIME BRANCH PIN — tracks terok-sandbox's feat/bridge-phase, which adds
-# the shield→clearance bridge as a first-class integration phase.  Executor
-# and terok must agree on the same sandbox tip during the in-flight chain
-# (a wheel URL pin here would otherwise conflict with terok's git pin on the
-# branch).  Release script flips back to the wheel URL when the next sandbox
-# release ships.
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"}
+# DEV-TIME BRANCH PIN — tracks terok-sandbox's feat/drop-bridge-phase,
+# which deletes the bridge install phase + PodmanInspector now that
+# the shield reader resolves the orchestrator dossier at emit time.
+# Executor and terok must agree on the same sandbox tip during the
+# in-flight dossier-in-events chain (a wheel URL pin here would
+# otherwise conflict with terok's git pin on the branch).  Release
+# script flips back to the wheel URL when the next sandbox release
+# ships.
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/drop-bridge-phase"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"


### PR DESCRIPTION
## Summary

Deps-only flip — pins ``terok-sandbox`` to its ``feat/drop-bridge-phase`` branch tip so the dossier-in-events chain has a contiguous set of git-pinned siblings during review.  Bottom-up release order: shield → clearance → sandbox → **executor (this PR)** → terok.

The branch carries a single commit (``13f297b``) — no executor logic changes; ``poetry.lock`` regenerated against the sandbox branch tip.

Companion PRs in the chain:

* https://github.com/terok-ai/terok-shield/pull/275
* https://github.com/terok-ai/terok-clearance/pull/79
* https://github.com/terok-ai/terok-sandbox/pull/231
* https://github.com/terok-ai/terok/pull/866

The release script (``tools/terok-release-chain.py`` in terok) flips the pins back to wheel URLs once the four leaf packages ship.

## Test plan

- [ ] CI green on branch
- [ ] ``poetry lock`` reproducible
- [ ] Released after sandbox#231 lands; pin flipped to released sandbox wheel pre-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package release version to the next patch release.
  * Updated sandbox dependency to a newer build to align with current development.
  * Revised accompanying orchestration/timing notes to reflect the updated sandbox behavior and branch alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->