### PR TITLE
fix(auth): use prompt_toolkit for masked API-key entry instead of pwinput

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1938,7 +1938,7 @@ version = "3.0.52"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
     {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
@@ -2107,17 +2107,6 @@ watchdog = ">=2.0"
 
 [package.extras]
 i18n = ["babel (>=2.9.0)"]
-
-[[package]]
-name = "pwinput"
-version = "1.0.3"
-description = "A cross-platform Python module that displays **** for password input. Works on Windows, unlike getpass. Formerly called stdiomask."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "pwinput-1.0.3.tar.gz", hash = "sha256:ca1a8bd06e28872d751dbd4132d8637127c25b408ea3a349377314a5491426f3"},
-]
 
 [[package]]
 name = "pycparser"
@@ -3085,7 +3074,7 @@ version = "0.7.0"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2"},
     {file = "wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"},
@@ -3237,4 +3226,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "473d04ccf4c39ec4dbc8c41f5de6a66e8b0f8ee609572e170b3a6c216ca39fd7"
+content-hash = "b5f82a3d464c5ef735982a9348edf3172cd9d2a84df19894edd8920be814b604"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/downl
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"
-pwinput = ">=1.0.3"
+prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 agent-client-protocol = ">=0.7"

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -277,23 +277,28 @@ def store_api_key(
 def _prompt_api_key(info: AuthProvider) -> str:
     """Interactively prompt for an API key (echoes ``*`` per character).
 
-    pwinput only guards against a *replaced* ``sys.stdin``, not against a
-    non-TTY one — shell redirection (``< keyfile.txt``) leaves ``sys.stdin``
-    identical to ``sys.__stdin__`` with a non-TTY fd, which would crash
-    ``tty.setraw`` inside pwinput.  Gate the call on ``isatty()`` and read
-    a line deterministically otherwise so pipe-fed automation still works.
+    Uses ``prompt_toolkit.prompt(is_password=True)`` for the TTY path —
+    proper terminal raw-mode handling, ``Ctrl+C`` raises
+    ``KeyboardInterrupt`` cleanly, and every character is reliably
+    masked (the previous ``pwinput`` implementation occasionally let a
+    keystroke echo through and swallowed ``SIGINT``).  Non-TTY input
+    (``terok auth … < keyfile.txt``) falls back to a plain
+    ``readline`` so pipe-fed automation still works.
     """
     import sys
 
     if info.api_key_hint:
         print(info.api_key_hint)
-    prompt = f"{info.label} API key: "
+    prompt_text = f"{info.label} API key: "
     if sys.stdin.isatty():
-        import pwinput
+        from prompt_toolkit import prompt as ptk_prompt
 
-        key = pwinput.pwinput(prompt=prompt, mask="*").strip()
+        try:
+            key = ptk_prompt(prompt_text, is_password=True).strip()
+        except (KeyboardInterrupt, EOFError):
+            raise SystemExit("API key entry cancelled.") from None
     else:
-        print(prompt, end="", flush=True)
+        print(prompt_text, end="", flush=True)
         key = sys.stdin.readline().strip()
     if not key:
         raise SystemExit("No API key entered.")


### PR DESCRIPTION
## Summary

User-reported issues with the existing API-key prompt:

- A keystroke occasionally echoes through unmasked instead of being replaced by ``*``.
- ``Ctrl+C`` is swallowed — the prompt can't be cancelled.

Both are ``pwinput``'s known issues with raw-mode input + signal handling.

Switch to ``prompt_toolkit.prompt(is_password=True)``, which:

- Reliably masks every keystroke with ``*``.
- Handles ``Ctrl+C`` (raises ``KeyboardInterrupt``) and ``Ctrl+D`` (raises ``EOFError``) cleanly — both surface as a plain ``SystemExit("API key entry cancelled.")``.
- Properly restores terminal raw-mode on every exit path.

The non-TTY fallback (``stdin.readline()`` for piped automation like ``terok auth claude < keyfile.txt``) is unchanged.

## Dependency change

- **Remove**: ``pwinput >= 1.0.3``
- **Add**: ``prompt-toolkit >= 3.0``

prompt_toolkit is the standard Python prompt library — used by ipython, ptpython, jupyter, and most major REPLs. ~3.7 MB on disk. Already a transitive dependency in the dev/docs install (via ``tach``); this just promotes it to a runtime dep.

## Test plan

- [x] ``pytest tests/unit/`` — 789 passing.
- [x] ``ruff check`` / ``ruff format --check`` clean.
- [x] ``tach check`` clean.
- [x] ``docstr-coverage`` 97.2%.
- [x] ``bandit`` no medium/high findings.
- [x] ``reuse lint`` clean.
- [x] Non-TTY path verified by feeding stdin programmatically: returns the input verbatim.
- [ ] (Manual, on test machine) Run ``terok auth blablador`` interactively — expect every character masked, ``Ctrl+C`` cancels cleanly, no rogue echoes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of keyboard interrupts (Ctrl+C) during API key input with cleaner exit messages.
  * Enhanced input handling for both interactive and automated environments.

* **Chores**
  * Updated project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->