### PR TITLE
chore(deps): bump terok-sandbox to v0.0.118; surface new VaultStatus fields

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3217,13 +3217,13 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/ter
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.117"
+version = "0.0.118"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.117-py3-none-any.whl", hash = "sha256:95ab04beedd1439e599378dcdad20623b342973027d57279f8763e86f002c8a8"},
+    {file = "terok_sandbox-0.0.118-py3-none-any.whl", hash = "sha256:129ff39814169efef0c428e66a41b909895a358de85842759f79ee30db767ae4"},
 ]
 
 [package.dependencies]
@@ -3241,7 +3241,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.117/terok_sandbox-0.0.117-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.118/terok_sandbox-0.0.118-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3659,4 +3659,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "f282300bc7e9f85a1e37a23348cccb4ba21d91f23252cbebdb1e6138e78a0d74"
+content-hash = "b4bd51cddb65f0591688975b8c060b96ca51642814c53ffdd5c2e7cad5886729"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.142"
+version = "0.0.143"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.117/terok_sandbox-0.0.117-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.118/terok_sandbox-0.0.118-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -199,6 +199,11 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
     print(f"Socket:      {status.socket_path}")
     print(f"DB:          {status.db_path}")
     print(f"Routes:      {status.routes_path} ({status.routes_configured} configured)")
+    print(f"SSH keys:    {status.ssh_keys_stored}")
+    if status.locked:
+        print("Passphrase:  (vault locked — no tier resolved)")
+    elif status.passphrase_source is not None:
+        print(f"Passphrase:  resolved via {status.passphrase_source}")
     if status.credentials_stored:
         print(f"Credentials: {_format_credentials(status, cfg)}")
     else:

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -338,6 +338,9 @@ class TestVaultCommandHandlers:
             routes_path="/data/routes.json",
             routes_configured=3,
             credentials_stored=("claude", "gh"),
+            ssh_keys_stored=0,
+            passphrase_source="keyring",
+            locked=False,
         )
         from terok_executor.credentials.vault_commands import _handle_status
 
@@ -345,6 +348,55 @@ class TestVaultCommandHandlers:
         out = capsys.readouterr().out
         assert "running" in out
         assert "claude" in out
+
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_surfaces_passphrase_source_and_ssh_key_count(
+        self, mock_status, _sd, _scan, capsys
+    ) -> None:
+        """The fields enriched by sandbox#276 round-trip into ``vault status`` output."""
+        mock_status.return_value = MagicMock(
+            mode="daemon",
+            running=True,
+            socket_path="/run/proxy.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=7,
+            passphrase_source="systemd-creds",
+            locked=False,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        out = capsys.readouterr().out
+        assert "SSH keys:    7" in out
+        assert "resolved via systemd-creds" in out
+
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_announces_locked_vault(self, mock_status, _sd, _scan, capsys) -> None:
+        """A locked vault prints an actionable hint instead of an empty source."""
+        mock_status.return_value = MagicMock(
+            mode="daemon",
+            running=True,
+            socket_path="/run/proxy.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source=None,
+            locked=True,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        out = capsys.readouterr().out
+        assert "vault locked" in out
 
     @patch("terok_sandbox.install_vault_systemd")
     @patch("terok_executor.credentials.vault_commands._ensure_routes")
@@ -411,6 +463,9 @@ class TestVaultCommandHandlers:
             routes_path="/data/routes.json",
             routes_configured=3,
             credentials_stored=("claude",),
+            ssh_keys_stored=0,
+            passphrase_source="keyring",
+            locked=False,
         )
         from terok_executor.credentials.vault_commands import _handle_status
 


### PR DESCRIPTION
Pulls in the three encrypted-vault PRs from terok-sandbox v0.0.118:

- [terok-ai/terok-sandbox#278](https://github.com/terok-ai/terok-sandbox/pull/278) VaultStatus enrichment (`ssh_keys_stored`, `passphrase_source`, `locked`)
- [terok-ai/terok-sandbox#281](https://github.com/terok-ai/terok-sandbox/pull/281) systemd-creds tier (5-tier chain, `vault seal` verb)
- [terok-ai/terok-sandbox#284](https://github.com/terok-ai/terok-sandbox/pull/284) credentials integration matrix + matrix-runner fixes

## Surface

`_handle_status` (i.e. `terok-sandbox vault status` via the executor) now prints:

```
SSH keys:    7
Passphrase:  resolved via systemd-creds
```

or when locked:

```
Passphrase:  (vault locked — no tier resolved)
```

The three new lines route through the new `VaultStatus` fields directly — no extra plumbing, just rendering.

## Test plan

- [x] `_handle_status` tests updated to set the three new fields on the `MagicMock` (default-truthy was tripping the locked branch)
- [x] new `test_status_surfaces_passphrase_source_and_ssh_key_count` and `test_status_announces_locked_vault` cover the new output paths
- [x] `make check` green except for 4 pre-existing `nft`-missing preflight failures (local env only — matrix containers install nftables)
- [x] 827 unit tests pass

## Coordinates

After this lands and `terok-executor v0.0.143` ships, terok PR D ([terok#877](https://github.com/terok-ai/terok/issues/877)) can bump both pins and build the TUI unlock modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced vault status display to show stored SSH key count and passphrase source resolution information. Status now includes a "vault locked" indicator when applicable.

* **Tests**
  * Added test coverage for enriched vault status output validation.

* **Chores**
  * Updated package version to 0.0.143 and dependency to latest compatible version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/307)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->