### PR TITLE
feat(init-script): add `gate` remote in online mode via GATE_REMOTE_URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.137"
+version = "0.0.138"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
@@ -270,7 +270,10 @@ if [[ -n "${REPO_ROOT:-}" && -n "${CODE_REPO:-}" ]]; then
   # gatekeeping mode the gate is already origin, so terok only sets
   # GATE_REMOTE_URL in online mode — its absence here is the natural guard.
   if [[ -n "${GATE_REMOTE_URL:-}" ]]; then
-    echo ">> adding 'gate' remote: ${GATE_REMOTE_URL}"
+    # Strip the per-task token from the printed URL — it's per-task Basic
+    # Auth credentials embedded in `http://<token>@host:port/repo`.  The
+    # actual git command below uses the unredacted URL.
+    echo ">> adding 'gate' remote: ${GATE_REMOTE_URL/:\/\/*@/://<token>@}"
     git -C "${REPO_ROOT}" remote remove gate 2>/dev/null || true
     git -C "${REPO_ROOT}" remote add gate "${GATE_REMOTE_URL}"
   fi

--- a/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 #   GIT_RESET_MODE          - "none" (default), "hard", or "soft"
 #   CLONE_FROM              - optional alternate source to seed the repo (e.g. file:///git-gate/gate.git)
 #   EXTERNAL_REMOTE_URL     - optional URL for upstream repo in gatekeeping mode (added as "external" remote)
+#   GATE_REMOTE_URL         - optional URL for the host-side gate in online mode (added as "gate" remote)
 #   (bridge env vars — TEROK_SSH_SIGNER_PORT, TEROK_SSH_SIGNER_TOKEN, TEROK_TOKEN_BROKER_PORT, GH_TOKEN —
 #    are consumed by ensure-bridges.sh, sourced below)
 
@@ -259,6 +260,19 @@ if [[ -n "${REPO_ROOT:-}" && -n "${CODE_REPO:-}" ]]; then
     # Remove existing external remote if present (idempotent)
     git -C "${REPO_ROOT}" remote remove external 2>/dev/null || true
     git -C "${REPO_ROOT}" remote add external "${EXTERNAL_REMOTE_URL}"
+  fi
+
+  # In online mode, surface the host-side gate as a "gate" remote so the
+  # agent can push WIP branches host-locally without going to upstream
+  # (and so a human can review them on the host before promoting).
+  # Mirror of the EXTERNAL_REMOTE_URL block above: gatekeeping mode adds
+  # upstream as "external"; online mode adds the gate as "gate".  In
+  # gatekeeping mode the gate is already origin, so terok only sets
+  # GATE_REMOTE_URL in online mode — its absence here is the natural guard.
+  if [[ -n "${GATE_REMOTE_URL:-}" ]]; then
+    echo ">> adding 'gate' remote: ${GATE_REMOTE_URL}"
+    git -C "${REPO_ROOT}" remote remove gate 2>/dev/null || true
+    git -C "${REPO_ROOT}" remote add gate "${GATE_REMOTE_URL}"
   fi
 
   # Check gate staleness (informational only)


### PR DESCRIPTION
## Summary

Mirror of the existing `EXTERNAL_REMOTE_URL → "external"` block: in online mode, surface the host-side gate as a `gate` remote so the agent can push WIP branches host-locally without going to upstream.

## Why

Today in online mode the gate seeds the initial clone, then `origin` is repointed to upstream and the gate is forgotten. After this change, the gate is also accessible as a named remote — agents and humans can use it as a free checkpoint mechanism without the upstream round-trip.

This makes the gate's role coherent across both modes:
- **gatekeeping**: gate is `origin`, optionally upstream as `external` (existing)
- **online**: upstream is `origin`, gate as `gate` (new)
- **gate.enabled: false**: no gate remote at all
- **no upstream**: gate is `origin` (modes collapse — existing)

Companion change in terok wires `GATE_REMOTE_URL` into the container env in online mode when the gate exists. terok PR will pin this branch in `pyproject.toml` until release.

## Design notes

- Always-on (no opt-in flag): adding the gate to an online container is **not** a security relaxation — the agent already has gate access via the initial clone path. There's no new capability, just a named handle.
- `EXTERNAL_REMOTE_URL` exists only in gatekeeping mode (where exposing upstream *would* be a security relaxation, hence opt-in).
- `GATE_REMOTE_URL`'s absence is the natural guard: terok only sets it in online mode (in gatekeeping the gate is already `origin`).

## Test plan

- [x] `bash -n` syntax check
- [x] `shellcheck` — no new findings (one pre-existing `SC1091` info on `source ensure-bridges.sh`)
- [x] `pytest tests/unit` — 789 passed (4 preflight tests skipped, they require `nft` binary not present in my container)
- [x] `ruff check` / `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now supports an optional GATE_REMOTE_URL environment variable to automatically and idempotently configure an additional Git remote named "gate" during repository initialization.

* **Chores**
  * Project version updated from 0.0.137 to 0.0.138.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/281)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->