### PR TITLE
docs: seed CHANGELOG.md for the first PyPI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Per-release notes live on the [GitHub Releases page][rel], which is
+also the "Changelog" link in PyPI metadata.
+
+[rel]: https://github.com/terok-ai/terok-executor/releases
+
+## v0.1.0 — first PyPI release
+
+`terok-executor` joined PyPI in v0.1.0. Versions before that were GitHub Release
+wheels only.


### PR DESCRIPTION
Adds a minimal `CHANGELOG.md` stub pointing at the GH Releases page (which is also the 'Changelog' link in our `pyproject.toml` `[project.urls]`), with a single forward-looking entry for the upcoming first PyPI release of this package as a minor bump.

Once the prep+notes editor flow ([terok-warden/terok-toolbox#2](https://github.com/terok-warden/terok-toolbox/issues/2)) lands, the chain script will write executive-summary text into both this file and the GH release body simultaneously.

Companion to the analogous PRs on the rest of the terok-ai family.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added changelog documenting the project's release history with guidance on accessing detailed release notes via GitHub Releases and information about the v0.1.0 initial release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/291)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->