### PR TITLE
feat: one-shot pickup of initial-prompt.txt across agent wrappers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.127"
+version = "0.0.128"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_executor/provider/agents.py
+++ b/src/terok_executor/provider/agents.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from terok_executor._util import ensure_dir, ensure_dir_writable, yaml_load as _yaml_load
 
-from .wrappers import WrapperConfig
+from .wrappers import WrapperConfig, initial_prompt_block
 
 # TODO: future — support global agent definitions in terok-config.yml (agent.subagents).
 # When implemented, global subagents would be merged with per-project subagents before
@@ -395,6 +395,10 @@ def _generate_claude_wrapper(cfg: WrapperConfig) -> str:
     lines.append("    [ -s /home/dev/.terok/claude-session.txt ] && \\")
     lines.append('       { [ -n "$_timeout" ] || [ $# -eq 0 ]; } && \\')
     lines.append('        _args+=(--resume "$(cat /home/dev/.terok/claude-session.txt)")')
+
+    # Pick up the task's initial prompt on bare interactive launch when no
+    # resume is being injected.  Mirrors the generic wrapper's behaviour.
+    lines.extend(initial_prompt_block("/home/dev/.terok/claude-session.txt"))
 
     # Git env vars and exec — with optional timeout.
     # _terok_resume_or_fresh guards against stale session IDs: if the agent

--- a/src/terok_executor/provider/wrappers.py
+++ b/src/terok_executor/provider/wrappers.py
@@ -21,6 +21,13 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+INITIAL_PROMPT_PATH = "/home/dev/.terok/initial-prompt.txt"
+"""Container path of the per-task initial prompt the TUI/CLI writes at launch."""
+
+INITIAL_PROMPT_CONSUMED_PATH = "/home/dev/.terok/initial-prompt.consumed.txt"
+"""Where the prompt file is moved after an agent picks it up (one-shot semantics)."""
+
+
 @dataclass(frozen=True)
 class WrapperConfig:
     """Groups parameters for generating the Claude shell wrapper."""
@@ -122,6 +129,30 @@ def _opencode_plugin_block(provider: AgentProvider) -> list[str]:
         '    if [ -f "$_plugin_src" ]; then',
         '        mkdir -p "$_plugin_dir"',
         '        ln -sf "$_plugin_src" "$_plugin_dir/terok-session.mjs"',
+        "    fi",
+    ]
+
+
+def initial_prompt_block(session_path: str | None) -> list[str]:
+    """Emit bash lines that pick up the task's initial prompt as the first message.
+
+    Fires only on a bare interactive launch (no user args, no headless timeout)
+    when no session is being resumed.  The file is renamed after consumption so
+    a subsequent agent invocation falls through to ``--resume`` (or starts
+    fresh) instead of replaying the same prompt.
+
+    The renamed copy is preserved as a paper trail; the user can ``mv`` it
+    back to recover from a launch that crashed before the session was saved.
+    """
+    guards = ['[ -z "$_timeout" ]', "[ $# -eq 0 ]"]
+    if session_path:
+        guards.append(f"[ ! -s {session_path} ]")
+    guards.append(f"[ -s {INITIAL_PROMPT_PATH} ]")
+    return [
+        "    # Pick up the task's initial prompt as the first message (one-shot).",
+        f"    if {' && '.join(guards)}; then",
+        f'        set -- "$(cat {INITIAL_PROMPT_PATH})"',
+        f"        mv {INITIAL_PROMPT_PATH} {INITIAL_PROMPT_CONSUMED_PATH}",
         "    fi",
     ]
 
@@ -288,6 +319,7 @@ def _generate_generic_wrapper(provider: AgentProvider) -> str:
     lines.extend(_opencode_plugin_block(provider))
     lines.extend(_session_resume_block(provider, session_path))
     lines.extend(_codex_instr_block(provider))
+    lines.extend(initial_prompt_block(session_path))
     lines.extend(_vibe_capture_fn(provider, session_path))
 
     headless_cmd = _wrap_invocation(

--- a/src/terok_executor/resources/scripts/terok-bash-banner.sh
+++ b/src/terok_executor/resources/scripts/terok-bash-banner.sh
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+# terok:container — concatenated into the system bashrc; never executed standalone.
+
+# Help banner (interactive login only)
+if [ -t 1 ] && [ -z "$_TEROK_BANNER_SHOWN" ]; then
+  export _TEROK_BANNER_SHOWN=1
+  _TEROK_LOGIN=1 hilfe --kurz 2>/dev/null || true
+  if [ -s /home/dev/.terok/initial-prompt.txt ]; then
+    printf '\033[1;33m📝 Initial prompt\033[0m \033[2m(/home/dev/.terok/initial-prompt.txt)\033[0m\n'
+    cat /home/dev/.terok/initial-prompt.txt
+    printf '\n\n'
+  fi
+fi

--- a/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
@@ -57,10 +57,13 @@ RUN set -eux; \
 # from /etc/skel.  Pick the right file per family or the help banner is
 # silently dropped on Fedora.
 COPY scripts/terok-env.sh /etc/profile.d/terok-env.sh
+COPY scripts/terok-bash-banner.sh /tmp/terok-bash-banner.sh
 RUN chmod +x /etc/profile.d/terok-env.sh; \
     bashrc={% if family == "deb" %}/etc/bash.bashrc{% else %}/etc/bashrc{% endif %}; \
     printf '\n# terok environment (PATH, git identity, agent wrappers)\n. /etc/profile.d/terok-env.sh\n' >> "$bashrc"; \
-    printf '\n# Help banner (interactive login only)\nif [ -t 1 ] && [ -z "$_TEROK_BANNER_SHOWN" ]; then\n  export _TEROK_BANNER_SHOWN=1\n  _TEROK_LOGIN=1 hilfe --kurz 2>/dev/null || true\nfi\n' >> "$bashrc"
+    printf '\n' >> "$bashrc"; \
+    cat /tmp/terok-bash-banner.sh >> "$bashrc"; \
+    rm -f /tmp/terok-bash-banner.sh
 
 # Symlink for per-task agent wrappers (resolved at runtime via mount).
 RUN mkdir -p /usr/local/share/terok && \

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -169,6 +169,14 @@ class TestGenerateClaudeWrapper:
         wrapper = _generate_claude_wrapper(WrapperConfig(has_agents=False))
         assert f'"{CONTAINER_CLAUDE_MEMORY_OVERRIDE}"' in wrapper
 
+    def test_wrapper_picks_up_initial_prompt(self) -> None:
+        """Wrapper consumes initial-prompt.txt one-shot, gated on no resume."""
+        wrapper = _generate_claude_wrapper(WrapperConfig(has_agents=False))
+        assert "/home/dev/.terok/initial-prompt.txt" in wrapper
+        assert "/home/dev/.terok/initial-prompt.consumed.txt" in wrapper
+        # Resume always wins — pickup is skipped if the session file is present.
+        assert f"[ ! -s {CONTAINER_CLAUDE_SESSION_PATH} ]" in wrapper
+
 
 class TestWriteSessionHook:
     """Tests for _write_session_hook."""

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -523,8 +523,10 @@ class TestTemplateRendering:
         rpm = render_l1("terok-l0:test", family="rpm")
         assert "bashrc=/etc/bash.bashrc" in deb
         assert "bashrc=/etc/bashrc" in rpm
-        assert "_TEROK_LOGIN=1 hilfe --kurz" in deb
-        assert "_TEROK_LOGIN=1 hilfe --kurz" in rpm
+        # Banner snippet is concatenated from a sidecar file (see
+        # scripts/terok-bash-banner.sh) into whichever bashrc the family uses.
+        assert 'cat /tmp/terok-bash-banner.sh >> "$bashrc"' in deb
+        assert 'cat /tmp/terok-bash-banner.sh >> "$bashrc"' in rpm
 
     def test_l1_unknown_agent_raises(self) -> None:
         with pytest.raises(ValueError, match="Unknown roster entries"):

--- a/tests/unit/test_headless_providers.py
+++ b/tests/unit/test_headless_providers.py
@@ -20,6 +20,8 @@ from terok_executor.provider.providers import (
     get_provider,
 )
 from terok_executor.provider.wrappers import (
+    INITIAL_PROMPT_CONSUMED_PATH,
+    INITIAL_PROMPT_PATH,
     generate_agent_wrapper,
     generate_all_wrappers,
 )
@@ -147,6 +149,31 @@ class TestGenerateAgentWrapper:
                 continue
             wrapper = _provider_wrapper(name)
             assert "vibe-model-sync" not in wrapper, f"{name} should not have model sync"
+
+    def test_all_wrappers_pick_up_initial_prompt(self) -> None:
+        """Every provider's wrapper consumes initial-prompt.txt one-shot."""
+        for name in AGENT_PROVIDERS:
+            wrapper = _provider_wrapper(name)
+            assert INITIAL_PROMPT_PATH in wrapper, f"{name} missing initial-prompt pickup"
+            assert INITIAL_PROMPT_CONSUMED_PATH in wrapper, f"{name} missing one-shot rename"
+            assert f'set -- "$(cat {INITIAL_PROMPT_PATH})"' in wrapper, (
+                f"{name} should set positional args from the prompt file"
+            )
+
+    def test_initial_prompt_skipped_when_session_present(self) -> None:
+        """Wrappers with a session_file gate the prompt pickup on no resume."""
+        for name in ("vibe", "opencode", "blablador", "kisski"):
+            p = AGENT_PROVIDERS[name]
+            wrapper = _provider_wrapper(name)
+            assert f"[ ! -s {CONTAINER_TEROK_DIR}/{p.session_file} ]" in wrapper, (
+                f"{name} initial-prompt block should defer to session resume"
+            )
+
+    def test_initial_prompt_skipped_in_headless(self) -> None:
+        """Pickup block requires `_timeout` empty so headless never picks up the file."""
+        for name in AGENT_PROVIDERS:
+            wrapper = _provider_wrapper(name)
+            assert '[ -z "$_timeout" ]' in wrapper, f"{name} missing headless guard"
 
 
 class TestResolveProviderValue:


### PR DESCRIPTION
## Summary

- Per-provider wrappers (`claude()`, `codex()`, `vibe()`, `blablador()`, `kisski()`, `opencode()`, `copilot()`) now treat `/home/dev/.terok/initial-prompt.txt` as the first message on a bare interactive launch when no session is being resumed. After consumption the file is renamed to `initial-prompt.consumed.txt` so subsequent invocations fall through to `--resume` (or a fresh session) instead of replaying the prompt.
- The renamed copy is preserved deliberately: a user can `mv` it back to recover from a launch that crashed before the session was saved, and it gives a one-shot replay handle without needing extra UI.
- The system bashrc now also surfaces the prompt right after `hilfe --kurz` (extracted into `scripts/terok-bash-banner.sh` for legibility), so a plain `bash` login shows what the task is supposed to be about. The bash side displays only — the wrapper retains sole responsibility for actually feeding the prompt to an agent, so a user starting in bash and then running `claude` gets a single delivery to the AI.

The pickup is gated on `[ -z "$_timeout" ] && [ $# -eq 0 ]` so headless runs (which already pass the prompt explicitly) are never affected, and on a per-provider session-file check so `--resume` always wins when a saved session exists.

Pairs with the matching simplification on the terok side that drops the in-process prompt plumbing (TUI/CLI just writes the file, no command-line plumbing).

## Test plan

- [x] `make lint` passes
- [x] `make tach`, `make docstrings`, `make security`, `make reuse` pass
- [x] New unit tests cover Claude + every generic wrapper for prompt pickup, session-resume gating, and headless guard
- [x] Existing `test_l1_banner_targets_family_specific_bashrc` updated to assert the new sidecar wiring
- [x] Full `pytest` (skipping `test_preflight.py` which needs `nft` not present in this dev container) — 695/695 pass
- [ ] In-container smoke: launch a task with an initial prompt → bashrc displays after the banner → `claude` consumes the file and `initial-prompt.consumed.txt` is left behind

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive sessions now support initial prompt pickup from a one-shot file that automatically consumes itself after first use.
  * Added a login banner that displays help information and shows initial prompts on interactive terminal sessions.
  * Initial prompt behavior is session-aware, skipping activation when resuming sessions or in headless mode.

* **Tests**
  * Added comprehensive unit tests covering initial prompt functionality and banner rendering across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->