### PR TITLE
feat(roster): add vault.shared_domain flag for mixed-purpose hosts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.140"
+version = "0.0.141a1"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -16,6 +16,10 @@ vault:
   credential_file: config.yml
   phantom_env:
     GITLAB_TOKEN: true
+  # gitlab.com carries both the API and ``git push`` traffic on the same
+  # apex; an nft host-deny would also kill pushes.  Read-only credential
+  # containment is the actual containment story for this provider.
+  shared_domain: true
 
 auth:
   host_dir: _glab-config

--- a/src/terok_executor/resources/agents/sonar.yaml
+++ b/src/terok_executor/resources/agents/sonar.yaml
@@ -16,6 +16,11 @@ vault:
   phantom_env:
     SONAR_TOKEN: true
   base_url_env: SONAR_HOST_URL
+  # sonarcloud.io serves API + project pages + docs + badges on the same
+  # apex; an nft host-deny would block legitimate browsing/curling in
+  # ``shield down`` mode.  Credential containment (read-only SONAR_TOKEN
+  # shadow) carries the security weight on its own.
+  shared_domain: true
 
 auth:
   host_dir: _sonar-config

--- a/src/terok_executor/roster/schema.py
+++ b/src/terok_executor/roster/schema.py
@@ -247,6 +247,14 @@ class RawVault(StrictModel):
     shared_config_patch: dict | None = None
     """Free-form dict consumed by the post-auth config patcher (TOML/YAML set ops)."""
     oauth_refresh: RawOAuthRefresh | None = None
+    shared_domain: bool = Field(
+        default=False,
+        description=(
+            "True when ``upstream`` host also serves non-API traffic "
+            "(docs, dashboards, ``git push``…); terok's auth-protect "
+            "layer skips host-level denies for these providers."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -282,6 +290,7 @@ class RawVault(StrictModel):
             socket_env=self.socket_env,
             shared_config_patch=self.shared_config_patch,
             oauth_refresh=refresh,
+            shared_domain=self.shared_domain,
         )
 
 

--- a/src/terok_executor/roster/types.py
+++ b/src/terok_executor/roster/types.py
@@ -109,6 +109,19 @@ class VaultRoute:
     oauth_refresh: dict | None = None
     """OAuth refresh config: ``{token_url, client_id, scope}``."""
 
+    shared_domain: bool = False
+    """Whether the upstream host also serves non-API traffic.
+
+    Set on entries whose ``upstream`` host is an apex (or otherwise mixed)
+    domain that legitimately serves docs, dashboards, ``git push``, etc.
+    Host-level egress denies can't separate paths, so terok's auth-protect
+    layer skips these providers when re-applying denies after ``shield
+    down`` — credential containment alone keeps the API safe.
+
+    Examples: ``gitlab.com`` (API + ``git push``), ``sonarcloud.io``
+    (API + project pages + docs + badges).
+    """
+
 
 @dataclass(frozen=True)
 class InstallSpec:

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -110,6 +110,49 @@ class TestVaultRoutesParsed:
         assert route.oauth_refresh["client_id"] == "app_EMoamEEZ73f0CkXaXp7hrann"
 
 
+class TestSharedDomain:
+    """Verify the ``vault.shared_domain`` flag is parsed and surfaced."""
+
+    def test_default_is_false(self) -> None:
+        """API-only upstreams (claude, codex, gh, …) leave the flag unset."""
+        roster = get_roster()
+        for name in ("claude", "codex", "gh", "vibe", "blablador", "kisski", "openrouter"):
+            route = roster.vault_routes[name]
+            assert route.shared_domain is False, f"{name} should not be shared_domain"
+
+    def test_glab_is_shared_domain(self) -> None:
+        """gitlab.com hosts both API and ``git push`` traffic."""
+        assert get_roster().vault_routes["glab"].shared_domain is True
+
+    def test_sonar_is_shared_domain(self) -> None:
+        """sonarcloud.io hosts API + project pages + docs + badges."""
+        assert get_roster().vault_routes["sonar"].shared_domain is True
+
+    def test_unknown_provider_defaults_to_false(self) -> None:
+        """Hand-rolled vault sections without the field default to False."""
+        route = _vault_route(
+            "test",
+            {"vault": {"route_prefix": "t", "upstream": "https://api.example.com"}},
+        )
+        assert route is not None
+        assert route.shared_domain is False
+
+    def test_explicit_true_round_trips(self) -> None:
+        """``shared_domain: true`` is preserved through schema → dataclass."""
+        route = _vault_route(
+            "test",
+            {
+                "vault": {
+                    "route_prefix": "t",
+                    "upstream": "https://example.com",
+                    "shared_domain": True,
+                }
+            },
+        )
+        assert route is not None
+        assert route.shared_domain is True
+
+
 class TestGenerateRoutesJson:
     """Verify routes.json generation."""
 


### PR DESCRIPTION
## Summary

- Add `shared_domain: bool` (default `false`) to `vault:` roster entries
- Set `shared_domain: true` on `sonar` (sonarcloud.io) and `glab` (gitlab.com)
- Field flows through `RawVault` → `VaultRoute`; not serialized into `routes.json` (sandbox vault doesn't need it)

## Why

Terok's auth-protect layer denies every `vault.upstream` host at the nft level so an in-container `/login` can't complete (terok-ai/terok#873). For API-only subdomains (`api.anthropic.com`, etc.) that's perfect. For apex hosts that mix API + non-API traffic, a host-level deny overshoots and breaks legitimate use:

- `sonarcloud.io` serves API + project pages + docs + badges. Even AGENTS.md instructs running `curl https://sonarcloud.io/api/issues/search?...` from inside containers — currently blocked in `shield down` mode unless the developer adds it to a custom allow profile.
- `gitlab.com` carries API + `git push`. Already worked around in terok by hardcoding `excluded = {"glab"}` in `_auth_protect_hosts`.

This PR pushes the classification into the roster so each agent owns it self-descriptively, and the consumer-side hardcoded skip in terok goes away (companion PR).

## Behavior

- `vault.shared_domain: false` (default) — host is denied as before.
- `vault.shared_domain: true` — terok's auth-protect skips this provider; credential containment (read-only token shadow) carries the security weight.
- Sandbox vault routing is unaffected — the field isn't part of `routes.json`.

## Test plan

- [x] Unit: new `TestSharedDomain` covers default-false, glab/sonar set true, unknown provider default, explicit-true round-trip
- [x] Unit: full `tests/unit/test_vault_routes.py` and `tests/unit/test_roster.py` pass (134/134)
- [x] Static: ruff, tach, mypy, docstr-coverage 97.2%, vulture clean
- [x] Companion terok PR consumes the new field (link to be added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new shared-domain setting for provider configurations; GitLab and SonarCloud are now marked as shared-domain.
  * Bumped package version to 0.0.141a1.

* **Tests**
  * Added tests covering the new shared-domain flag: defaults, provider-specific values, and explicit true round-trips.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/293)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->