### PR TITLE
refactor: rename quality_report → code_metrics in properdocs.yml

### DIFF
--- a/docs/summary.md
+++ b/docs/summary.md
@@ -6,7 +6,7 @@
 - Developer Guide
     - [Vault](vault.md)
     - [Roster Reference](roster-reference.md)
-    - [Code Metrics](quality-report.md)
+    - [Code Metrics](code-metrics.md)
     - [Module Map](module-map.md)
     - [CI Workflow Map](ci-map.md)
 - [API Reference](reference/)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1690,22 +1690,23 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.5.7a4"
+version = "0.5.7a5"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.5.7a4-py3-none-any.whl", hash = "sha256:24d74e20d15e948f5acdcded11a42fc2ab4a7fc437ba5207e5a5c88bc254f690"},
+    {file = "mkdocs_terok-0.5.7a5-py3-none-any.whl", hash = "sha256:71aa681d4b7f032c3660cc7015d86e25b3f1f4ce99020cadc598ec09fe37ac35"},
 ]
 
 [package.dependencies]
 properdocs = ">=1.6.7"
 PyYAML = ">=6.0"
+squarify = ">=0.4"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a4/mkdocs_terok-0.5.7a4-py3-none-any.whl"
+url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a5/mkdocs_terok-0.5.7a5-py3-none-any.whl"
 
 [[package]]
 name = "mkdocstrings"
@@ -2898,6 +2899,18 @@ files = [
 ]
 
 [[package]]
+name = "squarify"
+version = "0.4.4"
+description = "Pure Python implementation of the squarify treemap layout algorithm"
+optional = false
+python-versions = "*"
+groups = ["docs"]
+files = [
+    {file = "squarify-0.4.4-py3-none-any.whl", hash = "sha256:d7597724e29d48aa14fd2f551060d6b09e1f0a67e4cd3ea329fe03b4c9a56f11"},
+    {file = "squarify-0.4.4.tar.gz", hash = "sha256:b8a110c8dc5f1cd1402ca12d79764a081e90bfc445346cfa166df929753ecb46"},
+]
+
+[[package]]
 name = "stevedore"
 version = "5.7.0"
 description = "Manage dynamic plugins for Python applications"
@@ -3407,4 +3420,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "466557585ca4329e72733de22be1475eed3b6b305d84bfe6dd7f79da3b1f741e"
+content-hash = "27bc9aedcbbff7e8bef7311c5e8cd61076706228fbc1c6418e0f30e27530bd33"

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -58,8 +58,8 @@ plugins:
             merge_init_into_class: true
   - terok:
       ci_map: true
-      quality_report: true
-      quality_report_codecov_repo: terok-ai/terok-executor
+      code_metrics: true
+      code_metrics_codecov_repo: terok-ai/terok-executor
       module_map: true
       ref_pages: true
   - gen-files:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.24"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
-mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a4/mkdocs_terok-0.5.7a4-py3-none-any.whl"}
+mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.7a5/mkdocs_terok-0.5.7a5-py3-none-any.whl"}
 
 [tool.poetry.scripts]
 terok-executor = "terok_executor.cli:main"


### PR DESCRIPTION
## Summary

Companion PR to terok-ai/mkdocs-terok#67 which finishes the rename of the `quality_report` plugin module to `code_metrics` (the half-applied rename from `3d1e164` left every internal identifier still named `quality_report` while only the rendered `# Code Quality Report` heading became `# Code Metrics`).

This PR updates this repo's `properdocs.yml`:
- `quality_report*` plugin keys → `code_metrics*`
- nav target `quality-report.md` → `code-metrics.md`
- `mkdocs-terok` pinned to the rename PR branch for the duration of the chain (will be re-pinned to a wheel URL once the new alpha is cut)

## Verification

`poetry run properdocs build --strict` passes locally with `Generated code-metrics.md` and zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)