### PR TITLE
ci(sonar): only allow workflow_dispatch from master

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -31,7 +31,7 @@ jobs:
     if: >-
       github.repository == 'terok-ai/terok-executor' &&
       (github.event_name == 'push'
-       || github.event_name == 'workflow_dispatch'
+       || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
        || (github.actor != 'dependabot[bot]'
            && github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

CodeRabbit follow-up to the recent sonar split. `sonar.yml`'s job guard accepts `workflow_dispatch` as a triggering event but doesn't restrict the ref the dispatch came from. Dispatching from a non-master ref would hang the "Wait for Tests & Analysis" poll for the full 20-minute timeout — the upstream `Tests & Analysis` workflow only fires on push to master and on pull_request, so it never produces a run keyed on a feature-branch SHA unless a PR is also open for that exact commit.

This PR scopes `workflow_dispatch` to `refs/heads/master`. The supported use case for manual sonar runs is rescanning master after a transient SonarCloud flake; dispatching from feature branches isn't useful (no artifacts to consume) and would silently waste a worker.

## Diff
```diff
-       || github.event_name == 'workflow_dispatch'
+       || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
```

## Test plan

This small PR also doubles as the first end-to-end test of the new split CI shape on this repo. Expected:

- [ ] `Tests & Analysis` (unit-tests + ruff + bandit) runs and goes green in a few minutes.
- [ ] `Documentation` waits for Tests & Analysis on this commit, then either downloads same-SHA coverage or falls back to latest-master, builds docs.
- [ ] `SonarQube Cloud` polls Tests & Analysis, downloads coverage/ruff/bandit, runs the scan, reports back to SonarCloud.
- [ ] All three appear as separate PR checks.

After merge, manual dispatches from feature branches are skipped instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)