### PR TITLE
feat(docs): publish + consume sibling-decoupled inventory

### DIFF
--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
-# SPDX-License-Identifier: 0BSD
+# SPDX-License-Identifier: Apache-2.0
 
 # Calls the reusable inventory-publish workflow on every master merge,
 # in parallel with `docs.yml`.  Decoupled lifecycles: a failed Pages

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: 0BSD
+
+# Calls the reusable inventory-publish workflow on every master merge,
+# in parallel with `docs.yml`.  Decoupled lifecycles: a failed Pages
+# deploy doesn't stale the inventory bucket, and an inventory hiccup
+# doesn't stale the docs site.  See terok-ai/mkdocs-terok#58 for the
+# full design.
+
+name: Publish inventory
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish:
+    if: github.repository == 'terok-ai/terok-executor' && github.ref == 'refs/heads/master'
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-inventory.yml@v0.5.7a1
+    secrets:
+      INVENTORY_WRITE_TOKEN: ${{ secrets.INVENTORY_WRITE_TOKEN }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1690,13 +1690,13 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.5.0"
+version = "0.5.7a1"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.5.0-py3-none-any.whl", hash = "sha256:172ec2dd59a073888371f03c4bf47fe017dec3760fb9ba41c38d43945358b25d"},
+    {file = "mkdocs_terok-0.5.7a1-py3-none-any.whl", hash = "sha256:14460c98870cf3f4d4153594bc38d6d3b4a7048f4e080be179cc2431b1cab55d"},
 ]
 
 [package.dependencies]
@@ -1705,7 +1705,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.0/mkdocs_terok-0.5.0-py3-none-any.whl"
+url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a1/mkdocs_terok-0.5.7a1-py3-none-any.whl"
 
 [[package]]
 name = "mkdocstrings"
@@ -3407,4 +3407,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "9283b6757bd7a5da00bbb95d80b1634c5ec9c6fb7ec0cd673f90ca111c6aacc4"
+content-hash = "65569121b926056ec4536b48bc55e2f55c935c03d60faa4cad2334eef993cf45"

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -42,10 +42,10 @@ plugins:
           inventories:
             - https://docs.python.org/3/objects.inv
             - https://docs.pydantic.dev/latest/objects.inv
-            - https://terok-ai.github.io/terok/objects.inv
-            - https://terok-ai.github.io/terok-sandbox/objects.inv
-            - https://terok-ai.github.io/terok-shield/objects.inv
-            - https://terok-ai.github.io/terok-clearance/objects.inv
+            - https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok/objects.inv
+            - https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-sandbox/objects.inv
+            - https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-shield/objects.inv
+            - https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-clearance/objects.inv
           options:
             docstring_style: google
             show_source: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.24"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
-mkdocs-terok = "^0.5"
+mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a1/mkdocs_terok-0.5.7a1-py3-none-any.whl"}
 
 [tool.poetry.scripts]
 terok-executor = "terok_executor.cli:main"


### PR DESCRIPTION
## Summary

Wires this repo into the docs-inventory bucket workflow introduced in terok-ai/mkdocs-terok#58.

- New `.github/workflows/inventory.yml`: calls the reusable workflow from `mkdocs-terok` on every master push, in parallel with `docs.yml`. The two jobs are decoupled — neither's failure blocks the other.
- Pin `mkdocs-terok` to `v0.5.7a1` (alpha wheel).
- `properdocs.yml`: swap sibling inventory URLs from `terok-ai.github.io/<sibling>/objects.inv` (Pages-served, breaks the cycle) to `raw.githubusercontent.com/terok-ai/docs-inventories/master/<sibling>/objects.inv` (bucket-served, sibling-independent).

## Why

Strict docs build of every terok-* repo needs every sibling's `objects.inv`. That URL today only exists once a sibling's Pages deploy finishes — symmetric chicken-and-egg, breaks on every Pages flake.

The bucket repo `terok-ai/docs-inventories` holds inventories independently of any docs deploy. Each repo PUTs its own `objects.inv` via the Contents API on every master merge.

## Prerequisites (already in place)

- Bucket repo: `terok-ai/docs-inventories`
- Org secret: `INVENTORY_WRITE_TOKEN`
- mkdocs-terok release: `v0.5.7a1`

## Test plan

- [ ] After merge, `inventory.yml` runs on the next master push and creates `terok-executor/objects.inv` in the bucket
- [ ] Verify URL: `https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-executor/objects.inv`
- [ ] Confirm `docs.yml` still passes once every sibling has run its own `inventory.yml` at least once

## Rollout coordination

Sibling consumer PRs landing in parallel: terok#TBD, terok-sandbox#266, terok-shield#293, terok-clearance#103. Each repo's first `inventory.yml` run after merge populates its slot in the bucket; until every sibling has done so at least once, `docs.yml` strict builds may surface specific missing-target warnings — cleared by the next master push of the lagging sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflows and configuration for documentation tooling.
  * Updated build dependencies to support enhanced documentation publishing capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/296)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->