### PR TITLE
feat(vault): tier-knob encapsulation + unlock/lock/seal verbs + plaintext warning (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ also the "Changelog" link in PyPI metadata.
 
 [rel]: https://github.com/terok-ai/terok-executor/releases
 
+## v0.0.144 — Passphrase Handling
+
+**Full Changelog**: https://github.com/terok-ai/terok-executor/compare/v0.0.143...v0.0.144
+
 ## v0.0.143 — Trusted Platform Module
 
 ## What's Changed

--- a/poetry.lock
+++ b/poetry.lock
@@ -3222,9 +3222,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.118-py3-none-any.whl", hash = "sha256:129ff39814169efef0c428e66a41b909895a358de85842759f79ee30db767ae4"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3236,12 +3235,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.118/terok_sandbox-0.0.118-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/plaintext-passphrase-warning"
+resolved_reference = "79445c5543b3d1fa708646fe639b1cb2c470ad45"
 
 [[package]]
 name = "terok-shield"
@@ -3659,4 +3660,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "b4bd51cddb65f0591688975b8c060b96ca51642814c53ffdd5c2e7cad5886729"
+content-hash = "392386c9a70f88cdb90c96e98637c5667b2218e82a8ecd1165c4d4dfc0523708"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3217,13 +3217,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/ter
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.118"
+version = "0.0.119"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.119-py3-none-any.whl", hash = "sha256:bd24b7bf51398f752833bf3e2e9dc1ed2550c1be396013f83970321ee0f1de76"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3235,14 +3236,12 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/vault-log-improvements"
-resolved_reference = "d40c5362a888d44f4a6c14e6a4ed92afc6bec099"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.119/terok_sandbox-0.0.119-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3660,4 +3659,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "e4a200169477d80fcab66c7b441fb74e6d1d970a44eb92587a86d9b64b1ce5b8"
+content-hash = "193c81b4b71c5f34c4dc0dcf1b2da769f25f3d096f637e5fd5b50c9d81555ceb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3242,7 +3242,7 @@ terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/plaintext-passphrase-warning"
-resolved_reference = "79445c5543b3d1fa708646fe639b1cb2c470ad45"
+resolved_reference = "fc0d58cf5700b3a814a207484c14f8859bf37e7a"
 
 [[package]]
 name = "terok-shield"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3242,7 +3242,7 @@ terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/vault-log-improvements"
-resolved_reference = "9c4a211b00a5c024c1773be62493c5d3cf6b80b0"
+resolved_reference = "d40c5362a888d44f4a6c14e6a4ed92afc6bec099"
 
 [[package]]
 name = "terok-shield"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3241,8 +3241,8 @@ terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/plaintext-passphrase-warning"
-resolved_reference = "fc0d58cf5700b3a814a207484c14f8859bf37e7a"
+reference = "feat/vault-log-improvements"
+resolved_reference = "9c4a211b00a5c024c1773be62493c5d3cf6b80b0"
 
 [[package]]
 name = "terok-shield"
@@ -3660,4 +3660,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "392386c9a70f88cdb90c96e98637c5667b2218e82a8ecd1165c4d4dfc0523708"
+content-hash = "e4a200169477d80fcab66c7b441fb74e6d1d970a44eb92587a86d9b64b1ce5b8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/plaintext-passphrase-warning"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/vault-log-improvements"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.143"
+version = "0.0.144"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/vault-log-improvements"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.119/terok_sandbox-0.0.119-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.118/terok_sandbox-0.0.118-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/plaintext-passphrase-warning"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_executor/acp/roster.py
+++ b/src/terok_executor/acp/roster.py
@@ -67,22 +67,11 @@ def list_authenticated_agents(
     working agents).
     """
     cfg = SandboxConfig()
-    if db_path is None:
-        db = cfg.open_credential_db()
-    else:
-        # ``cfg.db_path`` is computed as ``vault_dir / "credentials.db"``,
-        # so a ``dataclasses.replace`` on ``vault_dir`` alone would lose
-        # an override that uses a different filename (e.g. tests).
-        # Bypass to the lower-level opener that takes an explicit path,
-        # threading the resolution-chain knobs from ``cfg``.
-        from terok_sandbox.credentials.db import open_credential_db
-
-        db = open_credential_db(
-            db_path,
-            passphrase_file=cfg.vault_passphrase_file,
-            use_keyring=cfg.credentials_use_keyring,
-            config_fallback=cfg.credentials_passphrase,
-        )
+    # ``db_path`` override exists for tests + multi-instance hosts; the
+    # cfg still owns the tier policy so this caller never has to know
+    # about the chain mechanism (session-file / systemd-creds /
+    # keyring / config).
+    db = cfg.open_credential_db(db_path)
     try:
         return list(db.list_credentials(scope))
     finally:

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -151,7 +151,6 @@ def _format_credentials(status: object, cfg: SandboxConfig | None = None) -> str
     callers that don't have one handy.
     """
     from terok_sandbox import SandboxConfig as _SandboxConfig, VaultStatus
-    from terok_sandbox.credentials.db import open_credential_db
 
     if cfg is None:
         cfg = _SandboxConfig()
@@ -159,18 +158,12 @@ def _format_credentials(status: object, cfg: SandboxConfig | None = None) -> str
     if not st.credentials_stored:
         return "none stored"
     try:
-        # Bypass ``cfg.open_credential_db`` because it computes
-        # ``vault_dir / "credentials.db"`` from the local config,
-        # which may not match the running daemon's actual ``db_path``
-        # (test fixtures and multi-instance hosts both diverge).
-        # The resolution-chain knobs still come from *cfg*.
-        db = open_credential_db(
-            st.db_path,
-            passphrase_file=cfg.vault_passphrase_file,
-            systemd_creds_file=cfg.vault_systemd_creds_file,
-            use_keyring=cfg.credentials_use_keyring,
-            config_fallback=cfg.credentials_passphrase,
-        )
+        # ``st.db_path`` is the running daemon's actual DB — may diverge
+        # from ``cfg.db_path`` under test fixtures or multi-instance
+        # hosts.  Pass it explicitly; *cfg* still owns the tier policy
+        # so this caller never has to know about session-file /
+        # systemd-creds / keyring / config.
+        db = cfg.open_credential_db(st.db_path)
         try:
             parts = []
             for name in st.credentials_stored:

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -167,6 +167,7 @@ def _format_credentials(status: object, cfg: SandboxConfig | None = None) -> str
         db = open_credential_db(
             st.db_path,
             passphrase_file=cfg.vault_passphrase_file,
+            systemd_creds_file=cfg.vault_systemd_creds_file,
             use_keyring=cfg.credentials_use_keyring,
             config_fallback=cfg.credentials_passphrase,
         )
@@ -201,8 +202,13 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
     print(f"DB:          {status.db_path}")
     print(f"Routes:      {status.routes_path} ({status.routes_configured} configured)")
     print(f"SSH keys:    {status.ssh_keys_stored}")
+    # ``Locked:`` is the operator-facing question — the chain tier
+    # ``Passphrase:`` answers WHICH tier resolved it; the explicit
+    # ``Locked:`` line answers WHETHER it resolved at all so a
+    # ``grep '^Locked:'`` is enough for scripts.
+    print(f"Locked:      {'yes' if status.locked else 'no'}")
     if status.locked:
-        print("Passphrase:  (vault locked — no tier resolved)")
+        print("Passphrase:  (no tier resolved — run `terok vault unlock`)")
     elif status.passphrase_source is not None:
         print(f"Passphrase:  resolved via {status.passphrase_source}")
     if status.credentials_stored:

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -11,6 +11,7 @@ generation from the YAML roster is performed before ``start`` and
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -290,29 +291,56 @@ def _handle_clean(*, cfg: SandboxConfig | None = None) -> None:  # noqa: ARG001
         print(f"Removed {provider}: {path}")
 
 
-VAULT_COMMANDS: tuple[CommandDef, ...] = (
-    CommandDef(name="start", help="Start the vault daemon", handler=_handle_start, group="vault"),
-    CommandDef(name="stop", help="Stop the vault daemon", handler=_handle_stop, group="vault"),
-    CommandDef(name="status", help="Show vault status", handler=_handle_status, group="vault"),
-    CommandDef(
-        name="install",
-        help="Install systemd socket activation",
-        handler=_handle_install,
-        group="vault",
-    ),
-    CommandDef(
-        name="uninstall", help="Remove systemd units", handler=_handle_uninstall, group="vault"
-    ),
-    CommandDef(
-        name="routes",
-        help="Regenerate routes.json from YAML roster",
-        handler=_handle_routes,
-        group="vault",
-    ),
-    CommandDef(
-        name="clean",
-        help="Remove leaked credential files from shared mounts",
-        handler=_handle_clean,
-        group="vault",
-    ),
-)
+#: Verbs where executor enriches the sandbox handler (leaked-credential
+#: scans, ``_ensure_routes`` before installs, typed credential listings,
+#: ``SystemExit`` on already-running).  Anything not in this map passes
+#: through from sandbox unchanged — that's how ``unlock`` / ``lock`` /
+#: ``seal`` reach ``terok vault`` without an executor-side handler.
+_HANDLER_OVERRIDES: dict[str, Callable[..., None]] = {
+    "start": _handle_start,
+    "stop": _handle_stop,
+    "status": _handle_status,
+    "install": _handle_install,
+    "uninstall": _handle_uninstall,
+}
+
+
+def _build_vault_commands() -> tuple[CommandDef, ...]:
+    """Compose ``VAULT_COMMANDS`` as an overlay over sandbox's tuple.
+
+    Sandbox owns the verb set + argparse schema (one source of truth
+    for ``--forget``, ``--key=``, help text, etc.).  Executor overlays
+    its enriched handlers for the five shared verbs and appends the
+    two executor-only verbs (``routes`` / ``clean``).  The three
+    sandbox-only verbs (``unlock`` / ``lock`` / ``seal``) flow through
+    so they surface under ``terok vault`` instead of only under
+    ``terok-sandbox vault``.
+    """
+    from dataclasses import replace
+
+    from terok_sandbox import VAULT_COMMANDS as _SANDBOX_VAULT_COMMANDS
+
+    overlaid = tuple(
+        replace(cmd, handler=_HANDLER_OVERRIDES[cmd.name])
+        if cmd.name in _HANDLER_OVERRIDES
+        else cmd
+        for cmd in _SANDBOX_VAULT_COMMANDS
+    )
+    executor_only = (
+        CommandDef(
+            name="routes",
+            help="Regenerate routes.json from YAML roster",
+            handler=_handle_routes,
+            group="vault",
+        ),
+        CommandDef(
+            name="clean",
+            help="Remove leaked credential files from shared mounts",
+            handler=_handle_clean,
+            group="vault",
+        ),
+    )
+    return overlaid + executor_only
+
+
+VAULT_COMMANDS: tuple[CommandDef, ...] = _build_vault_commands()

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -183,17 +183,26 @@ def _format_credentials(status: object, cfg: SandboxConfig | None = None) -> str
 
 def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
     """Show vault status."""
-    from terok_sandbox import get_vault_status, is_vault_systemd_available
+    from terok_sandbox import get_vault_status, is_vault_systemd_available, sanitize_tty
 
     from terok_executor.paths import mounts_dir
 
     status = get_vault_status(cfg=cfg)
     state = "running" if status.running else "stopped"
-    print(f"Mode:        {status.mode}")
+    # Path fields land in a terminal that interprets ANSI/control chars.
+    # The values originate from the vault daemon's config / live state —
+    # most installs trust those, but a malformed config layer or a
+    # manipulated systemd unit could plant control sequences that would
+    # otherwise spoof prompts or rewrite the screen.  Sanitise at the
+    # render boundary; matches what ``terok-sandbox vault status`` does.
+    print(f"Mode:        {sanitize_tty(status.mode)}")
     print(f"Status:      {state}")
-    print(f"Socket:      {status.socket_path}")
-    print(f"DB:          {status.db_path}")
-    print(f"Routes:      {status.routes_path} ({status.routes_configured} configured)")
+    print(f"Socket:      {sanitize_tty(str(status.socket_path))}")
+    print(f"DB:          {sanitize_tty(str(status.db_path))}")
+    print(
+        f"Routes:      {sanitize_tty(str(status.routes_path))}"
+        f" ({status.routes_configured} configured)"
+    )
     print(f"SSH keys:    {status.ssh_keys_stored}")
     # ``Locked:`` is the operator-facing question — the chain tier
     # ``Passphrase:`` answers WHICH tier resolved it; the explicit
@@ -233,11 +242,14 @@ def _print_plaintext_passphrase_warning(path: Path) -> None:
     ``None`` default lets the call site work against older
     ``VaultStatus`` builds that pre-date sandbox#282.
     """
+    from terok_sandbox import sanitize_tty
+
     use_color = sys.stderr.isatty()
     red = "\033[1;31m" if use_color else ""
     reset = "\033[0m" if use_color else ""
+    safe_path = sanitize_tty(str(path))
     print(
-        f"{red}WARNING: vault passphrase stored in plaintext at {path}{reset}\n"
+        f"{red}WARNING: vault passphrase stored in plaintext at {safe_path}{reset}\n"
         f"{red}         accept on-disk plaintext as your trust boundary,"
         f" or migrate to keyring/systemd-creds.{reset}",
         file=sys.stderr,

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -211,6 +211,10 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
     if not status.running and status.mode == "none" and is_vault_systemd_available():
         print("\nHint: run 'install' to set up systemd socket activation.")
 
+    plaintext_path = getattr(status, "plaintext_passphrase_path", None)
+    if plaintext_path is not None:
+        _print_plaintext_passphrase_warning(plaintext_path)
+
     leaked = scan_leaked_credentials(mounts_dir())
     if leaked:
         print("\nWARNING: Real credentials found in shared config mounts:")
@@ -218,6 +222,26 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
             print(f"  {provider}: {path}")
         print("These files are mounted into containers alongside vault phantom tokens.")
         print("Run 'clean' to remove them.")
+
+
+def _print_plaintext_passphrase_warning(path: Path) -> None:
+    """Stderr WARNING that the vault passphrase lives in plaintext on disk.
+
+    Mirrors [`terok_sandbox.commands._print_plaintext_passphrase_warning`][terok_sandbox.commands._print_plaintext_passphrase_warning]
+    so ``terok vault status`` (executor-wrapped) and ``terok-sandbox vault status``
+    surface the same operator-actionable warning.  ``getattr`` with a
+    ``None`` default lets the call site work against older
+    ``VaultStatus`` builds that pre-date sandbox#282.
+    """
+    use_color = sys.stderr.isatty()
+    red = "\033[1;31m" if use_color else ""
+    reset = "\033[0m" if use_color else ""
+    print(
+        f"{red}WARNING: vault passphrase stored in plaintext at {path}{reset}\n"
+        f"{red}         accept on-disk plaintext as your trust boundary,"
+        f" or migrate to keyring/systemd-creds.{reset}",
+        file=sys.stderr,
+    )
 
 
 def _handle_install(*, cfg: SandboxConfig | None = None) -> None:

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -319,7 +319,7 @@ def _fix_ssh_key(scope: str = "standalone") -> bool:
     from terok_sandbox import SandboxConfig, SSHManager
 
     try:
-        with SSHManager.open(scope=scope, db_path=SandboxConfig().db_path) as mgr:
+        with SSHManager.open_for_config(scope=scope, cfg=SandboxConfig()) as mgr:
             result = mgr.init()
     except Exception as exc:  # noqa: BLE001
         print(f"  SSH key generation failed: {exc}", file=sys.stderr)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -42,8 +42,13 @@ def _stub_credential_db_passphrase() -> Iterator[None]:
 
     from terok_sandbox import CredentialDB
 
-    def _open_method(self, *, prompt_on_tty: bool = False) -> CredentialDB:
-        return CredentialDB(self.db_path, passphrase=TEST_VAULT_PASSPHRASE)
+    def _open_method(
+        self, db_path: Path | None = None, *, prompt_on_tty: bool = False
+    ) -> CredentialDB:
+        return CredentialDB(
+            db_path if db_path is not None else self.db_path,
+            passphrase=TEST_VAULT_PASSPHRASE,
+        )
 
     def _open_module(db_path: Path, **_kw: object) -> CredentialDB:
         return CredentialDB(db_path, passphrase=TEST_VAULT_PASSPHRASE)

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -326,3 +326,52 @@ class TestRunPreflight:
         assert result is True
         fix_services.assert_called_once()
         mock_input.assert_not_called()
+
+
+class TestFixSshKey:
+    """``_fix_ssh_key`` provisions the gate-signing key via the new cfg seam."""
+
+    def test_success_returns_true_and_reports(self, capsys) -> None:
+        """Happy path: SSHManager opens, init succeeds, we print key + return True."""
+        from terok_executor.preflight import _fix_ssh_key
+
+        fake_mgr = MagicMock()
+        fake_mgr.init.return_value = {
+            "key_type": "ed25519",
+            "fingerprint": "abcdef0123456789" * 4,
+            "public_line": "ssh-ed25519 AAAA… proj-key",
+        }
+        # The context-manager protocol surface ``open_for_config`` uses.
+        fake_ctx = MagicMock()
+        fake_ctx.__enter__.return_value = fake_mgr
+        fake_ctx.__exit__.return_value = False
+        with patch("terok_sandbox.SSHManager.open_for_config", return_value=fake_ctx) as m_open:
+            assert _fix_ssh_key("proj") is True
+        # Sandbox seam called via the new ``open_for_config(cfg=)`` shape — not the
+        # removed ``open(db_path=…)``, which was the leaky tier-knob variant.
+        m_open.assert_called_once()
+        kwargs = m_open.call_args.kwargs
+        assert kwargs["scope"] == "proj"
+        # ``cfg`` is a SandboxConfig instance (the seam takes a config, not knobs).
+        from terok_sandbox import SandboxConfig
+
+        assert isinstance(kwargs["cfg"], SandboxConfig)
+        out = capsys.readouterr().out
+        assert "ed25519" in out
+        assert "ssh-ed25519" in out
+
+    def test_failure_prints_error_and_returns_false(self, capsys) -> None:
+        """If ``mgr.init`` raises, swallow + report on stderr + return False."""
+        from terok_executor.preflight import _fix_ssh_key
+
+        fake_mgr = MagicMock()
+        fake_mgr.init.side_effect = RuntimeError("keygen failed")
+        fake_ctx = MagicMock()
+        fake_ctx.__enter__.return_value = fake_mgr
+        fake_ctx.__exit__.return_value = False
+        with patch("terok_sandbox.SSHManager.open_for_config", return_value=fake_ctx):
+            assert _fix_ssh_key("proj") is False
+        # Operator-actionable diagnostic lands on stderr, not stdout.
+        captured = capsys.readouterr()
+        assert "keygen failed" in captured.err
+        assert "ed25519" not in captured.out

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -379,7 +379,7 @@ class TestVaultCommandHandlers:
     @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
     @patch("terok_sandbox.get_vault_status")
     def test_status_announces_locked_vault(self, mock_status, _sd, _scan, capsys) -> None:
-        """A locked vault prints an actionable hint instead of an empty source."""
+        """A locked vault prints the explicit ``Locked: yes`` line and the unlock hint."""
         mock_status.return_value = MagicMock(
             mode="daemon",
             running=True,
@@ -396,7 +396,32 @@ class TestVaultCommandHandlers:
 
         _handle_status()
         out = capsys.readouterr().out
-        assert "vault locked" in out
+        assert "Locked:      yes" in out
+        assert "vault unlock" in out
+
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_marks_unlocked_explicitly(self, mock_status, _sd, _scan, capsys) -> None:
+        """A resolved vault prints ``Locked: no`` alongside the chain-tier source."""
+        mock_status.return_value = MagicMock(
+            mode="systemd",
+            running=True,
+            socket_path="/run/proxy.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source="systemd-creds",
+            locked=False,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        out = capsys.readouterr().out
+        assert "Locked:      no" in out
+        assert "resolved via systemd-creds" in out
 
     @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
     @patch("terok_sandbox.is_vault_systemd_available", return_value=False)

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -398,6 +398,64 @@ class TestVaultCommandHandlers:
         out = capsys.readouterr().out
         assert "vault locked" in out
 
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_surfaces_plaintext_passphrase_warning(
+        self, mock_status, _sd, _scan, capsys
+    ) -> None:
+        """``plaintext_passphrase_path`` lights up a stderr WARNING (sandbox#282)."""
+        from pathlib import Path
+
+        plaintext_path = Path("/etc/terok/config.yml")
+        mock_status.return_value = MagicMock(
+            mode="systemd",
+            running=True,
+            socket_path="/run/proxy.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source="systemd-creds",
+            locked=False,
+            plaintext_passphrase_path=plaintext_path,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        captured = capsys.readouterr()
+        # Warning lives on stderr so structured stdout stays greppable.
+        assert "WARNING" in captured.err
+        assert "plaintext" in captured.err
+        assert str(plaintext_path) in captured.err
+        assert "WARNING" not in captured.out
+
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_silent_when_no_plaintext_warning(self, mock_status, _sd, _scan, capsys) -> None:
+        """Default-None case is silent — no plaintext line at all."""
+        mock_status.return_value = MagicMock(
+            mode="systemd",
+            running=True,
+            socket_path="/run/proxy.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source="systemd-creds",
+            locked=False,
+            plaintext_passphrase_path=None,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        captured = capsys.readouterr()
+        assert "plaintext" not in captured.err
+        assert "plaintext" not in captured.out
+
     @patch("terok_sandbox.install_vault_systemd")
     @patch("terok_executor.credentials.vault_commands._ensure_routes")
     @patch("terok_sandbox.is_vault_systemd_available", return_value=True)

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -921,3 +921,62 @@ class TestVaultHandlerCfgSignatures:
         for cmd in VAULT_COMMANDS:
             sig = inspect.signature(cmd.handler)
             assert "cfg" in sig.parameters, f"{cmd.handler.__name__} missing cfg param"
+
+
+class TestVaultCommandsOverlay:
+    """Executor's ``VAULT_COMMANDS`` overlays sandbox's set with enriched handlers.
+
+    Sandbox owns the verb registry and argparse schema; executor only
+    overrides the five shared verbs that need enrichment and appends
+    two executor-only verbs.  The three sandbox-only verbs (``unlock``,
+    ``lock``, ``seal``) pass through so they're visible under
+    ``terok vault`` and not just ``terok-sandbox vault``.
+    """
+
+    def test_sandbox_only_verbs_pass_through(self) -> None:
+        """``unlock`` / ``lock`` / ``seal`` are exposed without an executor handler."""
+        from terok_sandbox import VAULT_COMMANDS as SANDBOX_VAULT_COMMANDS
+
+        from terok_executor.credentials.vault_commands import VAULT_COMMANDS
+
+        by_name = {cmd.name: cmd for cmd in VAULT_COMMANDS}
+        sandbox_by_name = {cmd.name: cmd for cmd in SANDBOX_VAULT_COMMANDS}
+        for verb in ("unlock", "lock", "seal"):
+            assert verb in by_name, f"{verb} not exposed under executor vault"
+            # The handler is sandbox's — the overlay didn't replace it.
+            assert by_name[verb].handler is sandbox_by_name[verb].handler
+            # Argparse schema (``--forget`` / ``--key=``) survives the overlay.
+            assert by_name[verb].args == sandbox_by_name[verb].args
+
+    def test_shared_verbs_use_executor_handlers(self) -> None:
+        """``start`` / ``stop`` / ``status`` / ``install`` / ``uninstall`` route to executor."""
+        from terok_executor.credentials.vault_commands import (
+            VAULT_COMMANDS,
+            _handle_install,
+            _handle_start,
+            _handle_status,
+            _handle_stop,
+            _handle_uninstall,
+        )
+
+        expected = {
+            "start": _handle_start,
+            "stop": _handle_stop,
+            "status": _handle_status,
+            "install": _handle_install,
+            "uninstall": _handle_uninstall,
+        }
+        by_name = {cmd.name: cmd for cmd in VAULT_COMMANDS}
+        for verb, handler in expected.items():
+            assert by_name[verb].handler is handler, f"{verb} should use executor handler"
+
+    def test_executor_only_verbs_appended(self) -> None:
+        """``routes`` and ``clean`` exist in executor's set but not sandbox's."""
+        from terok_sandbox import VAULT_COMMANDS as SANDBOX_VAULT_COMMANDS
+
+        from terok_executor.credentials.vault_commands import VAULT_COMMANDS
+
+        executor_names = {cmd.name for cmd in VAULT_COMMANDS}
+        sandbox_names = {cmd.name for cmd in SANDBOX_VAULT_COMMANDS}
+        executor_only = executor_names - sandbox_names
+        assert executor_only == {"routes", "clean"}


### PR DESCRIPTION
## Summary

Three vault-surface improvements bundled — all aimed at making
sandbox the single source of truth for the passphrase-resolver chain
so cross-package releases stay cheap pre-PyPI.

### 1. ``VAULT_COMMANDS`` overlay — ``terok vault unlock`` is real

Executor maintained its own ``VAULT_COMMANDS`` tuple in parallel with
sandbox's, so the unlock/lock/seal verbs that sandbox v0.0.117 +
v0.0.118 added never reached ``terok vault`` and the docs that
promised ``terok vault unlock`` pointed at a missing verb.

Rebuilt ``VAULT_COMMANDS`` as an overlay over sandbox's tuple:
sandbox owns the registry + argparse schema, executor only overrides
the five shared verbs that need enrichment (``status``, ``start``,
``stop``, ``install``, ``uninstall``) and appends two executor-only
verbs (``routes``, ``clean``).  Sandbox-only verbs flow through ⇒
``terok vault unlock`` / ``vault lock [--forget]`` / ``vault seal
[--key=…]`` are now reachable under the top-level CLI.

### 2. ``Locked: yes|no`` + plaintext-passphrase warning in ``vault status``

- Picks up the new ``VaultStatus.plaintext_passphrase_path`` from
  the sandbox half of the #282 chain.  Stderr WARNING when configured
  (matching terok-sandbox's local rendering).
- New explicit ``Locked: yes|no`` line so ``grep '^Locked:'`` is
  enough for scripts.

### 3. Tier-knob encapsulation refactor (terok-ai/terok-sandbox#289)

Three executor sites previously re-threaded chain-tier kwargs
(``passphrase_file`` / ``systemd_creds_file`` / ``use_keyring`` /
``config_fallback``) whenever they opened the credentials DB at a
non-default ``db_path``.  Net result: two latent
missing-``systemd_creds_file`` bugs and one missing-all-knobs bug.

Adopts sandbox's new ``cfg.open_credential_db(db_path)`` seam:

- ``vault_commands._format_credentials_typed`` — knobs gone; the
  fix from this PR's earlier commit becomes structural.
- ``acp/roster.py`` — same shape, same latent bug, fixed.
- ``preflight.py`` — switch from the removed
  ``SSHManager.open(scope=, db_path=, …)`` (which dropped *all*
  tier knobs) to ``SSHManager.open_for_config(scope=, cfg=)``.
  Net bug fix for hosts with non-default tier setup.

After this, adding a new chain tier (sandbox#283
``passphrase_command``, etc.) is a sandbox-only change — zero
executor / terok cooperation needed.

## Cross-repo chain

- terok-ai/terok-sandbox#289 — sandbox-side refactor + log
  improvements (required)
- **this PR** — executor wires the verbs through, renders the
  warning, adopts the new sandbox seam
- terok-ai/terok#939 — TUI render + Vault-screen actions
  (depends on this tip)

Sandbox pin temporarily tracks
``sliwowitz:feat/vault-log-improvements``; flips to the released
wheel when the sandbox half merges.

## Test plan

- [x] ``make lint`` clean
- [x] ``make tach`` clean
- [x] ``make docstrings`` ≥ 95%
- [x] ``make security`` — 0 Medium / 0 High
- [x] ``poetry run pytest tests/`` — 820 passed (4 pre-existing
      preflight ``nft``-missing failures unrelated, confirmed
      against ``upstream/master``)
- [x] New tests: ``TestVaultCommandsOverlay`` (3 cases),
      ``test_status_surfaces_plaintext_passphrase_warning``,
      ``test_status_silent_when_no_plaintext_warning``,
      ``test_status_announces_locked_vault``,
      ``test_status_marks_unlocked_explicitly``
- [ ] Manual: ``terok vault --help`` lists ``unlock`` / ``lock`` /
      ``seal`` under the vault group
- [ ] Manual: ``terok vault status`` shows ``Locked: no`` line +
      plaintext WARNING on stderr when configured
- [ ] Manual: after removing keyring + reboot, no
      ``Warning [vault]: credential type lookup failed; showing
      names only`` (refactor wires the systemd-creds tier through
      structurally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vault status command now displays structured output format for scripting.
  * Added plaintext passphrase warnings when plaintext credentials are detected.

* **Tests**
  * Added test coverage for vault status output formatting and warnings.
  * Added test suite for SSH key generation handling.

* **Chores**
  * Updated dependency source configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/309)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->