### PR TITLE
feat(roster): support "-name" exclude prefix in agent selection

### DIFF
--- a/src/terok_executor/config_schema.py
+++ b/src/terok_executor/config_schema.py
@@ -52,7 +52,9 @@ class RawImageSection(BaseModel):
         default=None,
         description=(
             'Comma-separated roster entries to install in L1, or "all". '
-            "Inherits from the global config when unset."
+            'Prefix a name with "-" to exclude it from the selection '
+            '(e.g. "all,-vibe" or just "-vibe" — both mean "everything '
+            'except vibe").  Inherits from the global config when unset.'
         ),
     )
     user_snippet_inline: str | None = Field(

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -131,32 +131,50 @@ class AgentRoster:
 
     # ── Selection ──
 
-    def resolve_selection(self, names: str | tuple[str, ...]) -> tuple[str, ...]:
+    def resolve_selection(self, selection: str | tuple[str, ...]) -> tuple[str, ...]:
         """Resolve a user-supplied selection into the full set of roster names to install.
 
         Accepts the literal string ``"all"`` (every roster entry that has an
-        [`InstallSpec`][terok_executor.roster.types.InstallSpec]) or a tuple of names.  Expands ``depends_on``
-        transitively.  Returns the names sorted alphabetically — the canonical
-        order used for the OCI label, the tag suffix, and the in-container
-        manifest.
+        [`InstallSpec`][terok_executor.roster.types.InstallSpec]) or a tuple of
+        selection tokens.  Each token is either a roster name (include) or a
+        name prefixed with ``-`` (exclude).  The pseudo-name ``"all"`` is also
+        valid as an include token, meaning "seed from every installable
+        entry"; this combines naturally with excludes, e.g. ``("all",
+        "-vibe")`` installs everything except vibe.  When no include tokens
+        are present (only excludes), the seed is the full roster.
 
-        Raises ``ValueError`` if a requested name is not in the roster, or
-        ``TypeError`` if *names* is a string other than ``"all"`` (a bare
-        name like ``"claude"`` would otherwise be iterated into characters).
+        Includes are expanded transitively via ``depends_on`` *before*
+        excludes are applied, so an exclude that names a dependency of a
+        kept agent will silently drop that dependency — likely producing a
+        broken image, but matching the user's literal request.
+
+        Returns the names sorted alphabetically — the canonical order used
+        for the OCI label, the tag suffix, and the in-container manifest.
+
+        Raises ``ValueError`` if a requested include or exclude name is not
+        in the roster, or ``TypeError`` if *selection* is a string other
+        than ``"all"`` (a bare name like ``"claude"`` would otherwise be
+        iterated into characters).  Excludes that name a known agent but
+        don't appear in the resolved include set are a no-op.
         """
-        if isinstance(names, str):
-            if names != "all":
+        if isinstance(selection, str):
+            if selection != "all":
                 raise TypeError(
-                    f"Selection must be the literal string 'all' or a tuple of names, got {names!r}"
+                    f"Selection must be the literal string 'all' or a tuple of "
+                    f"tokens, got {selection!r}"
                 )
-            seed = set(self._installs)
-        else:
-            seed = set(names)
+            return tuple(sorted(self._installs))
 
-        unknown = seed - set(self._installs)
+        includes = {t for t in selection if not t.startswith("-")}
+        excludes = {t[1:] for t in selection if t.startswith("-")}
+
+        referenced = (includes | excludes) - {"all"}
+        unknown = referenced - set(self._installs)
         if unknown:
             avail = ", ".join(sorted(self._installs))
             raise ValueError(f"Unknown roster entries: {sorted(unknown)!r}. Available: {avail}")
+
+        seed = set(self._installs) if "all" in includes or not includes else includes
 
         resolved: set[str] = set()
         stack = list(seed)
@@ -176,7 +194,7 @@ class AgentRoster:
                     )
                 if dep not in resolved:
                     stack.append(dep)
-        return tuple(sorted(resolved))
+        return tuple(sorted(resolved - excludes))
 
     @property
     def mounts(self) -> tuple[MountDef, ...]:
@@ -289,18 +307,25 @@ def get_roster() -> AgentRoster:
 def parse_agent_selection(raw: str) -> str | tuple[str, ...]:
     """Normalise a user-supplied agent selection string.
 
-    Accepts a comma-list (``"claude,codex"``) or the literal ``"all"``.
-    Whitespace is stripped, empty / whitespace-only entries dropped,
-    and case folded.  Empty or all-whitespace input collapses to
-    ``"all"`` — the same shape [`AgentRoster.resolve_selection`][terok_executor.roster.loader.AgentRoster.resolve_selection]
+    Accepts a comma-list of selection tokens or the literal ``"all"``.  Each
+    token is either an agent name (``"claude"``) or a name prefixed with
+    ``-`` to exclude it from the selection (``"-vibe"``).  The pseudo-name
+    ``"all"`` is also valid as a token, so ``"all,-vibe"`` means "everything
+    except vibe".  When the input contains only excludes (``"-vibe"``), the
+    selection seeds from every installable entry — same effect as
+    ``"all,-vibe"``.
+
+    Whitespace is stripped, empty / whitespace-only entries dropped, and
+    case folded.  Empty or all-whitespace input collapses to ``"all"`` —
+    the same shape [`AgentRoster.resolve_selection`][terok_executor.roster.loader.AgentRoster.resolve_selection]
     expects.  Unknown names are not checked here; ``resolve_selection``
     does that.
     """
     folded = raw.strip().lower()
     if folded == "all" or not folded:
         return "all"
-    names = tuple(n.strip() for n in folded.split(",") if n.strip())
-    return names or "all"
+    tokens = tuple(n.strip() for n in folded.split(",") if n.strip())
+    return tokens or "all"
 
 
 def load_roster() -> AgentRoster:

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -17,7 +17,7 @@ from terok_executor.roster import (
     SidecarSpec,
     load_roster,
 )
-from terok_executor.roster.loader import _load_bundled_agents
+from terok_executor.roster.loader import _load_bundled_agents, parse_agent_selection
 from terok_executor.roster.schema import RawAgentYaml
 
 
@@ -522,6 +522,75 @@ class TestWebIngress:
         # resolve_selection returns the canonical alphabetical tuple.
         # Asserting the exact set guards against accidental extras creeping in.
         assert reg.resolve_selection(("toad",)) == ("caddy", "toad")
+
+
+class TestSelectionExcludes:
+    """The ``-name`` exclude prefix lets users subtract from a default-everything
+    selection without having to spell out the full include list."""
+
+    def test_exclude_with_all_token_drops_one_agent(self) -> None:
+        reg = load_roster()
+        full = set(reg.resolve_selection("all"))
+        assert "vibe" in full, "test premise: vibe must be in the bundled roster"
+        assert set(reg.resolve_selection(("all", "-vibe"))) == full - {"vibe"}
+
+    def test_bare_exclude_seeds_from_full_roster(self) -> None:
+        """``("-vibe",)`` is shorthand for ``("all", "-vibe")``."""
+        reg = load_roster()
+        assert reg.resolve_selection(("-vibe",)) == reg.resolve_selection(("all", "-vibe"))
+
+    def test_exclude_outside_include_set_is_noop(self) -> None:
+        """``claude,-vibe`` resolves to just claude — the exclude is harmless
+        even though vibe was never selected.  Per the agreed semantics: named
+        sets aren't a concept yet, so a stray exclude is a no-op, not an error."""
+        reg = load_roster()
+        assert reg.resolve_selection(("claude", "-vibe")) == ("claude",)
+
+    def test_unknown_exclude_name_raises(self) -> None:
+        reg = load_roster()
+        with pytest.raises(ValueError, match="Unknown roster entries.*nosuchthing"):
+            reg.resolve_selection(("all", "-nosuchthing"))
+
+    def test_exclude_can_drop_a_dependency(self) -> None:
+        """Excludes apply after dep expansion, so ``toad,-caddy`` yields just
+        ``("toad",)`` — likely a broken image, but matches the literal request.
+        We don't second-guess the user; the downstream build will surface it."""
+        reg = load_roster()
+        assert reg.resolve_selection(("toad", "-caddy")) == ("toad",)
+
+
+class TestParseAgentSelection:
+    """Parsing the user-facing string form into the tuple shape that
+    ``resolve_selection`` consumes."""
+
+    def test_all_passes_through(self) -> None:
+        assert parse_agent_selection("all") == "all"
+
+    def test_empty_string_collapses_to_all(self) -> None:
+        assert parse_agent_selection("") == "all"
+        assert parse_agent_selection("   ") == "all"
+
+    def test_comma_list_becomes_tuple(self) -> None:
+        assert parse_agent_selection("claude,codex") == ("claude", "codex")
+
+    def test_preserves_exclude_prefix(self) -> None:
+        assert parse_agent_selection("claude,-vibe") == ("claude", "-vibe")
+
+    def test_bare_exclude_kept_as_single_token(self) -> None:
+        assert parse_agent_selection("-vibe") == ("-vibe",)
+
+    def test_all_and_exclude_combine(self) -> None:
+        assert parse_agent_selection("all,-vibe") == ("all", "-vibe")
+
+    def test_case_folded_and_whitespace_stripped(self) -> None:
+        assert parse_agent_selection(" Claude , -VIBE ") == ("claude", "-vibe")
+
+    def test_end_to_end_roundtrip_through_resolve(self) -> None:
+        """The CLI/config string ``"-vibe"`` should install everything except vibe."""
+        reg = load_roster()
+        selection = parse_agent_selection("-vibe")
+        full = set(reg.resolve_selection("all"))
+        assert set(reg.resolve_selection(selection)) == full - {"vibe"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Lets users subtract from the default-everything agent set without
spelling out the full include list.  Motivation: the `vibe` agent's
upstream pypi release is currently malware-flagged, breaking every
default L1 build.  Today the only fix is to enumerate every other agent
in `image.agents`; with this change it's one token.

```yaml
image:
  agents: "-vibe"        # everything except vibe
  # or: "all,-vibe"      # same thing, explicit form
```

Same syntax works on the CLI: `terok-executor build --agents=-vibe`.

## Semantics

- Excludes apply **after** dep expansion.  `("toad", "-caddy")` yields
  `("toad",)` — a literal read of the user's request; downstream build
  will surface the broken dependency rather than us second-guessing.
- Excludes naming an agent not in the resolved include set are a
  **silent no-op** (e.g. `claude,-vibe` → just claude).  This leaves
  room for a future "named sets" feature where `webdev,-vibe` makes
  sense if `webdev` expands to a set that includes vibe.
- Unknown exclude names (typos) still raise `ValueError`.
- The pseudo-name `"all"` is a valid include token, so `all,-vibe`
  works alongside the bare `-vibe` shorthand.

## Surface

- `parse_agent_selection` now preserves `-` prefixes through to the tuple
- `resolve_selection` tokenizes the tuple into includes/excludes
- `RawImageSection.agents` description updated to document the syntax

## Test plan

- [x] `TestSelectionExcludes` — 5 cases: `all,-vibe`, bare `-vibe`,
      stray no-op exclude, unknown name raises, dep-drop is allowed
- [x] `TestParseAgentSelection` — 8 cases including case folding,
      whitespace handling, and end-to-end roundtrip through `resolve_selection`
- [x] All 809 non-env-blocked unit tests pass (4 `test_preflight.py`
      tests deselected — they fail on master too, missing `nft` binary
      in this dev container; unrelated)
- [x] `ruff check`, `ruff format --check`, `tach check`,
      `docstr-coverage` (97.2%), `reuse lint`, `bandit -ll` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent roster selection now supports exclusion syntax using `-` prefix to exclude agents (e.g., `all,-vibe`).
  * Enhanced validation for agent roster selections with improved error handling for unknown names.

* **Documentation**
  * Updated configuration documentation to clarify agent roster exclusion behavior and inheritance from global settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/302)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->