### PR TITLE
fix: skip touch() when credential file already exists

### DIFF
--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -416,7 +416,8 @@ def _shared_config_mounts(
 
         host_file = host_dir / m.credential_file
         host_file.parent.mkdir(parents=True, exist_ok=True)
-        host_file.touch(exist_ok=True)
+        if not host_file.exists():
+            host_file.touch()
 
         container_file = f"{m.container_path}/{m.credential_file}"
         specs.append(VolumeSpec(host_file, container_file, read_only=True))


### PR DESCRIPTION
## Summary

Follow-up to #260.  Users who hit the original root-owned-stub bug and
didn't manually clean their mounts dir before upgrading to 0.0.130 hit
a hard crash on the next ``terok task run``:

```
PermissionError: [Errno 13] Permission denied:
  '/var/home/strazce/.local/share/terok/sandbox-live/mounts/_blablador-config/config.json'
```

``Path.touch(exist_ok=True)`` opens with ``O_CREAT|O_WRONLY`` and
bumps mtime — that ``O_WRONLY`` is what fails on a leftover ``root:0700`` stub.

## Fix

We never needed to update mtime; we only needed the file to *exist* so
podman has a real bind source.  Guard the ``touch()`` with an existence
check.  No-op path costs one extra ``stat()``; broken stubs no longer
block startup.

Stale stubs still need ``sudo rm`` to be readable inside the container
(can't fix ownership from inside the executor), but at least the host
side stops crashing.

## Test plan

- [x] Existing ``TestSharedConfigMountsUnit`` suite passes — covers
      both branches (host has phantom / host file absent).
- [ ] Manual: reproduce strazce's case (pre-existing root-owned stub
      under ``mounts/_blablador-config/``) — ``terok task run`` should
      now proceed past env assembly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved credential file initialization in container environments by implementing more careful and explicit file existence checks before creating credential files. This prevents unnecessary file operations and significantly improves overall reliability during container setup. The system now provides more dependable and secure credential management throughout the entire container configuration and initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->