### PR TITLE
refactor: adopt canonical vault.{store,ssh}.* paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ also the "Changelog" link in PyPI metadata.
 
 [rel]: https://github.com/terok-ai/terok-executor/releases
 
+## v0.0.145 — Sandbox API restructure
+
+## What's Changed
+* refactor: adopt canonical vault.{store,ssh}.* paths in https://github.com/terok-ai/terok-executor/pull/310
+
+**Full Changelog**: https://github.com/terok-ai/terok-executor/compare/v0.0.144...v0.0.145
+
 ## v0.0.144 — Passphrase Handling
 
 **Full Changelog**: https://github.com/terok-ai/terok-executor/compare/v0.0.143...v0.0.144

--- a/poetry.lock
+++ b/poetry.lock
@@ -3222,9 +3222,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.119-py3-none-any.whl", hash = "sha256:bd24b7bf51398f752833bf3e2e9dc1ed2550c1be396013f83970321ee0f1de76"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3236,12 +3235,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.119/terok_sandbox-0.0.119-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "refactor/drop-back-compat-shims"
+resolved_reference = "13b0c13c99570dfe5f2f14ee995f716eaeb048b4"
 
 [[package]]
 name = "terok-shield"
@@ -3659,4 +3660,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "193c81b4b71c5f34c4dc0dcf1b2da769f25f3d096f637e5fd5b50c9d81555ceb"
+content-hash = "961e6e246bbe8f4f1d7366ee4909997955dab476df423e47a22b6085ec94582f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3217,13 +3217,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/ter
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.119"
+version = "0.0.120"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.120-py3-none-any.whl", hash = "sha256:d0e247573ff522577290817580f0fc7c09991b3538242c4d1f79053abd814a7d"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3235,14 +3236,12 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "refactor/drop-back-compat-shims"
-resolved_reference = "13b0c13c99570dfe5f2f14ee995f716eaeb048b4"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.120/terok_sandbox-0.0.120-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3660,4 +3659,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "961e6e246bbe8f4f1d7366ee4909997955dab476df423e47a22b6085ec94582f"
+content-hash = "6c8f74a3462a6770de1775ba46d97229b24c29e924ece90b31b72197baab0f23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.119/terok_sandbox-0.0.119-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "refactor/drop-back-compat-shims"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.144"
+version = "0.0.145"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "refactor/drop-back-compat-shims"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.120/terok_sandbox-0.0.120-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,6 +55,6 @@ def _stub_credential_db_passphrase() -> Iterator[None]:
 
     with (
         patch("terok_sandbox.config.SandboxConfig.open_credential_db", new=_open_method),
-        patch("terok_sandbox.credentials.db.open_credential_db", new=_open_module),
+        patch("terok_sandbox.vault.store.db.open_credential_db", new=_open_module),
     ):
         yield

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -48,8 +48,8 @@ def _make_vault_db(tmp_path: Path, cred_name: str = "claude", cred_data: dict | 
 
 def _make_vault_db_with_ssh_keys(tmp_path: Path, scope: str = "myproj"):
     """Return a SandboxConfig with credential DB seeded with a key assigned to *scope*."""
-    from terok_sandbox.credentials.db import CredentialDB
-    from terok_sandbox.credentials.ssh_keypair import generate_keypair
+    from terok_sandbox.vault.ssh.keypair import generate_keypair
+    from terok_sandbox.vault.store.db import CredentialDB
 
     cfg = _make_vault_db(tmp_path)
     cfg.vault_dir.mkdir(parents=True, exist_ok=True)
@@ -662,7 +662,7 @@ class TestVaultTokenInjection:
     def test_vault_ssh_only_no_provider_creds(self, workspace, envs_dir, roster, tmp_path):
         """SSH signer token injected even when no provider credentials are stored."""
         from terok_sandbox import CredentialDB, SandboxConfig
-        from terok_sandbox.credentials.ssh_keypair import generate_keypair
+        from terok_sandbox.vault.ssh.keypair import generate_keypair
 
         cfg = SandboxConfig(state_dir=tmp_path, vault_dir=tmp_path / "credentials")
         cfg.db_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

terok-sandbox merged the vault/credentials directory unification
(sandbox#292) and the back-compat shims are coming out via
[\`sliwowitz/terok-sandbox:refactor/drop-back-compat-shims\`](https://github.com/terok-ai/terok-sandbox/pull/293).
Update terok-executor to import via the canonical paths before the
shims disappear.

## Changes

- \`pyproject.toml\`: re-pin terok-sandbox at the matching sandbox PR
  branch for the merge window.  Re-pinned to the released v0.0.120
  wheel once the chain merges.
- Two test files updated to canonical paths:
  - \`terok_sandbox.credentials.db\` → \`terok_sandbox.vault.store.db\`
  - \`terok_sandbox.credentials.ssh_keypair\` → \`terok_sandbox.vault.ssh.keypair\`

That's it — source code never imported via the legacy paths.

## Coordination

Middle link of a three-PR chain:

1. [\`sliwowitz/terok-sandbox:refactor/drop-back-compat-shims\`](https://github.com/terok-ai/terok-sandbox/pull/293) (foundation)
2. **this PR** (executor adopts canonical paths)
3. [\`sliwowitz/terok:refactor/canonical-vault-paths\`](https://github.com/terok-ai/terok/pulls) (orchestrator does the same)

Merge order: sandbox → executor → terok.

## Test plan

- [x] \`make check\` green (lint, unit tests, tach, docstring coverage,
      reuse, security)
- [x] \`properdocs build --strict\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package to v0.0.145 and updated sandbox dependency to the matching release artifact.
* **Tests**
  * Adjusted test setup to align with reorganized internal vault modules.
* **Documentation**
  * Added changelog entry describing the sandbox API restructure and canonical vault path changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/310)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->