### PR TITLE
ci: split SonarQube into its own workflow; add fork-PR sonar; simplify docs wait

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -145,33 +145,8 @@ jobs:
           path: reports/bandit-report.json
           retention-days: 1
 
-  sonar:
-    name: SonarQube Cloud
-    if: github.repository == 'terok-ai/terok-executor' && (github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
-    needs: [unit-tests, ruff, bandit]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: coverage
-          path: reports
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: ruff
-          path: reports
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: bandit
-          path: reports
-
-      - name: SonarQube Cloud scan
-        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  # The SonarQube Cloud scan runs in sonar.yml (same-repo) and sonar_pr.yml
+  # (fork PRs) — both consume the coverage/ruff/bandit artifacts uploaded
+  # above. Splitting Sonar out keeps this workflow free of third-party wait
+  # time, so downstream consumers (docs.yml, sonar.yml) unblock as soon as
+  # the local jobs finish.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,22 @@
 # Pin third-party actions to full commit SHAs for supply-chain security.
 # GitHub-owned actions (actions/*) may use version tags.
+#
+# Coverage handoff contract (well-known address):
+#   workflow=analysis.yml  job=unit-tests  artifact=coverage  contains reports/coverage.{json,xml}
+#
+# reports/coverage.json drives mkdocs-terok's code-coverage treemap. The unit
+# tests workflow already produces it, so the docs build downloads that artifact
+# instead of paying for a second `make test-unit`. The coverage JSON itself is
+# throwaway: only the rendered SVG is published.
+#
+# Freshness policy:
+#   master ref  -> require the same-SHA Tests & Analysis run to complete
+#                  successfully (with a 20m wait). The published treemap must
+#                  match the published code.
+#   other refs  -> try same-SHA opportunistically, fall back immediately to
+#                  the latest successful master run. PR builds are not
+#                  published, so a one-merge-stale treemap is acceptable in
+#                  exchange for never-pending PR feedback.
 name: Documentation
 
 on:
@@ -13,12 +30,14 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     if: github.repository == 'terok-ai/terok-executor'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -51,15 +70,86 @@ jobs:
           echo "6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772  scc_Linux_x86_64.tar.gz" | sha256sum -c
           sudo tar xzf scc_Linux_x86_64.tar.gz -C /usr/local/bin scc
 
-      - name: Generate coverage data for treemap
-        # Produces reports/coverage.json, consumed by mkdocs-terok's
-        # code_metrics generator to render a local SVG treemap.
-        run: make test-unit
+      # On master we strictly require the Tests & Analysis run for *this* commit
+      # to have finished successfully — published docs must agree with published
+      # code. Tests & Analysis only contains the fast in-repo jobs (unit-tests,
+      # ruff, bandit); the third-party SonarQube scan lives in sonar.yml, so
+      # waiting on workflow completion here no longer drags in Sonar wait time.
+      # Polling rather than `workflow_run` keeps this build visible as its own
+      # PR check.
+      - name: Wait for Tests & Analysis on this commit (master)
+        if: github.ref == 'refs/heads/master'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deadline = Date.now() + 20 * 60 * 1000;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            while (Date.now() < deadline) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'analysis.yml',
+                head_sha: context.sha,
+                per_page: 5,
+              });
+              const run = data.workflow_runs[0];
+              if (run?.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.info(`Tests & Analysis succeeded for ${context.sha}`);
+                  return;
+                }
+                core.setFailed(
+                  `Tests & Analysis ${run.conclusion} for ${context.sha} — refusing to publish docs with a mismatched treemap`
+                );
+                return;
+              }
+              core.info(`Tests & Analysis for ${context.sha}: ${run?.status ?? 'not yet started'} — waiting`);
+              await sleep(20_000);
+            }
+            core.setFailed('Timed out after 20m waiting for Tests & Analysis')
+
+      - name: Coverage artifact (master — same SHA, required)
+        if: github.ref == 'refs/heads/master'
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: coverage
+          path: reports
+          if_no_artifact_found: fail
+
+      # First push of a PR: Tests & Analysis and this workflow start together,
+      # so this step usually misses and we fall through to latest-master below.
+      # Re-running this workflow after Tests & Analysis goes green picks up the
+      # same-SHA artifact here instead.
+      - name: Coverage artifact (non-master — same SHA, best effort)
+        if: github.ref != 'refs/heads/master'
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: coverage
+          path: reports
+          if_no_artifact_found: warn
+
+      - name: Coverage artifact (non-master — fall back to latest master)
+        if: github.ref != 'refs/heads/master' && !hashFiles('reports/coverage.json')
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          branch: master
+          name: coverage
+          path: reports
+          if_no_artifact_found: fail
 
       - name: Build documentation
         run: poetry run properdocs build --strict
 
       - name: Upload artifact
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v5
         with:
           path: site

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,103 @@
+name: SonarQube Cloud
+
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
+#
+# Same-repo SonarQube scan. Split out of analysis.yml so its third-party
+# wait time doesn't block the Tests & Analysis workflow's conclusion (which
+# docs.yml waits on, and which gates the master Pages deploy).
+#
+# Triggering contexts (must match the inline sonar job this replaces):
+#   - push to master in terok-ai/terok-executor
+#   - same-repo pull request against master (excluding dependabot)
+# Fork PRs are handled by sonar_pr.yml via workflow_run in the trusted
+# base-repo context, because GitHub does not expose SONAR_TOKEN to runs
+# originating from forks.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  sonar:
+    name: SonarQube Cloud
+    if: >-
+      github.repository == 'terok-ai/terok-executor' &&
+      (github.event_name == 'push'
+       || github.event_name == 'workflow_dispatch'
+       || (github.actor != 'dependabot[bot]'
+           && github.event.pull_request.head.repo.full_name == github.repository))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Wait for Tests & Analysis on this commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deadline = Date.now() + 20 * 60 * 1000;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            const sha = context.payload.pull_request?.head.sha || context.sha;
+            while (Date.now() < deadline) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'analysis.yml',
+                head_sha: sha,
+                per_page: 5,
+              });
+              const run = data.workflow_runs[0];
+              if (run?.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.info(`Tests & Analysis succeeded for ${sha}`);
+                  return;
+                }
+                core.setFailed(`Tests & Analysis ${run.conclusion} for ${sha}`);
+                return;
+              }
+              core.info(`Tests & Analysis for ${sha}: ${run?.status ?? 'not yet started'} — waiting`);
+              await sleep(20_000);
+            }
+            core.setFailed('Timed out after 20m waiting for Tests & Analysis')
+
+      - name: Coverage artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: coverage
+          path: reports
+
+      - name: Ruff artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: ruff
+          path: reports
+
+      - name: Bandit artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: bandit
+          path: reports
+
+      - name: SonarQube Cloud scan
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -1,0 +1,95 @@
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
+# Fork pull requests cannot access SONAR_TOKEN in the original PR-triggered run.
+# This follow-up workflow runs in the base repository context, downloads only the
+# previously generated artifacts, checks out the exact PR commit, and runs Sonar
+# without re-running untrusted test commands under repository secrets.
+name: Sonar PR
+
+on:
+  workflow_run:
+    workflows: ["Tests & Analysis"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  # Restrict this workflow to fork PRs only. Same-repo PRs and pushes are
+  # handled by sonar.yml in their own event context (with SONAR_TOKEN access).
+  sonar:
+    name: SonarQube Cloud
+    if: github.repository == 'terok-ai/terok-executor' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: pr
+          path: reports/pr
+
+      - name: Load PR metadata
+        env:
+          EXPECTED_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          read -r PR_NUMBER < reports/pr/number
+          read -r PR_BASE < reports/pr/base
+          read -r PR_REF < reports/pr/ref
+          read -r PR_REPO < reports/pr/repo
+          read -r PR_SHA < reports/pr/sha
+
+          test "$PR_REPO" = "$EXPECTED_REPO"
+          test "$PR_SHA" = "$EXPECTED_SHA"
+
+          {
+            printf 'PR_NUMBER=%s\n' "$PR_NUMBER"
+            printf 'PR_BASE=%s\n' "$PR_BASE"
+            printf 'PR_REF=%s\n' "$PR_REF"
+            printf 'PR_REPO=%s\n' "$PR_REPO"
+            printf 'PR_SHA=%s\n' "$PR_SHA"
+          } >> "$GITHUB_ENV"
+
+      # Checkout happens after metadata is loaded so the workflow can analyze the PR's
+      # exact head commit while still running under the trusted base-repo workflow context.
+      - uses: actions/checkout@v6
+        with:
+          repository: ${{ env.PR_REPO }}
+          ref: ${{ env.PR_SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: coverage
+          path: reports
+
+      - uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: ruff
+          path: reports
+
+      - uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: bandit
+          path: reports
+
+      - name: SonarQube Cloud scan
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
+            -Dsonar.pullrequest.branch=${{ env.PR_REF }}
+            -Dsonar.pullrequest.base=${{ env.PR_BASE }}
+            -Dsonar.scm.revision=${{ env.PR_SHA }}


### PR DESCRIPTION
## Summary

Mirrors the cleanup landed in terok-ai/terok#930 — splits the inline `sonar` job out of `analysis.yml` so the **Tests & Analysis** workflow no longer blocks on a third-party service. Downstream consumers reuse the `coverage`/`ruff`/`bandit` artifacts already uploaded by the unit-tests/ruff/bandit jobs.

**Additionally** introduces `sonar_pr.yml` (new capability — fork PRs against `terok-executor` were previously not getting any SonarQube scan). `analysis.yml`'s `unit-tests` job was already uploading the `pr` metadata artifact in anticipation of this; the wiring is finally hooked up.

## File changes

| File | Change |
|---|---|
| `analysis.yml` | Remove the inline `sonar` job. Replace with a comment pointing at sonar.yml / sonar_pr.yml. |
| `sonar.yml` | **New.** Same-repo SonarQube scan. Triggers on push/pull_request/workflow_dispatch; polls analysis.yml run, downloads artifacts via dawidd6, runs scan. |
| `sonar_pr.yml` | **New.** Fork-PR SonarQube scan via workflow_run in the trusted base-repo context. Mirrors the existing pattern in terok-shield / terok-clearance. |
| `docs.yml` | Drops `make test-unit` in favour of `dawidd6/action-download-artifact`. Master gate waits for same-SHA Tests & Analysis run; PR builds fall back to latest-master coverage. |

## Test plan

- [ ] PR check column shows `Tests & Analysis`, `Documentation`, and `SonarQube Cloud` as separate checks.
- [ ] `Tests & Analysis` finishes faster (no longer waits on sonar).
- [ ] `Documentation` PR build falls back to latest-master coverage on first run; re-run picks up same-SHA after Tests & Analysis goes green.
- [ ] `SonarQube Cloud` on a same-repo PR waits for Tests & Analysis success, downloads artifacts, runs scan.
- [ ] After merge to master: Documentation deploys to Pages as soon as Tests & Analysis succeeds; SonarQube Cloud scans master in parallel.
- [ ] Fork PR: `sonar_pr.yml` fires via `workflow_run` after Tests & Analysis completes and reports a new SonarCloud scan (new capability — confirm SonarCloud receives the analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality scanning workflow with separated push and fork PR handling for improved analysis coverage
  * Updated documentation build process to leverage precomputed artifacts and enforce freshness contracts
  * Improved CI/CD pipeline security through pinned third-party action versions and refined permission management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/305)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->