### PR TITLE
fix(docs): drop autorefs into siblings without published `objects.inv`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,11 +40,15 @@ plugins:
       handlers:
         python:
           inventories:
+            # Cross-package autorefs land here only for sibling packages
+            # whose published GitHub Pages site exposes ``objects.inv``.
+            # ``terok-sandbox`` and ``terok-clearance`` aren't currently
+            # publishing one (404 against ``mkdocs build --strict``), so
+            # docstring references into those packages stay as plain
+            # code text rather than autorefs.
             - https://docs.python.org/3/objects.inv
             - https://terok-ai.github.io/terok/objects.inv
-            - https://terok-ai.github.io/terok-sandbox/objects.inv
             - https://terok-ai.github.io/terok-shield/objects.inv
-            - https://terok-ai.github.io/terok-clearance/objects.inv
           options:
             docstring_style: google
             show_source: true

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -52,7 +52,7 @@ class CommandDef:
 def _setup_verdict_or_exit(*, skip: bool) -> None:
     """Cheap stamp-based gate that runs before live preflight.
 
-    Reads [`terok_sandbox.needs_setup`][terok_sandbox.needs_setup] and bounces the user with
+    Reads `terok_sandbox.needs_setup` and bounces the user with
     a structured exit code when the install is missing or stale:
 
     - ``OK`` → return; live preflight proceeds.

--- a/src/terok_executor/config_schema.py
+++ b/src/terok_executor/config_schema.py
@@ -6,7 +6,7 @@
 terok-executor owns one top-level section in the shared config:
 ``image:`` (base image, agent roster, Dockerfile snippets).  This
 module defines that section's strict schema and composes it with
-sandbox's [`SandboxConfigView`][terok_sandbox.config_schema.SandboxConfigView].
+sandbox's `SandboxConfigView`.
 
 Standalone executor consumers (``terok-executor run``) validate the
 file against [`ExecutorConfigView`][terok_executor.config_schema.ExecutorConfigView].  Sandbox-owned and
@@ -70,7 +70,7 @@ class ExecutorConfigView(SandboxConfigView):
     """The slice of ``config.yml`` executor owns + sandbox owns (transitively).
 
     Inherits all eight sandbox-owned sections from
-    [`SandboxConfigView`][terok_sandbox.config_schema.SandboxConfigView] and adds
+    `SandboxConfigView` and adds
     the executor-owned ``image:`` section.  ``extra="allow"`` keeps the
     view tolerant of foreign top-level keys (terok's ``tui:`` /
     ``logs:`` / ``tasks:`` / ``git:`` / ``hooks:``) — standalone

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -33,7 +33,7 @@ from terok_sandbox import Sharing, VolumeSpec
 from terok_executor._util import detect_host_timezone
 
 _CONTAINER_RUNTIME_DIR = "/run/terok"
-"""Container-side mount point — must match [`terok_sandbox.CONTAINER_RUNTIME_DIR`][terok_sandbox.CONTAINER_RUNTIME_DIR]."""
+"""Container-side mount point — must match `terok_sandbox.CONTAINER_RUNTIME_DIR`."""
 
 CONTAINER_PROTOCOL = 1
 """Version of the host↔container env/script contract.

--- a/src/terok_executor/container/inject.py
+++ b/src/terok_executor/container/inject.py
@@ -19,7 +19,7 @@ def inject_agent_config(container_name: str, config_dir: Path) -> None:
     """Copy a prepared agent-config directory into a sealed container.
 
     The container must be in the *created* or *stopped* state.  Delegates
-    to [`terok_sandbox.Sandbox.copy_to`][terok_sandbox.Sandbox.copy_to].
+    to `terok_sandbox.Sandbox.copy_to`.
     """
     from terok_sandbox import Sandbox
 

--- a/src/terok_executor/credentials/extractors.py
+++ b/src/terok_executor/credentials/extractors.py
@@ -5,7 +5,7 @@
 
 Each extractor reads a vendor-specific credential file from a temporary
 auth container mount and returns a normalized dict suitable for storage
-in [`CredentialDB`][terok_sandbox.CredentialDB].  The dict must contain at least
+in `CredentialDB`.  The dict must contain at least
 one of ``access_token``, ``token``, or ``key`` --- the vault server
 uses these fields to inject the real auth header.
 

--- a/src/terok_executor/paths.py
+++ b/src/terok_executor/paths.py
@@ -3,7 +3,7 @@
 
 """Resolves filesystem paths for executor state and bind-mount directories.
 
-Delegates to [`terok_sandbox.paths.namespace_state_dir`][terok_sandbox.paths.namespace_state_dir] for the
+Delegates to `terok_sandbox.paths.namespace_state_dir` for the
 shared XDG/FHS resolution logic — no vendored copy of the platform
 detection code.
 """

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -538,7 +538,7 @@ def ensure_vault_routes(cfg: SandboxConfig | None = None) -> Path:
     """Generate ``routes.json`` from the YAML roster and write it to disk.
 
     The routes file is written to the path configured in
-    [`SandboxConfig`][terok_sandbox.SandboxConfig] (typically
+    `SandboxConfig` (typically
     ``~/.local/share/terok/vault/routes.json``).
 
     When *cfg* is ``None``, falls back to standalone defaults.


### PR DESCRIPTION
## Summary

CI's ``poetry run mkdocs build --strict`` was aborting on:

```
ERROR   -  mkdocstrings: Couldn't load inventory
  https://terok-ai.github.io/terok-clearance/objects.inv
  through handler 'python': HTTP Error 404: Not Found
ERROR   -  mkdocstrings: Couldn't load inventory
  https://terok-ai.github.io/terok-sandbox/objects.inv
  through handler 'python': HTTP Error 404: Not Found
[14 × WARNING -  mkdocs_autorefs: Could not find cross-reference target 'terok_sandbox.…']
Aborted with 2 errors, 14 warnings in strict mode!
```

Sibling sites are up but neither ``terok-sandbox`` nor ``terok-clearance`` publishes ``objects.inv`` yet.  PR #251 ("docs: migrate Sphinx RST roles to mkdocs-autorefs syntax") had landed the cross-package autorefs assuming both would publish — they don't, so strict mode breaks.

Two surgical edits:

1. Drop ``terok-sandbox`` and ``terok-clearance`` from ``inventories`` in ``mkdocs.yml`` until they publish their inventories (note in place explaining the gap).
2. Rewrite the 8 ``[`X`][terok_sandbox.X]``-shape autorefs to plain ``` `X` ``` — same fall-through PR #251's migration script already uses for unresolvable refs.

## Test plan

- [x] ``poetry run mkdocs build --strict`` exits 0 locally
- [x] ``make check`` green locally
- [ ] CI green on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)