### PR TITLE
fix: avoid podman creating root-owned bind-target stubs (gh broken)

### DIFF
--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -282,17 +282,11 @@ def assemble_container_env(
     volumes.append(VolumeSpec(spec.workspace_host_path, "/workspace", sharing=Sharing.PRIVATE))
 
     # 8. Shared config mounts from roster
-    #
-    #    Resolve task_dir up-front so the credential-shadow path has a
-    #    private scratch location for placeholder files when the host
-    #    has no credential yet.  The *task_dir = ...* assignment that
-    #    used to live near the return is now this resolution.
     mounts_base = spec.envs_dir or _mounts_dir()
     task_dir = spec.task_dir or Path(tempfile.mkdtemp(prefix=f"terok-executor-{spec.task_id}-"))
     volumes += _shared_config_mounts(
         roster,
         mounts_base,
-        task_dir=task_dir,
         expose_credential_providers=spec.expose_credential_providers,
     )
 
@@ -385,14 +379,10 @@ def _resolve_git_identity(spec: ContainerEnvSpec, roster: AgentRoster) -> dict[s
     }
 
 
-_CRED_PLACEHOLDER_DIR = "cred-placeholders"
-
-
 def _shared_config_mounts(
     roster: AgentRoster,
     mounts_base: Path,
     *,
-    task_dir: Path,
     expose_credential_providers: frozenset[str] = frozenset(),
 ) -> list[VolumeSpec]:
     """Derive shared volume specs from the agent roster.
@@ -404,16 +394,17 @@ def _shared_config_mounts(
     For mounts that carry a [`MountDef.credential_file`][terok_executor.roster.loader.MountDef.credential_file],
     a read-only file mount is layered on top of the shared directory so an
     in-container ``/login`` cannot rewrite the host-side phantom token
-    (terok-ai/terok#873).  The source is the host file when present, else
-    a per-task empty placeholder under ``task_dir/cred-placeholders/`` —
-    so the read-only shadow is consistent regardless of host auth state.
+    (terok-ai/terok#873).  We ``touch()`` the host-side credential file
+    when missing so podman has a real bind source — otherwise podman
+    materialises the destination inside the container's userns as root
+    with mode 0700, leaving the file unreadable to the agent (and breaking
+    e.g. ``gh`` whose ``hosts.yml`` is normally absent on fresh installs).
 
     Providers in *expose_credential_providers* keep the writable mount —
     used by terok's experimental ``expose_oauth_token`` mode where the
     agent intentionally manages its own token.
     """
     specs: list[VolumeSpec] = []
-    placeholder_dir = task_dir / _CRED_PLACEHOLDER_DIR
 
     for m in roster.mounts:
         host_dir = mounts_base / m.host_dir
@@ -424,10 +415,8 @@ def _shared_config_mounts(
             continue
 
         host_file = host_dir / m.credential_file
-        if not host_file.exists():
-            host_file = placeholder_dir / m.host_dir
-            host_file.parent.mkdir(parents=True, exist_ok=True)
-            host_file.touch()
+        host_file.parent.mkdir(parents=True, exist_ok=True)
+        host_file.touch(exist_ok=True)
 
         container_file = f"{m.container_path}/{m.credential_file}"
         specs.append(VolumeSpec(host_file, container_file, read_only=True))

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -1034,19 +1034,19 @@ class TestSharedConfigMountsUnit:
     """Unit tests for the internal shared mount builder."""
 
     def test_creates_host_dirs(self, roster, tmp_path):
-        mounts = _shared_config_mounts(roster, tmp_path, task_dir=tmp_path / "task")
+        mounts = _shared_config_mounts(roster, tmp_path)
         assert len(mounts) > 0
         assert (tmp_path / "_claude-config").is_dir()
 
     def test_deduplicates_by_host_dir(self, roster, tmp_path):
-        mounts = _shared_config_mounts(roster, tmp_path, task_dir=tmp_path / "task")
+        mounts = _shared_config_mounts(roster, tmp_path)
         # Directory mounts (rw shared dir) must be unique by host path; ro
         # credential shadows are layered on top and reuse the parent.
         dir_paths = [str(m.host_path) for m in mounts if not m.read_only]
         assert len(dir_paths) == len(set(dir_paths))
 
     def test_all_use_shared_label(self, roster, tmp_path):
-        mounts = _shared_config_mounts(roster, tmp_path, task_dir=tmp_path / "task")
+        mounts = _shared_config_mounts(roster, tmp_path)
         for m in mounts:
             assert m.sharing == "shared", f"Expected sharing='shared', got: {m.sharing}"
 
@@ -1056,8 +1056,7 @@ class TestSharedConfigMountsUnit:
         host_cred.parent.mkdir(parents=True)
         host_cred.write_text('{"phantom": true}')
 
-        task_dir = tmp_path / "task"
-        mounts = _shared_config_mounts(roster, tmp_path, task_dir=task_dir)
+        mounts = _shared_config_mounts(roster, tmp_path)
         cred = next(
             (m for m in mounts if m.container_path == "/home/dev/.claude/.credentials.json"),
             None,
@@ -1066,27 +1065,25 @@ class TestSharedConfigMountsUnit:
         assert cred.read_only is True
         assert cred.host_path == host_cred
 
-    def test_credential_file_uses_placeholder_when_host_absent(self, roster, tmp_path):
-        """Host has no credential — ro bind sources from a per-task placeholder."""
-        task_dir = tmp_path / "task"
-        mounts = _shared_config_mounts(roster, tmp_path, task_dir=task_dir)
+    def test_credential_file_touched_when_host_absent(self, roster, tmp_path):
+        """Host has no credential — touch an empty file at the natural path so
+        podman doesn't materialise the bind target as root with mode 0700."""
+        mounts = _shared_config_mounts(roster, tmp_path)
         cred = next(
             (m for m in mounts if m.container_path == "/home/dev/.claude/.credentials.json"),
             None,
         )
         assert cred is not None
         assert cred.read_only is True
-        assert cred.host_path.is_relative_to(task_dir / "cred-placeholders")
+        assert cred.host_path == tmp_path / "_claude-config" / ".credentials.json"
         assert cred.host_path.exists()
         assert cred.host_path.stat().st_size == 0
 
     def test_credential_file_skipped_when_provider_exposed(self, roster, tmp_path):
         """Providers in expose set keep the writable mount — no ro shadow."""
-        task_dir = tmp_path / "task"
         mounts = _shared_config_mounts(
             roster,
             tmp_path,
-            task_dir=task_dir,
             expose_credential_providers=frozenset({"claude"}),
         )
         cred = [m for m in mounts if m.container_path == "/home/dev/.claude/.credentials.json"]


### PR DESCRIPTION
## Summary

After v0.0.129, ``gh`` (and any tool whose credential file is normally
absent on a fresh install) breaks inside task containers — its
``hosts.yml`` shows up as ``-rwx------ root root 0`` and the dev user
can no longer read its own config.

```
[dev@…] $ gh repo list
warning: failed to load config: open /home/dev/.config/gh/hosts.yml: permission denied
[dev@…] $ ll ~/.config/gh/
-rw-r--r--. 1 dev  dev  55 May  4 01:01 config.yml
-rwx------. 1 root root  0 May  3 21:10 hosts.yml
```

## Cause

The credential-containment work pointed the ro file mount at a
per-task placeholder under ``task_dir/cred-placeholders/`` when the
host had no credential.  The mount destination is
``/home/dev/.config/gh/hosts.yml`` inside the container — which sits
*inside* the rw bind of ``mounts_base/_gh-config``.  Because the
underlying directory's ``hosts.yml`` did not exist, podman materialised
the bind target itself, **as root with mode 0700**.  With
``--userns=keep-id`` that uid maps to real root, leaving the agent
(running as ``dev``) unable to read the file.

The placeholder buys nothing — podman creates a stub on the host
either way; the only question is whether *we* create it as the terok
user, or *podman* creates it as root.

## Fix

Drop the placeholder dance.  ``touch()`` the credential file in-place
at ``mounts_base/<host_dir>/<credential_file>`` — owned by uid 1000,
empty, harmless.  The ro bind on top still blocks the
``/login``-style phantom→real conversion vector that #873 was about.

## Recovery for affected users

On the **host** (outside any container):

    rm ~/.local/share/terok/sandbox-live/mounts/_gh-config/hosts.yml

Then start a fresh task — the next container build creates the file
correctly.  Same recipe applies for any other tool whose credential
file got materialised as root (check
``ls -la ~/.local/share/terok/sandbox-live/mounts/*/`` for stray
``root:root  0`` files).

## Test plan

- [x] Renamed ``test_credential_file_uses_placeholder_when_host_absent`` →
      ``test_credential_file_touched_when_host_absent``; asserts the bind
      source is the natural host path, not a per-task placeholder.
- [x] ``make check`` clean (719 unit tests, lint, tach, vulture, reuse, docstrings, security).
- [ ] Manual: start a fresh task on a host with no ``~/.local/share/terok/sandbox-live/mounts/_gh-config/``; ``gh auth status`` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized credential file handling during container setup to ensure host-side credential files are created when absent, while preserving writable credential mounts for exposed providers.
  * Streamlined environment preparation for more reliable container mount setup and easier maintenance.

* **Tests**
  * Updated unit tests to reflect the new host-file creation behavior and simplified mount validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->