### PR TITLE
docs: convert Sphinx :role: cross-refs to mkdocstrings autoref form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,17 @@ those run on a dedicated test machine.
 
 - Domain-first docstrings, public entry points above private helpers,
   top-down reading order.
+- Cross-references in docstrings use mkdocstrings autoref syntax
+  `` [`Name`][module.path.Name] `` — never the Sphinx
+  ``:class:`Name``` / ``:func:`name``` forms.  Sphinx roles render as
+  literal text on the rendered docs site (mkdocstrings doesn't process
+  them).  Prefer the explicit full path over the bare `` [`Name`][] ``
+  autoref form: explicit paths keep `properdocs build --strict` green
+  even when the symbol's short name isn't unique.  For external symbols
+  use the dependency's own path
+  (`` [`Sandbox`][terok_sandbox.Sandbox] ``,
+  `` [`StreamReader`][asyncio.StreamReader] ``) — those resolve via the
+  inventories listed in `properdocs.yml`.
 - SPDX copyright: author name "Jiri Vyskocil".  Add a new
   `SPDX-FileCopyrightText` line only for a previously unlisted
   contributor making a substantive change.

--- a/src/terok_executor/acp/__init__.py
+++ b/src/terok_executor/acp/__init__.py
@@ -15,9 +15,9 @@ backend-needing method (e.g. ``session/prompt``).  Cross-agent switching
 mid-session is out of scope for v1; subsequent picks against a different
 agent are rejected at the protocol level.
 
-Public surface: :class:`ACPRoster`, :class:`AgentRosterCache`,
-:func:`list_authenticated_agents`, :func:`acp_socket_is_live`,
-plus the daemon entry point :func:`serve_acp`.  Re-exported from
+Public surface: [`ACPRoster`][terok_executor.acp.roster.ACPRoster], [`AgentRosterCache`][terok_executor.acp.cache.AgentRosterCache],
+[`list_authenticated_agents`][terok_executor.acp.roster.list_authenticated_agents], [`acp_socket_is_live`][terok_executor.acp.daemon.acp_socket_is_live],
+plus the daemon entry point [`serve_acp`][terok_executor.acp.daemon.serve_acp].  Re-exported from
 ``terok_executor`` for the host-side caller (terok) so it doesn't
 have to reach into ``terok_executor.acp.daemon`` directly.
 """

--- a/src/terok_executor/acp/cache.py
+++ b/src/terok_executor/acp/cache.py
@@ -36,7 +36,7 @@ class CacheKey:
 
 
 class AgentRosterCache:
-    """Thread-safe map from :class:`CacheKey` to a tuple of model ids.
+    """Thread-safe map from [`CacheKey`][terok_executor.acp.cache.CacheKey] to a tuple of model ids.
 
     Models are stored as a tuple so cache entries are immutable once
     inserted — callers can return them directly without defensive copying.
@@ -76,6 +76,6 @@ class AgentRosterCache:
 
 
 # Module-level singleton: most callers get this implicitly via
-# :class:`ACPRoster`'s default.  Tests inject a fresh
-# :class:`AgentRosterCache` via the constructor.
+# [`ACPRoster`][terok_executor.acp.roster.ACPRoster]'s default.  Tests inject a fresh
+# [`AgentRosterCache`][terok_executor.acp.cache.AgentRosterCache] via the constructor.
 GLOBAL_CACHE = AgentRosterCache()

--- a/src/terok_executor/acp/daemon.py
+++ b/src/terok_executor/acp/daemon.py
@@ -185,7 +185,7 @@ def _make_handler(
 ) -> Callable[[asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]]:
     """Return an ``asyncio.start_unix_server`` callback bound to *roster*.
 
-    Each accepted connection gets its own :class:`ACPProxy` — no
+    Each accepted connection gets its own [`ACPProxy`][terok_executor.acp.proxy.ACPProxy] — no
     daemon-level concurrency lock.  Concurrent ACP clients on the
     same task are unusual in practice and would only race over the
     backend agent, which the proxy's ``_client_session_id`` check

--- a/src/terok_executor/acp/model_options.py
+++ b/src/terok_executor/acp/model_options.py
@@ -9,7 +9,7 @@ Three consumers share this vocabulary: the probe reads it to learn
 what an agent can serve, the proxy builds aggregated responses
 pre-bind, and the proxy rewrites it post-bind so the client sees
 the namespaced ``agent:model`` ids it expects.  All three sit on
-top of :func:`iter_model_choice_dicts`, which tolerates the in-flight
+top of [`iter_model_choice_dicts`][terok_executor.acp.model_options.iter_model_choice_dicts], which tolerates the in-flight
 ACP schema variants in one place.
 """
 
@@ -64,7 +64,7 @@ def iter_model_choice_dicts(result: dict[str, Any]) -> Iterator[dict[str, Any]]:
 def _humanise_model_id(namespaced: str) -> str:
     """Render ``claude:opus-4.6`` as ``Claude: opus-4.6`` for the picker.
 
-    Colon (matching the wire-level :data:`MODEL_NAMESPACE_SEP`) keeps
+    Colon (matching the wire-level [`MODEL_NAMESPACE_SEP`][]) keeps
     slashes free for model ids that legitimately contain them, e.g.
     OpenCode's ``opencode:opencode/big-pickle`` — humanising that to
     ``OpenCode: opencode/big-pickle`` reads as one provider plus one
@@ -87,8 +87,8 @@ def _build_model_config_option(
     """Build a ``category: "model"`` ``select`` configOption.
 
     Returns the SDK pydantic model (not a dict) so the caller can drop
-    it straight into a :class:`NewSessionResponse` /
-    :class:`SetSessionConfigOptionResponse`.  ``current`` is required
+    it straight into a [`NewSessionResponse`][] /
+    [`SetSessionConfigOptionResponse`][].  ``current`` is required
     by the schema (``current_value`` is a non-nullable ``str``); the
     caller is expected to handle the empty-models case by skipping
     the option entirely rather than passing a placeholder.
@@ -114,7 +114,7 @@ def _build_session_new_response(session_id: str, models: list[str]) -> NewSessio
     when no agents probed successfully, the ``models`` block and the
     model ``configOption`` are omitted entirely (both have non-nullable
     required fields the proxy can't fill in for an empty list).  The
-    ``modes`` block is also omitted — :class:`SessionModeState` requires
+    ``modes`` block is also omitted — [`SessionModeState`][] requires
     a non-null ``current_mode_id`` and the proxy doesn't manage modes.
     """
     if not models:

--- a/src/terok_executor/acp/probe.py
+++ b/src/terok_executor/acp/probe.py
@@ -12,13 +12,13 @@ agent currently advertises, we drive a minimal handshake:
 3. close stdin — agent exits cleanly
 
 The handshake is cheap (a few round-trips) but non-trivial to repeat:
-the result is cached by :class:`~terok_executor.acp.cache.AgentRosterCache`
+the result is cached by [`AgentRosterCache`][terok_executor.acp.cache.AgentRosterCache]
 and reused for the lifetime of the authenticated session.
 
 The probe is transport-agnostic on top of
-:meth:`terok_sandbox.ContainerRuntime.exec_stdio` — it owns no FDs of its
+[`exec_stdio`][terok_sandbox.ContainerRuntime.exec_stdio] — it owns no FDs of its
 own; it spawns the agent in an executor thread and bridges the two ends
-of a pipe pair as asyncio :class:`StreamReader`/:class:`StreamWriter`
+of a pipe pair as asyncio [`StreamReader`][asyncio.StreamReader]/[`StreamWriter`][asyncio.StreamWriter]
 so the proxy loop can drive them naturally and cancel cleanly.
 """
 
@@ -74,12 +74,12 @@ async def probe_agent_models(
     """Drive the minimal ACP handshake against ``terok-{agent_id}-acp``.
 
     Spawns the in-container wrapper via
-    :meth:`terok_sandbox.ContainerRuntime.exec_stdio` (running in an
+    [`exec_stdio`][terok_sandbox.ContainerRuntime.exec_stdio] (running in an
     executor thread because the primitive is sync), sends
     ``initialize`` and ``session/new``, parses the response for the
     ``category: "model"`` configOption, and returns the model ids.
 
-    Raises :class:`ProbeError` on timeout, malformed JSON, or any
+    Raises [`ProbeError`][terok_executor.acp.probe.ProbeError] on timeout, malformed JSON, or any
     other handshake failure.  Callers (the roster cache) typically
     catch it, cache an empty roster, and skip the agent until the
     container is restarted.
@@ -243,8 +243,8 @@ def _extract_model_ids(session_new_result: dict) -> tuple[str, ...]:
     """Return the model ids from a ``session/new`` response.
 
     Walks the ``configOptions[category=model]`` entry via the shared
-    :func:`iter_model_choice_dicts` iterator (so the schema-tolerance
-    logic lives in one place — see :mod:`.proxy`).  Unknown shapes
+    [`iter_model_choice_dicts`][terok_executor.acp.model_options.iter_model_choice_dicts] iterator (so the schema-tolerance
+    logic lives in one place — see [`proxy`][terok_executor.acp.proxy]).  Unknown shapes
     yield an empty tuple, which the caller caches to avoid hammering
     a misbehaving agent on every session.
     """

--- a/src/terok_executor/acp/proxy.py
+++ b/src/terok_executor/acp/proxy.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""ACP proxy state machine — the JSON-RPC mediator behind :class:`ACPRoster`.
+"""ACP proxy state machine — the JSON-RPC mediator behind [`ACPRoster`][terok_executor.acp.roster.ACPRoster].
 
 The proxy speaks ACP to the connected client and ACP to one chosen
 in-container backend, namespacing the model selector so a multi-agent
@@ -13,14 +13,14 @@ Two phases drive the lifecycle:
 
 - **Pre-bind**: the proxy answers ``initialize`` and ``session/new``
   locally, advertising the aggregated ``agent:model`` list in
-  :class:`acp.schema.SessionModelState` plus a mirroring
+  `acp.schema.SessionModelState` plus a mirroring
   ``configOptions[category=model]``.  No backend process exists yet.
 - **Bound**: on the first model-picking client request — modern
   ACP's ``session/set_model`` or older Zed's
   ``session/set_config_option(configId="model")`` — the proxy
   uses the ``agent:`` namespace prefix to pick which in-container
-  wrapper to spawn via :func:`asyncio.create_subprocess_exec`
-  (argv from :meth:`ACPRoster.wrapper_argv`), replays
+  wrapper to spawn via [`create_subprocess_exec`][asyncio.create_subprocess_exec]
+  (argv from [`wrapper_argv`][terok_executor.acp.roster.ACPRoster.wrapper_argv]), replays
   ``initialize`` + ``session/new`` + ``session/set_model`` (with
   the bare sub-id) to it, and from then on bridges frames in both
   directions.  Backend frames are mutated on the way out so model
@@ -81,15 +81,15 @@ class AgentBindError(RuntimeError):
     """Surface error raised when the proxy fails to bind a backend agent.
 
     Always converted to a JSON-RPC error response on the wire — never
-    bubbles to the caller of :meth:`ACPProxy.run`.
+    bubbles to the caller of [`run`][terok_executor.acp.proxy.ACPProxy.run].
     """
 
 
 class ACPProxy:
     """One client connection's worth of proxy state.
 
-    Constructed by :meth:`ACPRoster.attach`; lives for the duration of
-    a single client connection.  Not reusable — discard after :meth:`run`
+    Constructed by [`attach`][terok_executor.acp.roster.ACPRoster.attach]; lives for the duration of
+    a single client connection.  Not reusable — discard after [`run`][terok_executor.acp.proxy.ACPProxy.run]
     returns.
     """
 
@@ -174,7 +174,7 @@ class ACPProxy:
         Built via the ACP SDK's pydantic model so missing-or-misnamed
         fields fail at construction with a precise traceback rather
         than at the client end with "failed to deserialize".  The
-        capability defaults from :class:`acp.schema.AgentCapabilities`
+        capability defaults from `acp.schema.AgentCapabilities`
         are conservative — clients should treat the proxy's caps as a
         floor; the bound backend's are the real ceiling.
         """
@@ -200,7 +200,7 @@ class ACPProxy:
         Generates a synthetic session id (``proxy-N``) so the client can
         proceed to picking a model before any backend exists.  When a
         backend is later spawned on bind, the backend's real session id
-        is captured in :attr:`_backend_session_id` and translated on
+        is captured in [`_backend_session_id`][] and translated on
         every forwarded frame.
         """
         if self._client_session_id is not None:
@@ -220,7 +220,7 @@ class ACPProxy:
 
         self._client_session_id = "proxy-1"
         models = await self._roster.list_available_agents()
-        # Same first-of-list rule as :func:`_build_session_new_response`'s
+        # Same first-of-list rule as [`_build_session_new_response`][terok_executor.acp.model_options._build_session_new_response]'s
         # ``currentModelId``; record it so a client that skips set_model
         # and goes straight to a backend-needing method can be lazy-bound
         # against the value it already saw advertised.
@@ -239,7 +239,7 @@ class ACPProxy:
 
         Modern ACP's dedicated method for model selection.  Reads
         ``modelId`` from the request, hands the namespaced id to the
-        shared :meth:`_select_model` driver.
+        shared [`_select_model`][terok_executor.acp.proxy.ACPProxy._select_model] driver.
         """
         raw_params = frame.get("params")
         if not isinstance(raw_params, dict):
@@ -268,9 +268,9 @@ class ACPProxy:
         """Bind on category=model; otherwise forward to the bound backend.
 
         Older ACP clients (Zed v1.0.x at the time of writing) pick the
-        model through :data:`session/set_config_option` with the
+        model through [`session/set_config_option`][] with the
         category set to ``"model"`` — modern clients use the dedicated
-        :data:`session/set_model` instead.  We accept both: a model
+        [`session/set_model`][] instead.  We accept both: a model
         category here triggers the same bind flow as ``set_model``,
         any other category passes through to the bound backend, and
         a non-model category pre-bind is rejected as a no-op.
@@ -359,7 +359,7 @@ class ACPProxy:
         ``session/prompt`` and friends arrive here.  If we're already
         bound the proxy stays out of the way.  If we're not — and the
         client skipped explicit model selection — bind lazily to the
-        ``currentModelId`` we advertised in :meth:`_handle_session_new`,
+        ``currentModelId`` we advertised in [`_handle_session_new`][terok_executor.acp.proxy.ACPProxy._handle_session_new],
         because that's the contract Zed-style clients act on (they
         trust the current value and prompt against it without an
         explicit set_model).  If the proxy never advertised a current
@@ -391,10 +391,10 @@ class ACPProxy:
     async def _bind(self, agent_id: str, model_id: str) -> None:
         """Spawn the backend wrapper and replay the handshake.
 
-        On success, sets :attr:`_bound_agent` so subsequent client
+        On success, sets [`_bound_agent`][] so subsequent client
         frames forward to the backend.  On failure, tears the
         partially-set-up backend down and re-raises
-        :class:`AgentBindError`; the caller decides whether to surface
+        [`AgentBindError`][terok_executor.acp.proxy.AgentBindError]; the caller decides whether to surface
         that as a JSON-RPC error or wrap it.
         """
         try:
@@ -419,9 +419,9 @@ class ACPProxy:
         ``ack_kind`` selects the response shape for the triggering
         request:
 
-        - ``"set_model"`` → :class:`SetSessionModelResponse` (empty
+        - ``"set_model"`` → [`SetSessionModelResponse`][] (empty
           ``result: {}`` body).
-        - ``"set_config_option"`` → :class:`SetSessionConfigOptionResponse``
+        - ``"set_config_option"`` → [`SetSessionConfigOptionResponse`][]`
           carrying the post-bind ``configOptions`` snapshot.
 
         On bind failure, replies with a JSON-RPC error in lieu of the
@@ -453,7 +453,7 @@ class ACPProxy:
         models — Zed rebuilds its picker from this response and a
         filtered list silently hides the other agents.  Cross-agent
         switches are still rejected, but at the request level
-        (:meth:`_select_model`), not by erasing the options.
+        ([`_select_model`][terok_executor.acp.proxy.ACPProxy._select_model]), not by erasing the options.
         """
         if ack_kind == "set_model":
             return {}
@@ -467,7 +467,7 @@ class ACPProxy:
     async def _spawn_backend(self, agent_id: str) -> None:
         """Spawn ``terok-{agent_id}-acp`` and attach asyncio pipes for the bind handshake.
 
-        Uses :func:`asyncio.create_subprocess_exec` — proc.stdin /
+        Uses [`create_subprocess_exec`][asyncio.create_subprocess_exec] — proc.stdin /
         proc.stdout become the proxy's writer / reader directly.  The
         probe path goes through sandbox's ``exec_stdio`` instead
         (single-shot, sync-friendly); bind's connection-shaped
@@ -476,7 +476,7 @@ class ACPProxy:
         the extra kernel pipe pair plus pump threads ``exec_stdio``
         layers in.
 
-        :meth:`ACPRoster.wrapper_argv` hides the runtime detail
+        [`wrapper_argv`][terok_executor.acp.roster.ACPRoster.wrapper_argv] hides the runtime detail
         (currently podman-specific) so a future krun runtime can
         plug in its own argv without touching the proxy.
         """
@@ -502,13 +502,13 @@ class ACPProxy:
         task that handles post-bind traffic.  Inline keeps the
         handshake's state local: no parked-future bookkeeping, no
         id-discrimination at the pump, and a failed handshake tears
-        down without leaving an orphan pump.  :meth:`_start_pump_loop`
+        down without leaving an orphan pump.  [`_start_pump_loop`][terok_executor.acp.proxy.ACPProxy._start_pump_loop]
         spins the pump up only after all three frames acknowledge,
         from which point the client owns the conversation.
 
         Captures the backend's session id so subsequent client frames
         can be re-targeted on forwarding.  Errors raise
-        :class:`AgentBindError`.
+        [`AgentBindError`][terok_executor.acp.proxy.AgentBindError].
         """
         await self._inline_request(
             "initialize",
@@ -570,7 +570,7 @@ class ACPProxy:
         ``PROXY_REQUEST_ID_BASE+N`` range so responses are recognisable
         as proxy-originated if the pump later sees one in transit.
 
-        Raises :class:`AgentBindError` on timeout, malformed JSON,
+        Raises [`AgentBindError`][terok_executor.acp.proxy.AgentBindError] on timeout, malformed JSON,
         unexpected ids, or backend disconnect during the read.
         """
         self._proxy_request_counter += 1
@@ -594,7 +594,7 @@ class ACPProxy:
         Skips notifications (no ``id``) so a chatty wrapper's progress
         events don't get mistaken for the reply.  Out-of-order ids on
         a freshly-spawned single-track wrapper signal protocol confusion
-        — bail with :class:`AgentBindError` rather than queue.
+        — bail with [`AgentBindError`][terok_executor.acp.proxy.AgentBindError] rather than queue.
         """
         assert self._backend_reader is not None
         while True:

--- a/src/terok_executor/acp/roster.py
+++ b/src/terok_executor/acp/roster.py
@@ -3,17 +3,17 @@
 
 """Per-task ACP roster: aggregates in-container agents into one endpoint.
 
-:class:`ACPRoster` owns the per-task state for the ACP host-proxy:
+[`ACPRoster`][terok_executor.acp.roster.ACPRoster] owns the per-task state for the ACP host-proxy:
 
 - the cache lookup that answers "what models does this agent advertise?"
 - the live walk that answers "what agents are currently authenticated for
   this image?" — re-evaluated on every ``session/new`` so newly-authed
   agents appear without daemon restart
-- the proxy attach loop (delegated to :mod:`.proxy`) that brokers JSON-RPC
+- the proxy attach loop (delegated to [`proxy`][terok_executor.acp.proxy]) that brokers JSON-RPC
   frames between the connected client and the chosen backend
 
 The class follows the shape of
-:class:`terok_executor.container.runner.AgentRunner`: lazy-init
+[`AgentRunner`][terok_executor.container.runner.AgentRunner]: lazy-init
 properties for cross-cutting subsystems, OOP over free functions, no
 mutable state in ``__init__`` beyond the parameters themselves.
 """
@@ -47,9 +47,9 @@ accommodates the change without a schema migration.
 """
 
 DEFAULT_CREDENTIAL_SCOPE = "default"
-"""Scope name used by :class:`terok_sandbox.CredentialDB` for the
+"""Scope name used by [`CredentialDB`][terok_sandbox.CredentialDB] for the
 process-wide credential set.  Mirrors what
-:func:`terok_executor.credentials.auth.authenticate` writes."""
+[`authenticate`][terok_executor.credentials.auth.authenticate] writes."""
 
 
 def list_authenticated_agents(
@@ -59,7 +59,7 @@ def list_authenticated_agents(
 ) -> list[str]:
     """Return provider names that have stored credentials in *scope*.
 
-    Pure query against :class:`terok_sandbox.CredentialDB` — no probing,
+    Pure query against [`CredentialDB`][terok_sandbox.CredentialDB] — no probing,
     no container exec.  Used by the host-side ``acp list`` to classify
     endpoints in its status display; the roster itself doesn't gate
     probing on this anymore (file-based auth like Claude's OAuth lives
@@ -115,7 +115,7 @@ class ACPRoster:
 
         Parsed once per roster instance — the image label is stable for
         the lifetime of the running task.  The label is a comma-
-        separated list (see :data:`terok_executor.container.build.AGENTS_LABEL`).
+        separated list (see [`AGENTS_LABEL`][terok_executor.container.build.AGENTS_LABEL]).
         """
         image = self._sandbox.runtime.image(self._image_id)
         raw = image.labels().get(AGENTS_LABEL, "")
@@ -181,7 +181,7 @@ class ACPRoster:
         Probes every agent in the image's ``ai.terok.agents`` label
         (filtered through the cache) and concatenates the namespaced
         model ids of those that responded.  Cold-cache agents are
-        probed in parallel via :func:`asyncio.gather`, so first-call
+        probed in parallel via [`gather`][asyncio.gather], so first-call
         latency is ``max(probe_time)`` rather than ``sum(probe_time)``.
         Successful probes cache the model tuple for the daemon's
         lifetime; failed probes are *not* cached so a transient cold
@@ -228,7 +228,7 @@ class ACPRoster:
     ) -> None:
         """Run the proxy loop for one connected client until disconnect.
 
-        Delegates the JSON-RPC state machine to :class:`ACPProxy`.  The
+        Delegates the JSON-RPC state machine to [`ACPProxy`][terok_executor.acp.proxy.ACPProxy].  The
         roster owns the data (cache + live walk); the proxy owns the
         protocol.
         """
@@ -240,11 +240,11 @@ class ACPRoster:
 
         Used by the *probe* path: a short single-shot handshake whose
         wrapper subprocess is torn down immediately afterwards.  Sync
-        because :meth:`Sandbox.runtime.exec_stdio` is sync — callers
+        because [`exec_stdio`][terok_sandbox.ContainerRuntime.exec_stdio] is sync — callers
         in async contexts wrap the call in ``loop.run_in_executor``.
 
-        The *bind* path uses :meth:`wrapper_argv` and spawns the
-        wrapper directly via :func:`asyncio.create_subprocess_exec`
+        The *bind* path uses [`wrapper_argv`][terok_executor.acp.roster.ACPRoster.wrapper_argv] and spawns the
+        wrapper directly via [`create_subprocess_exec`][asyncio.create_subprocess_exec]
         instead — fewer hops between the proxy and the subprocess
         (no kernel pipe pair, no pump threads), and the long-lived
         connection-shaped lifecycle there fits asyncio's subprocess
@@ -263,7 +263,7 @@ class ACPRoster:
         """Return the argv that runs ``terok-{agent_id}-acp`` in this container.
 
         Hands back something a caller can pass directly to
-        :func:`asyncio.create_subprocess_exec` — the bind path uses
+        [`create_subprocess_exec`][asyncio.create_subprocess_exec] — the bind path uses
         this so it can attach asyncio's own pipe transports to the
         wrapper subprocess without going through sandbox's pump
         threads.  Currently podman-specific; a krun runtime would


### PR DESCRIPTION
## Summary

Convert every `:class:`/`:func:`/`:meth:`/`:mod:`/`:attr:` Sphinx-style cross-reference in source docstrings to mkdocstrings' `[`Name`][module.path.Name]` autoref form. mkdocstrings doesn't process Sphinx info-field roles, so the originals rendered as **literal text** on the docs site (e.g. "Public surface: :class:ACPRoster, :class:AgentRosterCache, …") instead of as links.

Also adds an AGENTS.md bullet under "Coding Standards" / "Code style" so future changes don't re-introduce the Sphinx forms.

## What changed

- All converted docstrings now produce real `<a class="autorefs autorefs-internal">` links in rendered HTML, with hover tooltips showing the target's signature.
- External symbols (asyncio, terok-sandbox, …) use the dependency's own path so they resolve via the inventories listed in `properdocs.yml`.
- A handful of imprecise docstring refs (e.g. `Sandbox.runtime.exec_stdio` → `terok_sandbox.ContainerRuntime.exec_stdio`, `acp.schema.X` demoted to plain `` `code` `` text since agent-client-protocol publishes no inventory) were corrected by hand.
- AGENTS.md gains one bullet calling out the autoref convention.

## Verification

`poetry run properdocs build --strict` passes locally with **zero autoref warnings** in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)