### PR TITLE
docs(readme): add SonarCloud quality-gate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![REUSE status](https://api.reuse.software/badge/github.com/terok-ai/terok-executor)](https://api.reuse.software/info/github.com/terok-ai/terok-executor)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=terok-ai_terok-executor&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=terok-ai_terok-executor)
 
 One command to run an AI coding agent inside a hardened, rootless
 Podman container.


### PR DESCRIPTION
## Summary
- Surface the existing \`terok-ai_terok-executor\` SonarCloud project in the README, matching terok and terok-shield.