### PR TITLE
fix(l0): force shadow entry after rename so pam_unix can validate dev

### DIFF
--- a/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
@@ -38,6 +38,12 @@ RUN set -eux; \
       if getent group "$uid_owner" >/dev/null; then groupmod -n dev "$uid_owner" || true; fi; \
       usermod -l dev "$uid_owner"; \
       usermod -d /home/dev -m dev; \
+      # usermod -l only updates /etc/passwd.  On bases whose UID-1000 user \
+      # ships no /etc/shadow entry (e.g. quay.io/podman/stable, fedora:43), \
+      # pam_unix later fails getspnam("dev") and breaks sudo with a confusing \
+      # "Authentication service cannot retrieve authentication info" error. \
+      # Force a locked shadow row so the account exists for PAM to look up. \
+      usermod -p '!' dev; \
       # usermod -l / groupmod -n don't touch /etc/sub{u,g}id; rewrite \
       # those entries so pre-configured rootless ranges (e.g. the podman \
       # image's `podman:100000:65536`) keep working under the new name. \
@@ -52,8 +58,9 @@ RUN set -eux; \
       useradd -m -u 1000 -g dev -s /bin/bash dev; \
     fi; \
     if [ "$(id -u dev)" != "1000" ]; then usermod -u 1000 dev; fi; \
-    printf 'dev ALL=(ALL) NOPASSWD:ALL\n' > /etc/sudoers.d/dev; \
+    echo 'dev ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/dev; \
     chmod 0440 /etc/sudoers.d/dev; \
+    visudo -cf /etc/sudoers.d/dev; \
     mkdir -p /workspace /home/dev/.ssh; \
     chown -R dev:dev /home/dev /workspace; \
     chmod 700 /home/dev/.ssh; \

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -481,6 +481,21 @@ class TestTemplateRendering:
         content = render_l0("nvidia/cuda:12.4.1-devel-ubuntu24.04")
         assert "FROM" in content
 
+    def test_l0_forces_shadow_entry_after_rename(self) -> None:
+        # Bases whose UID-1000 user has no /etc/shadow row (quay.io/podman/stable,
+        # fedora:43) silently produce a renamed dev user that pam_unix can't look
+        # up — sudo then fails with "PAM account management error: Authentication
+        # service cannot retrieve authentication info".  ``usermod -p '!' dev``
+        # writes a locked shadow row regardless of what the base shipped.
+        content = render_l0()
+        assert "usermod -p '!' dev" in content
+
+    def test_l0_validates_sudoers(self) -> None:
+        # ``visudo -cf`` fails the build on a malformed sudoers drop-in, which
+        # is much friendlier than discovering it at first sudo.
+        content = render_l0()
+        assert "visudo -cf /etc/sudoers.d/dev" in content
+
     def test_l1_is_valid_dockerfile(self) -> None:
         content = render_l1("terok-l0:test", family="deb")
         assert content.startswith("# syntax=docker")


### PR DESCRIPTION
## Summary

- The L0 rename branch (`usermod -l dev "$uid_owner"`) updates `/etc/passwd` only. On bases whose UID-1000 user ships no `/etc/shadow` row (`quay.io/podman/stable`, `fedora:43`), pam_unix's account stack then fails `getspnam("dev")` and `sudo` refuses with `PAM account management error: Authentication service cannot retrieve authentication info / a password is required`.
- Add `usermod -p '!' dev` after the rename — writes a locked shadow row regardless of base state, the same locked-account format `useradd` produces in the fresh-create path. Idiomatic and one line.
- Add `visudo -cf /etc/sudoers.d/dev` so a malformed sudoers drop-in fails the build instead of being discovered at first sudo. Drop `printf` for `echo` and add the conventional space in `NOPASSWD: ALL` while we're there.
- Two unit tests assert the rendered L0 Dockerfile contains both fixes.

Refs #273 (broader refactor to support the base image's existing default user instead of forcing a rename — out of scope for this hotfix).

## Test plan

- [x] `poetry run pytest tests/unit/test_build.py -k "TestTemplateRendering"` — 22 passed including the two new assertions.
- [x] `poetry run pytest tests/unit/` — full suite green except 4 preexisting `test_preflight` failures caused by missing `nft` in this dev container (also fail on master, unrelated to this change).
- [x] `ruff check .` clean; `ruff format --check .` clean; `docstr-coverage` 97.2%; `bandit` no medium/high findings.
- [ ] Rebuild a project image on a Fedora 43 base and confirm `sudo -nl` works as `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security hardening for user account management in the build system
  * Added configuration file validation during the build process to ensure integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->