### PR TITLE
feat(docs): wire local coverage treemap

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -46,11 +46,13 @@ jobs:
       - name: Run unit tests
         run: make test-unit
 
-      - name: Upload coverage for SonarQube Cloud
+      - name: Upload coverage for SonarQube Cloud and docs treemap
         uses: actions/upload-artifact@v7
         with:
           name: coverage
-          path: reports/coverage.xml
+          path: |
+            reports/coverage.xml
+            reports/coverage.json
           retention-days: 1
 
       - name: Save PR metadata

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
           key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-docs-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
 
       - name: Install dependencies
-        run: poetry install --with dev,docs --no-interaction
+        run: poetry install --with dev,docs,test --no-interaction
 
       - name: Install scc (lines of code counter)
         run: |
@@ -50,6 +50,11 @@ jobs:
           curl -sLO https://github.com/boyter/scc/releases/download/v3.5.0/scc_Linux_x86_64.tar.gz
           echo "6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772  scc_Linux_x86_64.tar.gz" | sha256sum -c
           sudo tar xzf scc_Linux_x86_64.tar.gz -C /usr/local/bin scc
+
+      - name: Generate coverage data for treemap
+        # Produces reports/coverage.json, consumed by mkdocs-terok's
+        # code_metrics generator to render a local SVG treemap.
+        run: make test-unit
 
       - name: Build documentation
         run: poetry run properdocs build --strict

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 REPORTS_DIR ?= reports
 COVERAGE_XML ?= $(REPORTS_DIR)/coverage.xml
+COVERAGE_JSON ?= $(REPORTS_DIR)/coverage.json
 UNIT_JUNIT_XML ?= $(REPORTS_DIR)/unit.junit.xml
 RUFF_REPORT ?= $(REPORTS_DIR)/ruff-report.json
 BANDIT_REPORT ?= $(REPORTS_DIR)/bandit-report.json
@@ -25,7 +26,7 @@ format:
 # Run tests with coverage
 test-unit:
 	mkdir -p $(REPORTS_DIR)
-	poetry run pytest tests/unit/ --cov=terok_executor --cov-report=term-missing --cov-report=xml:$(COVERAGE_XML) --junitxml=$(UNIT_JUNIT_XML) -o junit_family=legacy
+	poetry run pytest tests/unit/ --cov=terok_executor --cov-report=term-missing --cov-report=xml:$(COVERAGE_XML) --cov-report=json:$(COVERAGE_JSON) --junitxml=$(UNIT_JUNIT_XML) -o junit_family=legacy
 
 # Write Ruff's JSON report without failing on findings.
 ruff-report:

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -59,6 +59,7 @@ plugins:
   - terok:
       ci_map: true
       code_metrics: true
+      code_metrics_coverage_json_path: reports/coverage.json
       code_metrics_codecov_repo: terok-ai/terok-executor
       module_map: true
       ref_pages: true


### PR DESCRIPTION
## Summary
- mkdocs-terok v0.5.7a5 (already pinned) ships a local SVG treemap generator fed by Coverage.py JSON. Switch the docs pipeline to use it so the treemap renders from our own coverage data instead of depending on codecov's flaky \`tree.svg\` endpoint.
- \`test-unit\` now also emits \`reports/coverage.json\` alongside \`coverage.xml\`; \`analysis.yml\`'s \`coverage\` artifact bundles both.
- \`docs.yml\` runs \`make test-unit\` before \`properdocs build\` so the generator finds the JSON.
- \`properdocs.yml\` adds \`code_metrics_coverage_json_path: reports/coverage.json\`.

## Why
Codecov's tree.svg endpoint flakes out semi-regularly. Generating the treemap from data we already collect for Sonar/Codecov removes that external dependency. Part of a coordinated change across terok-ai packages.

## Test plan
- [x] \`ruff check .\` clean
- [ ] CI: \`make test-unit\` produces \`reports/coverage.{xml,json}\`
- [ ] CI: docs build produces \`coverage_treemap.svg\` via the generator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code coverage reporting by introducing JSON format support alongside existing XML output for improved metrics flexibility and tooling compatibility.
  * Updated continuous integration workflows to automatically generate coverage data and upload it as build artifacts for documentation systems.
  * Integrated code coverage metrics into documentation builds, providing improved visibility of code quality and health indicators across the project.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/301)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->