### PR TITLE
chore(deps): pin terok-sandbox to feat/credentials-encryption branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ also the "Changelog" link in PyPI metadata.
 
 [rel]: https://github.com/terok-ai/terok-executor/releases
 
+## v0.0.142 — Vault Passphrase
+
+Credentials Vault DB encryption
+
+**Full Changelog**: https://github.com/terok-ai/terok-executor/compare/v0.0.141...v0.0.142
+
 ## v0.0.141 — Checkpoint Charlie
 
 ## What's Changed

--- a/poetry.lock
+++ b/poetry.lock
@@ -3217,13 +3217,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/ter
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.116"
+version = "0.0.117"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.117-py3-none-any.whl", hash = "sha256:95ab04beedd1439e599378dcdad20623b342973027d57279f8763e86f002c8a8"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3235,14 +3236,12 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "7937e5c1dc4737831c4d322c7c17aa685d30d064"
-resolved_reference = "7937e5c1dc4737831c4d322c7c17aa685d30d064"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.117/terok_sandbox-0.0.117-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3660,4 +3659,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "7d20f40c7332b6ddc0023f229e8e02d860314cd4936dcb129cc1201aa479570b"
+content-hash = "f282300bc7e9f85a1e37a23348cccb4ba21d91f23252cbebdb1e6138e78a0d74"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1234,6 +1234,85 @@ files = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+description = "Utility functions for Python class constructs"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"},
+    {file = "jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"},
+]
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+description = "Useful decorators and context managers"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535"},
+    {file = "jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["jaraco.test (>=5.6.0)", "portend", "pytest (>=6,!=8.1.*)"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+description = "Functools like those found in stdlib"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176"},
+    {file = "jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb"},
+]
+
+[package.dependencies]
+more_itertools = "*"
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["jaraco.classes", "pytest (>=6,!=8.1.*)"]
+type = ["mypy (<1.19) ; platform_python_implementation == \"PyPy\"", "pytest-mypy (>=1.0.1)"]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+description = "Low-level, pure Python DBus protocol wrapper."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "sys_platform == \"linux\""
+files = [
+    {file = "jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"},
+    {file = "jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"},
+]
+
+[package.extras]
+test = ["async-timeout ; python_version < \"3.11\"", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
+trio = ["trio"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
@@ -1250,6 +1329,35 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+description = "Store and access your passwords safely."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f"},
+    {file = "keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b"},
+]
+
+[package.dependencies]
+"jaraco.classes" = "*"
+"jaraco.context" = "*"
+"jaraco.functools" = "*"
+jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
+pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
+SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+completion = ["shtab (>=1.1.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["pyfakefs", "pytest (>=6,!=8.1.*)"]
+type = ["pygobject-stubs", "pytest-mypy (>=1.0.1)", "shtab", "types-pywin32"]
 
 [[package]]
 name = "librt"
@@ -1747,6 +1855,18 @@ files = [
 griffelib = ">=2.0"
 mkdocs-autorefs = ">=1.4"
 mkdocstrings = ">=0.30"
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4"},
+    {file = "more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804"},
+]
 
 [[package]]
 name = "multidict"
@@ -2649,6 +2769,19 @@ files = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755"},
+    {file = "pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -2860,6 +2993,23 @@ files = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+description = "Python bindings to FreeDesktop.org Secret Service API"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"linux\""
+files = [
+    {file = "secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137"},
+    {file = "secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be"},
+]
+
+[package.dependencies]
+cryptography = ">=2.0"
+jeepney = ">=0.6"
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
@@ -2893,6 +3043,94 @@ groups = ["dev"]
 files = [
     {file = "smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f"},
     {file = "smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c"},
+]
+
+[[package]]
+name = "sqlcipher3"
+version = "0.6.2"
+description = "DB-API 2.0 interface for SQLCipher 4.x"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sqlcipher3-0.6.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:42df4c5e4b8843a658a36f11d1158227c078efa8d36ab9b4b2389a0c76163be3"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:046b9b9ca206b3e4490e1ce31826a7f8128895c524b1d763bba16a2a22d27409"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a37967693e4a3bc40a532ced0e333293b3b856a0b261958c82313a9bb0517cf9"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:c36bcb87969a7a1176106e1f97d9e6552823c09c72237293edf1598019919e46"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:78ed6d21df4b4742c9fc0bc1e6fe7f675af11f812e028530eb41daa12abed6fe"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:cc76dd6dbdbb82383dcd746116f7f83ecc9f1d49d590fd556462ecb3aefc1678"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c67330d041b174884dc8498d06c41ed3c88386f05b340a055b10ce1ad96a853c"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9929444703eec43728f0a1f0dcfdf8cebf732c7b880c6af8e03bf1cf3a62e4d9"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-win32.whl", hash = "sha256:931309d6bfdfd43b8453a284ea57185c6a415b15f8849680ab17fc82bd4c43fa"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-win_amd64.whl", hash = "sha256:f58db62e3e3324c2c6b3816dbcdb2416935be4703417b8956070754fd7b03d0b"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-win_arm64.whl", hash = "sha256:cf5ff0786b0a2a36dd0974264a7be182db5610eba1c14ce2745ed25c37a074ad"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:87432804bf88e9017fc174bdd3d0862a1d1e9ef3c755517595c91da2c59e3808"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eece737c583c285e9bbe3bf829eee3b6624eb6e9dad8ccff7821a45641f436dd"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:22e6502c364706fe64695219877f2bb01cdb25450bec81e69c8a08deff8c14ee"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0ca92202881bcb69b3703b744b40a3a3476e122d4612a82eb2b0a36f2f78de1d"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:15abe3de01faa194f1aaea144ff9ecbfdce2991964dcc7ce8ec1ecc5950a4bc4"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0f08e5bb5eb1ab93819c444ebec61fa3349e9690c14f5d0276fd4f61c3049fd9"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dfe90f1e0e81a8c6c8c4129a8439ed6b9b27a8e32077c59ed3b7f1263e3c5544"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a5f805c1f156634e4e91f1b073d95930756fdf23eeeeb7b85c511a5cf165b10c"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-win32.whl", hash = "sha256:fc08ff475ab0e0f43adca0647d827e81da5fa406bbb6bd04471e28a3ad2864d9"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-win_amd64.whl", hash = "sha256:4ad7e4a32de907011ea22ac2012c9bca1bb414e2f599c56a55c8b0fe6445b932"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-win_arm64.whl", hash = "sha256:3ad6b39a7fa8c2f7ec471dd29fadbffa19c194fbae1730f013f0d29f5b96fae0"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a51b18bd782652a2282f9cb1b03b840ba5a6c0c675de6cefb76262c9789c8f06"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fea0f1264f09d219dd6ce699ffca8cc9022a914661c6efa4390e85a2bf78acf9"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bc2edd981e65783bc0d4e337704a9eb436871ab91c68af02ed76354876087642"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:50f64086da0a5f14281f2b0b459c4d9923b50055813a48ad29baf8c41c7fa56c"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:2288215f462a16996689e1c22d611c94dd865faddb703cb105981dc3c0307b23"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6b26d28ca844dc2a69b8f74b390e940db47760f0be4c96d93337c57ae8250a48"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:11e85c1fa4dfe6bf031af8ada500e94b5a77762355b500580360aa162896cecd"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:80ae14562d98419b32149e8d66eea567eb3792e149b103ee5c8e1e5c67c5d799"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-win32.whl", hash = "sha256:fb15c43f8a4f8b6b0ebe62ad2ab97a7946e3b75cb98a02069ff56b7d5a96c415"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-win_amd64.whl", hash = "sha256:8bd60ffb7bfa65bd0e51da3d5c308553d7149f0091d4ea9f754c33d5ebbf0a66"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-win_arm64.whl", hash = "sha256:99148bf4bf8e73c2c35f810f80de776d7de09b6cf277322c07759026400e90d0"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8093773cd59b2a205d2cdb21383a93f7725126497032c269983ed89a89993631"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:29f39d50bea02d78a824022989164c171e865bfeced3f9b84d1d45193dae074c"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8e1ff6079603dfd955d57c26dad5eab14f6baacdc643d8753dd651913ba789cf"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:35ae605f7594fca64a6d71007795dd39effd625cdc2a181d47f7d9fc8a5e1965"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:8a3e39ad5f73060232b17715aa3b757e82ec4b67bb6acfc081147f66d00c2659"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9fb7109981583b631ac795e7e955d4bf78058f64b54c7f334ccc437adc322d4b"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1ab63dcba15868853cb4d318cceb50dc47b94095e0c434f2785b9b098f3f5b42"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:16d54822ad2fe44e49818a27f4862ba041f2d4a6aeb69422186379f9af97ced0"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-win32.whl", hash = "sha256:31789ce5ec7dd3f6c4ebd612c9cd9f7079a1d3698829111f7a382b0c10da3a87"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-win_amd64.whl", hash = "sha256:9dc959ff792228c6df836cfd3667c713ae13e6e18dc2905c9d5666558606e832"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-win_arm64.whl", hash = "sha256:30eeac16e755e5b0cff584ff541d3001bfcfc20be0ae364ff5305bbaeccbb3f1"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:dae7ce66554f2416d9e9012cc78dfe4d4053385e7fa289a8d0bd7772e5f5a702"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:be137cc92c9a039e469a758ee55e27e2385f419d1387f24e2029c536aa5d9736"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5c1f4a5805faa418c9c7290e6a556a8c5abae40ea59b04d76e960e33c257e618"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2328f0848ffb78807cf0898749dc22ff3f5aa95ab0d5a8a253628de20c11a1c"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:a1fbb693bf7c2f6f46ed038544b0bf76ea43dcc3231905cf5a686af15dc9b424"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e00988174ecd67ecd4537504c3df55bf8daeb75fce98401f099dff8e22c43ae1"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a105e816579bb7cce6f03e7e208b06d6d886c6445e1c738ed9aa2febabff3041"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e3a936d7414ae62f40880668bc036b0fde1ef0f48ed86cfe6564340f780ceea4"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-win32.whl", hash = "sha256:7a07dafe752e013d4030accf218e80472d08de1309ddaf26df6f02d0850b2cec"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-win_amd64.whl", hash = "sha256:7de6133b19aec27b30698267cc2a0ea6e82c21d9a81d349cf0b480439fb549ac"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-win_arm64.whl", hash = "sha256:765e133bd4ddda5596275f1221fa63b2b5d7d2b6e3670809bbf630edb705e27a"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:83533b5b7622ec9b78bec7596d96534e30015136f3e3e69a22f836fc59e393bc"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:310d7adbea382bda31007ee7d3dc63ba6ca86fcf7c0626ea804161fad2efce5e"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1010c4ff1ff13a7e53284a3b03980754dbd37e6eea6faed9c6409e52bac082e6"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d437215611b620b32cb6b68dbc66dbeaccdfb3f76a7b6d8118a40849f8612088"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:09e4170b1b2744b02b1c9315996a228d0b8d8a3ec1a0f7d4d41db0e79872fcea"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:bb4eaa9093bd46a7d51a65b9f63bac29ec4fc6b4ac794083e53eeb49f6db7e2c"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:782111277cbd999b7bc4e9e910396492ee28397c2c60ef7287b6dbc36a0b6a24"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a01424f0d0120e8d9d3e0e1751ef78e70867bbce91f283b56911e8c6adaafddb"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-win32.whl", hash = "sha256:311fa50be627a4d1566bed31fd7725dec535a71332dcefdcdf9ec2472c4f824d"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:7ac16581a5b80c54237c5f08f2e488051dfa7f52e3890e7765a6364d5bb3a2c6"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:76125dd222f4946302f70281e155ae9336efa4bc6fabdc81a7ae9bd4dfce9180"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8d6300bc294a9dfeee5a5696f4b3c8de311d1bc63591cf908581e29c60d500e0"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17268ccb657bde0f4588837b480d1e512f5ca762faf795010dac6ed8f83d6a85"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7634c16e937c42f3570b41bf2a5032fbec8413cd221e84782ff567f850a0f76c"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:c14ba97592547e1a47fcdf5ba801626c4648d5205da9091029515e5a554d98aa"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-manylinux_2_28_i686.whl", hash = "sha256:1e785c594ee98bb3aba88b93e63ee31fdc6bcb09351df23b301449fbf8b17ab2"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:3a8ced91852c599a19a1e223436ef2e43f6727141958880183aea02b6ad5b375"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:e8055ebe76ecdbd77ce49da32bfa367319381cbd8a656230d793a6953048ef0b"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0df26d51513ddd07e0fb0f311046b2e798e3040032ebed6e670381cf26e89215"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-win32.whl", hash = "sha256:e73a690b8652a17365112a75883aaf965ca6e8a4c190c7c7a9eb38e154ca223e"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1585d88b38a8e6969ec60fbaaafaa3c6eaa6b61e4411d0e25ffdb387b2629c7"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-win_arm64.whl", hash = "sha256:84f02bde14b64810e0a4d472cecae0a63f359247f06a62544b6ef0cec85826b4"},
+    {file = "sqlcipher3-0.6.2.tar.gz", hash = "sha256:a2b675289ba8889f389625a21f3a01f1ff159a551b5b88fba8fd92da0e02380a"},
 ]
 
 [[package]]
@@ -2984,22 +3222,27 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.116-py3-none-any.whl", hash = "sha256:a3f1f1fc4472562b32d0deb1cc452962dbe8fd3471140c689087b2181cb0f811"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=46.0.7"
+keyring = ">=25.0"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
+prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+"ruamel.yaml" = ">=0.18"
+sqlcipher3 = ">=0.6.2"
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.116/terok_sandbox-0.0.116-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/credentials-encryption"
+resolved_reference = "254595378f3172b8487dbb72e9d17085a9c32045"
 
 [[package]]
 name = "terok-shield"
@@ -3417,4 +3660,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "060c18e78eb42e2d3025caab1ccd4a6440200d45a933ae5a6a537a8f43d2ec5b"
+content-hash = "dda4211d70fd3315538bc5c952994442d7f3aba2fcbc6e55466eb9a13b6b4ecc"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3241,8 +3241,8 @@ terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/credentials-encryption"
-resolved_reference = "254595378f3172b8487dbb72e9d17085a9c32045"
+reference = "7937e5c1dc4737831c4d322c7c17aa685d30d064"
+resolved_reference = "7937e5c1dc4737831c4d322c7c17aa685d30d064"
 
 [[package]]
 name = "terok-shield"
@@ -3660,4 +3660,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "dda4211d70fd3315538bc5c952994442d7f3aba2fcbc6e55466eb9a13b6b4ecc"
+content-hash = "7d20f40c7332b6ddc0023f229e8e02d860314cd4936dcb129cc1201aa479570b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.116/terok_sandbox-0.0.116-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/credentials-encryption"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/credentials-encryption"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "7937e5c1dc4737831c4d322c7c17aa685d30d064"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.141"
+version = "0.0.142"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "7937e5c1dc4737831c4d322c7c17aa685d30d064"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.117/terok_sandbox-0.0.117-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_executor/acp/roster.py
+++ b/src/terok_executor/acp/roster.py
@@ -26,7 +26,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
-from terok_sandbox import CredentialDB, SandboxConfig
+from terok_sandbox import SandboxConfig
 
 from terok_executor.container.build import AGENTS_LABEL
 
@@ -66,8 +66,16 @@ def list_authenticated_agents(
     outside the vault, so a vault-only filter would silently hide
     working agents).
     """
-    path = db_path or SandboxConfig().db_path
-    db = CredentialDB(path)
+    cfg = SandboxConfig()
+    # ``db_path`` is a back-compat override (e.g. tests pointing at a
+    # tmp DB).  When set, dataclass-replace the config so its
+    # ``open_credential_db`` targets the override; the resolution chain
+    # still runs against the rest of the operator's tiers.
+    if db_path is not None:
+        import dataclasses
+
+        cfg = dataclasses.replace(cfg, vault_dir=db_path.parent)
+    db = cfg.open_credential_db()
     try:
         return list(db.list_credentials(scope))
     finally:

--- a/src/terok_executor/acp/roster.py
+++ b/src/terok_executor/acp/roster.py
@@ -67,15 +67,22 @@ def list_authenticated_agents(
     working agents).
     """
     cfg = SandboxConfig()
-    # ``db_path`` is a back-compat override (e.g. tests pointing at a
-    # tmp DB).  When set, dataclass-replace the config so its
-    # ``open_credential_db`` targets the override; the resolution chain
-    # still runs against the rest of the operator's tiers.
-    if db_path is not None:
-        import dataclasses
+    if db_path is None:
+        db = cfg.open_credential_db()
+    else:
+        # ``cfg.db_path`` is computed as ``vault_dir / "credentials.db"``,
+        # so a ``dataclasses.replace`` on ``vault_dir`` alone would lose
+        # an override that uses a different filename (e.g. tests).
+        # Bypass to the lower-level opener that takes an explicit path,
+        # threading the resolution-chain knobs from ``cfg``.
+        from terok_sandbox.credentials.db import open_credential_db
 
-        cfg = dataclasses.replace(cfg, vault_dir=db_path.parent)
-    db = cfg.open_credential_db()
+        db = open_credential_db(
+            db_path,
+            passphrase_file=cfg.vault_passphrase_file,
+            use_keyring=cfg.credentials_use_keyring,
+            config_fallback=cfg.credentials_passphrase,
+        )
     try:
         return list(db.list_credentials(scope))
     finally:

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -449,7 +449,6 @@ def _inject_vault_tokens(
     if the vault is unreachable.
     """
     from terok_sandbox import (
-        CredentialDB,
         SandboxConfig,
         get_ssh_signer_port,
         get_token_broker_port,
@@ -470,7 +469,7 @@ def _inject_vault_tokens(
 
     vault_routes = roster.vault_routes
     try:
-        db = CredentialDB(cfg.db_path)
+        db = cfg.open_credential_db()
     except Exception:
         _logger.exception("Vault DB unavailable")
         if vault_required:

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -825,12 +825,10 @@ class AgentRunner:
         this injects the actual credential.  Safe because sidecar containers
         have no agent code that could leak it.
         """
-        from terok_sandbox import CredentialDB
-
         spec = self.roster.get_sidecar_spec(tool_name)
         cfg = self.sandbox.config
         try:
-            db = CredentialDB(cfg.db_path)
+            db = cfg.open_credential_db()
         except Exception as exc:
             print(
                 f"Warning [runner]: credential DB unavailable: {type(exc).__name__}: {exc}",

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -260,10 +260,10 @@ def store_api_key(
     This is the non-interactive fast path for automated workflows and CI.
     The key is stored as ``{"type": "api_key", "key": "<value>"}``.
     """
-    from terok_sandbox import CredentialDB, SandboxConfig
+    from terok_sandbox import SandboxConfig
 
     cfg = SandboxConfig()
-    db = CredentialDB(cfg.db_path)
+    db = cfg.open_credential_db(prompt_on_tty=True)
     try:
         db.store_credential(credential_set, provider, {"type": "api_key", "key": api_key})
         print(f"API key stored for {provider} (set: {credential_set})")
@@ -468,10 +468,10 @@ def _capture_credentials(
         )
     else:
         try:
-            from terok_sandbox import CredentialDB, SandboxConfig
+            from terok_sandbox import SandboxConfig
 
             cfg = SandboxConfig()
-            db = CredentialDB(cfg.db_path)
+            db = cfg.open_credential_db(prompt_on_tty=True)
             try:
                 db.store_credential(credential_set, provider_name, cred_data)
                 _out.print(

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -139,22 +139,30 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     return leaked
 
 
-def _format_credentials(status: object) -> str:
-    """Format stored credentials as ``name (type), ...`` for status display."""
-    from terok_sandbox import SandboxConfig, VaultStatus
+def _format_credentials(status: object, cfg: SandboxConfig | None = None) -> str:
+    """Format stored credentials as ``name (type), ...`` for status display.
+
+    *cfg* threads the caller's chosen passphrase-resolution knobs
+    (session-unlock file, keyring opt-in, config-file fallback) into
+    the DB open — without this hook the function would construct a
+    fresh ``SandboxConfig()`` and silently miss any non-default tier
+    the caller had set up.  Defaults to a fresh config for direct
+    callers that don't have one handy.
+    """
+    from terok_sandbox import SandboxConfig as _SandboxConfig, VaultStatus
     from terok_sandbox.credentials.db import open_credential_db
 
+    if cfg is None:
+        cfg = _SandboxConfig()
     st: VaultStatus = status  # type: ignore[assignment]
     if not st.credentials_stored:
         return "none stored"
     try:
-        # Open the DB the status reported.  Bypass
-        # ``cfg.open_credential_db`` because it computes
+        # Bypass ``cfg.open_credential_db`` because it computes
         # ``vault_dir / "credentials.db"`` from the local config,
         # which may not match the running daemon's actual ``db_path``
         # (test fixtures and multi-instance hosts both diverge).
-        # The resolution-chain knobs still come from the local cfg.
-        cfg = SandboxConfig()
+        # The resolution-chain knobs still come from *cfg*.
         db = open_credential_db(
             st.db_path,
             passphrase_file=cfg.vault_passphrase_file,
@@ -192,7 +200,7 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
     print(f"DB:          {status.db_path}")
     print(f"Routes:      {status.routes_path} ({status.routes_configured} configured)")
     if status.credentials_stored:
-        print(f"Credentials: {_format_credentials(status)}")
+        print(f"Credentials: {_format_credentials(status, cfg)}")
     else:
         print("Credentials: none stored")
     if not status.running and status.mode == "none" and is_vault_systemd_available():

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -141,13 +141,26 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
 
 def _format_credentials(status: object) -> str:
     """Format stored credentials as ``name (type), ...`` for status display."""
-    from terok_sandbox import CredentialDB, VaultStatus
+    from terok_sandbox import SandboxConfig, VaultStatus
+    from terok_sandbox.credentials.db import open_credential_db
 
     st: VaultStatus = status  # type: ignore[assignment]
     if not st.credentials_stored:
         return "none stored"
     try:
-        db = CredentialDB(st.db_path)
+        # Open the DB the status reported.  Bypass
+        # ``cfg.open_credential_db`` because it computes
+        # ``vault_dir / "credentials.db"`` from the local config,
+        # which may not match the running daemon's actual ``db_path``
+        # (test fixtures and multi-instance hosts both diverge).
+        # The resolution-chain knobs still come from the local cfg.
+        cfg = SandboxConfig()
+        db = open_credential_db(
+            st.db_path,
+            passphrase_file=cfg.vault_passphrase_file,
+            use_keyring=cfg.credentials_use_keyring,
+            config_fallback=cfg.credentials_passphrase,
+        )
         try:
             parts = []
             for name in st.credentials_stored:

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -225,10 +225,10 @@ def check_images(base_image: str) -> CheckResult:
 
 def check_credentials(provider: str) -> CheckResult:
     """Check whether credentials are stored for *provider*."""
-    from terok_sandbox import CredentialDB, SandboxConfig
+    from terok_sandbox import SandboxConfig
 
     try:
-        db = CredentialDB(SandboxConfig().db_path)
+        db = SandboxConfig().open_credential_db()
     except Exception:  # noqa: BLE001
         return CheckResult(f"{provider} credentials", False, "credential database unavailable")
     try:
@@ -242,10 +242,10 @@ def check_credentials(provider: str) -> CheckResult:
 
 def check_ssh_key(scope: str = "standalone") -> CheckResult:
     """Check whether a gate-signing SSH key exists for *scope*."""
-    from terok_sandbox import CredentialDB, SandboxConfig
+    from terok_sandbox import SandboxConfig
 
     try:
-        db = CredentialDB(SandboxConfig().db_path)
+        db = SandboxConfig().open_credential_db()
     except Exception:  # noqa: BLE001
         return CheckResult("ssh key", False, "credential database unavailable")
     try:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit-test fixtures for terok-executor.
+
+After at-rest encryption (terok-sandbox#268), opening the credentials
+DB requires a passphrase that resolves through the chain.  Unit-test
+runners have no passphrase anywhere on disk, so every test that
+constructs a ``CredentialDB`` (directly or via ``cfg.open_credential_db``)
+would raise ``NoPassphraseError``.
+
+A single autouse fixture replaces ``SandboxConfig.open_credential_db``
+with a thin wrapper that honours the config's own ``db_path`` but
+applies ``TEST_VAULT_PASSPHRASE`` instead of walking the resolution
+chain.  Tests that seed a real SQLCipher file at ``cfg.db_path``
+should construct ``CredentialDB(cfg.db_path, passphrase=TEST_VAULT_PASSPHRASE)``
+so the on-disk file uses the same key the autouse fixture opens it
+with.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+TEST_VAULT_PASSPHRASE = "unit-test-passphrase"  # nosec: B105 — fixture, not a real secret
+"""Passphrase used everywhere a unit test seeds or opens the vault DB."""
+
+
+@pytest.fixture(autouse=True)
+def _stub_credential_db_passphrase() -> Iterator[None]:
+    """Open ``cfg.open_credential_db`` with ``TEST_VAULT_PASSPHRASE``.
+
+    The wrapper honours each config's own ``db_path`` so tests that
+    seed a DB at ``cfg.db_path`` see the production code read from
+    exactly the same file.  ``prompt_on_tty`` is accepted (and
+    ignored) to match the real signature.
+    """
+    from pathlib import Path
+
+    from terok_sandbox import CredentialDB
+
+    def _open_method(self, *, prompt_on_tty: bool = False) -> CredentialDB:
+        return CredentialDB(self.db_path, passphrase=TEST_VAULT_PASSPHRASE)
+
+    def _open_module(db_path: Path, **_kw: object) -> CredentialDB:
+        return CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
+
+    with (
+        patch("terok_sandbox.config.SandboxConfig.open_credential_db", new=_open_method),
+        patch("terok_sandbox.credentials.db.open_credential_db", new=_open_module),
+    ):
+        yield

--- a/tests/unit/test_acp_roster.py
+++ b/tests/unit/test_acp_roster.py
@@ -298,3 +298,79 @@ class TestWarm:
         assert first == ("opus-4.6",)
         assert second == ["claude:opus-4.6"]
         assert attempts == ["claude"]
+
+
+class TestListAuthenticatedAgents:
+    """Top-level credential-store query used by ``acp list``.
+
+    Exercises both code paths of the open-DB seam: the default
+    ``cfg.open_credential_db()`` (covered by the autouse fixture's
+    stub against ``cfg.db_path``) and the ``db_path`` override that
+    routes through the lower-level ``open_credential_db(path, …)``
+    opener so a custom filename is honoured verbatim.
+    """
+
+    def test_returns_provider_names_with_default_cfg(self, tmp_path, monkeypatch) -> None:
+        """Default open path resolves through ``SandboxConfig.open_credential_db``."""
+        import pytest
+        from terok_sandbox import CredentialDB
+
+        from terok_executor.acp.roster import list_authenticated_agents
+        from tests.unit.conftest import TEST_VAULT_PASSPHRASE
+
+        # Redirect the sandbox state into tmp_path so ``cfg.db_path``
+        # is a clean tmp file rather than the real XDG default
+        # (which may have a DB encrypted with a different key).
+        assert isinstance(monkeypatch, pytest.MonkeyPatch)
+        monkeypatch.setenv("TEROK_SANDBOX_STATE_DIR", str(tmp_path / "state"))
+        monkeypatch.setenv("TEROK_VAULT_DIR", str(tmp_path / "vault"))
+
+        from terok_sandbox import SandboxConfig
+
+        cfg = SandboxConfig()
+        cfg.db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = CredentialDB(cfg.db_path, passphrase=TEST_VAULT_PASSPHRASE)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "k"})
+        db.store_credential("default", "vibe", {"type": "api_key", "key": "k"})
+        db.close()
+
+        result = list_authenticated_agents()
+        # ``list_credentials`` returns names in insertion order — assert
+        # set membership rather than order.
+        assert set(result) == {"claude", "vibe"}
+
+    def test_db_path_override_honors_exact_filename(self, tmp_path) -> None:
+        """An override at a non-default filename opens that file verbatim.
+
+        Pins the fix for the silent-filename-drop bug: a previous
+        ``dataclasses.replace(cfg, vault_dir=db_path.parent)`` would
+        have computed ``vault_dir / "credentials.db"`` and missed the
+        explicit ``custom.db`` filename.
+        """
+        from terok_sandbox import CredentialDB
+
+        from terok_executor.acp.roster import list_authenticated_agents
+        from tests.unit.conftest import TEST_VAULT_PASSPHRASE
+
+        explicit = tmp_path / "custom.db"
+        db = CredentialDB(explicit, passphrase=TEST_VAULT_PASSPHRASE)
+        db.store_credential("default", "codex", {"type": "api_key", "key": "k"})
+        db.close()
+
+        assert list_authenticated_agents(db_path=explicit) == ["codex"]
+
+    def test_scope_filter_passes_through(self, tmp_path) -> None:
+        """Non-default scope reaches ``db.list_credentials`` unchanged."""
+        from terok_sandbox import CredentialDB
+
+        from terok_executor.acp.roster import list_authenticated_agents
+        from tests.unit.conftest import TEST_VAULT_PASSPHRASE
+
+        explicit = tmp_path / "scoped.db"
+        db = CredentialDB(explicit, passphrase=TEST_VAULT_PASSPHRASE)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "k"})
+        db.store_credential("work", "gh", {"type": "api_key", "key": "k"})
+        db.close()
+
+        assert list_authenticated_agents(db_path=explicit, scope="work") == ["gh"]
+        assert list_authenticated_agents(db_path=explicit, scope="ghost") == []

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -10,7 +10,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-from terok_sandbox import CODEX_SHARED_OAUTH_MARKER, PHANTOM_CREDENTIALS_MARKER
+from terok_sandbox import CODEX_SHARED_OAUTH_MARKER, PHANTOM_CREDENTIALS_MARKER, CredentialDB
 
 from terok_executor.credentials.auth import (
     _apply_post_capture_state,
@@ -20,6 +20,7 @@ from terok_executor.credentials.auth import (
     _write_claude_credentials_file,
     store_api_key,
 )
+from tests.unit.conftest import TEST_VAULT_PASSPHRASE
 
 
 def _fake_jwt(payload: dict | None = None) -> str:
@@ -53,12 +54,14 @@ class TestCaptureCredentials:
         db_path = tmp_path / "proxy" / "credentials.db"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials("claude", tmp_path, "default")
 
         # Verify it's in the DB
-        from terok_sandbox import CredentialDB
 
-        db = CredentialDB(db_path)
+        db = CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
         stored = db.load_credential("default", "claude")
         db.close()
         assert stored is not None
@@ -71,11 +74,12 @@ class TestCaptureCredentials:
         db_path = tmp_path / "proxy" / "credentials.db"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials("blablador", tmp_path, "default")
 
-        from terok_sandbox import CredentialDB
-
-        db = CredentialDB(db_path)
+        db = CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
         stored = db.load_credential("default", "blablador")
         db.close()
         assert stored["key"] == "blab-key"
@@ -117,11 +121,12 @@ class TestCaptureCredentials:
         db_path = tmp_path / "proxy" / "credentials.db"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials("kisski", tmp_path, "work-project")
 
-        from terok_sandbox import CredentialDB
-
-        db = CredentialDB(db_path)
+        db = CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
         stored = db.load_credential("work-project", "kisski")
         db.close()
         assert stored["key"] == "work-key"
@@ -322,6 +327,9 @@ class TestCaptureAppliesPostCaptureState:
         db_path = tmp_path / "proxy" / "credentials.db"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials(
                 "claude", tmp_path, "default", mounts_base=mounts, auth_provider=provider
             )
@@ -351,6 +359,9 @@ class TestCaptureAppliesPostCaptureState:
         db_path = tmp_path / "proxy" / "credentials.db"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials(
                 "claude", tmp_path, "default", mounts_base=mounts, auth_provider=provider
             )
@@ -387,6 +398,9 @@ class TestCaptureAppliesPostCaptureState:
         db_path = tmp_path / "proxy" / "credentials.db"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             # Should NOT raise — error is caught and printed
             _capture_credentials(
                 "claude", tmp_path, "default", mounts_base=mounts, auth_provider=provider
@@ -397,9 +411,8 @@ class TestCaptureAppliesPostCaptureState:
         assert "post_capture_state" in err
 
         # Verify credentials were still stored in the DB
-        from terok_sandbox import CredentialDB
 
-        db = CredentialDB(db_path)
+        db = CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
         stored = db.load_credential("default", "claude")
         db.close()
         assert stored is not None
@@ -424,6 +437,9 @@ class TestCaptureWritesCredentialsFile:
         mounts = tmp_path / "mounts"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials("claude", tmp_path, "default", mounts_base=mounts)
 
         cred_file = mounts / "_claude-config" / ".credentials.json"
@@ -440,6 +456,9 @@ class TestCaptureWritesCredentialsFile:
         mounts = tmp_path / "mounts"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials("claude", tmp_path, "default", mounts_base=mounts)
 
         assert not (mounts / "_claude-config" / ".credentials.json").exists()
@@ -471,6 +490,9 @@ class TestCaptureWritesCredentialsFile:
         mounts = tmp_path / "mounts"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials("codex", tmp_path, "default", mounts_base=mounts)
 
         phantom = mounts / "_codex-config" / "auth.json"
@@ -648,6 +670,9 @@ class TestCaptureWithExposeToken:
         mounts = tmp_path / "mounts"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials(
                 "claude", tmp_path, "default", mounts_base=mounts, expose_token=True
             )
@@ -667,6 +692,9 @@ class TestCaptureWithExposeToken:
         mounts = tmp_path / "mounts"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials(
                 "claude", tmp_path, "default", mounts_base=mounts, expose_token=False
             )
@@ -683,6 +711,9 @@ class TestCaptureWithExposeToken:
         mounts = tmp_path / "mounts"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials(
                 "claude", tmp_path, "default", mounts_base=mounts, expose_token=True
             )
@@ -699,13 +730,14 @@ class TestCaptureWithExposeToken:
         mounts = tmp_path / "mounts"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             _capture_credentials(
                 "claude", tmp_path, "default", mounts_base=mounts, expose_token=True
             )
 
-        from terok_sandbox import CredentialDB
-
-        db = CredentialDB(db_path)
+        db = CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
         stored = db.load_credential("default", "claude")
         db.close()
         assert stored is None
@@ -719,11 +751,12 @@ class TestStoreApiKey:
         db_path = tmp_path / "proxy" / "credentials.db"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             store_api_key("vibe", "sk-test-key-123")
 
-        from terok_sandbox import CredentialDB
-
-        db = CredentialDB(db_path)
+        db = CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
         stored = db.load_credential("default", "vibe")
         db.close()
         assert stored == {"type": "api_key", "key": "sk-test-key-123"}
@@ -733,11 +766,12 @@ class TestStoreApiKey:
         db_path = tmp_path / "proxy" / "credentials.db"
         with patch("terok_sandbox.SandboxConfig") as mock_cfg_cls:
             mock_cfg_cls.return_value.db_path = db_path
+            mock_cfg_cls.return_value.open_credential_db = lambda **_kw: CredentialDB(
+                db_path, passphrase=TEST_VAULT_PASSPHRASE
+            )
             store_api_key("claude", "sk-ant-key", credential_set="work")
 
-        from terok_sandbox import CredentialDB
-
-        db = CredentialDB(db_path)
+        db = CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
         stored = db.load_credential("work", "claude")
         db.close()
         assert stored["key"] == "sk-ant-key"

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -487,7 +487,10 @@ class TestVaultTokenInjection:
         """DB open failure returns empty env gracefully."""
         with (
             patch("terok_sandbox.is_vault_socket_active", return_value=True),
-            patch("terok_sandbox.CredentialDB", side_effect=OSError("corrupt")),
+            patch(
+                "terok_sandbox.config.SandboxConfig.open_credential_db",
+                side_effect=OSError("corrupt"),
+            ),
         ):
             result = assemble_container_env(base_spec, roster, caller_manages_vault=False)
         assert "ANTHROPIC_API_KEY" not in result.env
@@ -692,11 +695,14 @@ class TestVaultTokenInjection:
         assert "ANTHROPIC_API_KEY" not in result.env
 
     def test_vault_required_hard_fails_on_db_error(self, workspace, envs_dir, roster):
-        """vault_required=True raises SystemExit on CredentialDB construction failure."""
+        """vault_required=True raises SystemExit on credential-DB open failure."""
         spec = _spec(workspace, envs_dir, vault_required=True)
         with (
             patch("terok_sandbox.is_vault_socket_active", return_value=True),
-            patch("terok_sandbox.CredentialDB", side_effect=OSError("corrupt")),
+            patch(
+                "terok_sandbox.config.SandboxConfig.open_credential_db",
+                side_effect=OSError("corrupt"),
+            ),
             pytest.raises(SystemExit, match="DB unavailable.*Check logs"),
         ):
             assemble_container_env(spec, roster, caller_manages_vault=False)

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -19,6 +19,7 @@ from terok_executor.container.env import (
     assemble_container_env,
 )
 from terok_executor.roster import get_roster
+from tests.unit.conftest import TEST_VAULT_PASSPHRASE
 
 
 def _find_vol(volumes: tuple[VolumeSpec, ...], container_path: str) -> VolumeSpec | None:
@@ -35,7 +36,7 @@ def _make_vault_db(tmp_path: Path, cred_name: str = "claude", cred_data: dict | 
 
     cfg = SandboxConfig(state_dir=tmp_path, vault_dir=tmp_path / "credentials")
     cfg.db_path.parent.mkdir(parents=True, exist_ok=True)
-    db = CredentialDB(cfg.db_path)
+    db = CredentialDB(cfg.db_path, passphrase=TEST_VAULT_PASSPHRASE)
     db.store_credential(
         "default",
         cred_name,
@@ -52,7 +53,7 @@ def _make_vault_db_with_ssh_keys(tmp_path: Path, scope: str = "myproj"):
 
     cfg = _make_vault_db(tmp_path)
     cfg.vault_dir.mkdir(parents=True, exist_ok=True)
-    db = CredentialDB(cfg.db_path)
+    db = CredentialDB(cfg.db_path, passphrase=TEST_VAULT_PASSPHRASE)
     try:
         kp = generate_keypair("ed25519", comment=f"tk-main:{scope}")
         key_id = db.store_ssh_key(
@@ -664,7 +665,7 @@ class TestVaultTokenInjection:
         cfg.db_path.parent.mkdir(parents=True, exist_ok=True)
         cfg.vault_dir.mkdir(parents=True, exist_ok=True)
         # DB exists with NO provider credentials — only SSH keys.
-        db = CredentialDB(cfg.db_path)
+        db = CredentialDB(cfg.db_path, passphrase=TEST_VAULT_PASSPHRASE)
         try:
             kp = generate_keypair("ed25519", comment="tk-main:sshonly")
             key_id = db.store_ssh_key(

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -83,7 +83,7 @@ def test_sandbox_services_lists_missing(
 # ── check_credentials ────────────────────────────────────────────────
 
 
-@patch("terok_sandbox.CredentialDB")
+@patch("terok_sandbox.config.SandboxConfig.open_credential_db")
 def test_credentials_found(mock_db_cls: MagicMock) -> None:
     """Credentials stored → ok."""
     db = mock_db_cls.return_value
@@ -92,7 +92,7 @@ def test_credentials_found(mock_db_cls: MagicMock) -> None:
     db.close.assert_called_once()
 
 
-@patch("terok_sandbox.CredentialDB")
+@patch("terok_sandbox.config.SandboxConfig.open_credential_db")
 def test_credentials_missing(mock_db_cls: MagicMock) -> None:
     """No credentials → fail."""
     db = mock_db_cls.return_value
@@ -103,7 +103,7 @@ def test_credentials_missing(mock_db_cls: MagicMock) -> None:
     db.close.assert_called_once()
 
 
-@patch("terok_sandbox.CredentialDB", side_effect=Exception("db error"))
+@patch("terok_sandbox.config.SandboxConfig.open_credential_db", side_effect=Exception("db error"))
 def test_credentials_db_unavailable(_cls: MagicMock) -> None:
     """DB open fails → fail with message."""
     r = check_credentials("claude")
@@ -114,7 +114,7 @@ def test_credentials_db_unavailable(_cls: MagicMock) -> None:
 # ── check_ssh_key ────────────────────────────────────────────────────
 
 
-@patch("terok_sandbox.CredentialDB")
+@patch("terok_sandbox.config.SandboxConfig.open_credential_db")
 def test_ssh_key_present(mock_db_cls: MagicMock) -> None:
     """Existing key in scope → ok."""
     db = mock_db_cls.return_value
@@ -124,7 +124,7 @@ def test_ssh_key_present(mock_db_cls: MagicMock) -> None:
     db.close.assert_called_once()
 
 
-@patch("terok_sandbox.CredentialDB")
+@patch("terok_sandbox.config.SandboxConfig.open_credential_db")
 def test_ssh_key_absent(mock_db_cls: MagicMock) -> None:
     """Empty scope → fail."""
     db = mock_db_cls.return_value

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 
 from terok_executor.roster import VaultRoute, get_roster
 from terok_executor.roster.schema import RawAgentYaml
+from tests.unit.conftest import TEST_VAULT_PASSPHRASE
 
 
 def _vault_route(name: str, data: dict) -> VaultRoute | None:
@@ -639,7 +640,7 @@ class TestFormatCredentials:
         from terok_executor.credentials.vault_commands import _format_credentials
 
         db_path = tmp_path / "creds.db"
-        db = CredentialDB(db_path)
+        db = CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
         db.store_credential("default", "claude", {"type": "oauth", "access_token": "t"})
         db.store_credential("default", "vibe", {"type": "api_key", "key": "k"})
         db.close()
@@ -658,7 +659,7 @@ class TestFormatCredentials:
         from terok_executor.credentials.vault_commands import _format_credentials
 
         db_path = tmp_path / "creds.db"
-        db = CredentialDB(db_path)
+        db = CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)
         db.store_credential("default", "legacy", {"key": "k"})
         db.close()
 


### PR DESCRIPTION
## Summary

PR-chain plumbing for **terok-sandbox#268** and **terok#927**.

terok#927 routes credentials-DB access through new API on `SandboxConfig` / `SSHManager` / `terok_sandbox.credentials.db.{NoPassphraseError,WrongPassphraseError}`, all introduced in terok-sandbox#268.  Poetry rejects conflicting URL pins, so terok-executor and terok must agree on the terok-sandbox source until #268 releases — this PR keeps that agreement by pointing executor at the same branch tip.

Reverts to a release wheel URL the moment terok-sandbox#268 ships.

## Test plan

- [x] `poetry lock --no-update` succeeds against the new pin.
- [ ] Wait for terok-sandbox#268 to release; bump back to a wheel URL in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched terok-sandbox dependency from a pre-built wheel to a git-based source pinned to a specific revision.

* **Refactor**
  * Centralized credential/secret store access so all credential, vault and token flows use a common configuration-backed opener.

* **Tests**
  * Added fixtures and updated unit tests to use a stable test vault passphrase and exercise the consolidated credential-access path.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/304)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->