### PR TITLE
feat(cli): adopt sandbox CommandTree; expose sandbox via deep nesting + shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ also the "Changelog" link in PyPI metadata.
 
 [rel]: https://github.com/terok-ai/terok-executor/releases
 
+## v0.0.146 — The Tree of Command
+
+## What's Changed
+* feat(cli): adopt sandbox CommandTree; expose sandbox via deep nesting + shortcut in https://github.com/terok-ai/terok-executor/pull/311
+* chore: refresh virtualenv + python-discovery in poetry.lock by @sliwowitz in https://github.com/terok-ai/terok-executor/pull/312
+
+
+**Full Changelog**: https://github.com/terok-ai/terok-executor/compare/v0.0.145...v0.0.146
+
 ## v0.0.145 — Sandbox API restructure
 
 ## What's Changed

--- a/poetry.lock
+++ b/poetry.lock
@@ -3222,9 +3222,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.120-py3-none-any.whl", hash = "sha256:d0e247573ff522577290817580f0fc7c09991b3538242c4d1f79053abd814a7d"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3236,12 +3235,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.120/terok_sandbox-0.0.120-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/command-tree"
+resolved_reference = "c1e672b7045c01f4832798b9847c0d9b0603bb1b"
 
 [[package]]
 name = "terok-shield"
@@ -3659,4 +3660,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "6c8f74a3462a6770de1775ba46d97229b24c29e924ece90b31b72197baab0f23"
+content-hash = "2b3fd386a91e1aeff484e41a7a3c4c5abeec7b28adde328eec86c409a91be855"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3197,34 +3197,34 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.11"
+version = "0.6.12"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_clearance-0.6.12-py3-none-any.whl", hash = "sha256:06196e96463288272a4c0718e588d394ebc50f87d39c444fc2b10e18bf72c2f6"},
+]
 
 [package.dependencies]
-asyncvarlink = "^0.3.1"
+asyncvarlink = ">=0.3.1,<0.4.0"
 dbus-fast = ">=2.0,<5.0"
-pyyaml = "^6.0"
+pyyaml = ">=6.0,<7.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-clearance.git"
-reference = "feat/command-def-children"
-resolved_reference = "27866ad9cdf73258b9a03836b83eca57264ec65a"
+type = "url"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.12/terok_clearance-0.6.12-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.120"
+version = "0.0.121"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.121-py3-none-any.whl", hash = "sha256:0a3003c7627b4864ac5c6b008f4a5057d78f96484c0413c3a0baef7bcdf92ceb"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3236,34 +3236,31 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/command-def-children"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/command-def-children"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.12/terok_clearance-0.6.12-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.40/terok_shield-0.6.40-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/command-tree"
-resolved_reference = "b43224f753eca7b243f079d5ca1e9238326bba7f"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.121/terok_sandbox-0.0.121-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.39"
+version = "0.6.40"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_shield-0.6.40-py3-none-any.whl", hash = "sha256:d10b84da6f583bb4dcb6b717e44edce5bba2bfe436a743eb9b1ee98654b9746e"},
+]
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-shield.git"
-reference = "feat/command-def-children"
-resolved_reference = "e02631178c03f917b666a1041296e97e423a5a6d"
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.40/terok_shield-0.6.40-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -3662,4 +3659,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "2b3fd386a91e1aeff484e41a7a3c4c5abeec7b28adde328eec86c409a91be855"
+content-hash = "06115dfb30241835ae322911613394eabccd5832887381f9cc6a9d454cbecea9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3202,18 +3202,19 @@ description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_clearance-0.6.11-py3-none-any.whl", hash = "sha256:eba3d21ff03a6ca927ce0fffa655a9602f0bb2a2920af751483d27eed272e935"},
-]
+files = []
+develop = false
 
 [package.dependencies]
-asyncvarlink = ">=0.3.1,<0.4.0"
+asyncvarlink = "^0.3.1"
 dbus-fast = ">=2.0,<5.0"
-pyyaml = ">=6.0,<7.0"
+pyyaml = "^6.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-clearance.git"
+reference = "feat/command-def-children"
+resolved_reference = "27866ad9cdf73258b9a03836b83eca57264ec65a"
 
 [[package]]
 name = "terok-sandbox"
@@ -3235,14 +3236,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/command-def-children"}
+terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/command-def-children"}
 
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/command-tree"
-resolved_reference = "c1e672b7045c01f4832798b9847c0d9b0603bb1b"
+resolved_reference = "b43224f753eca7b243f079d5ca1e9238326bba7f"
 
 [[package]]
 name = "terok-shield"
@@ -3251,17 +3252,18 @@ description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_shield-0.6.39-py3-none-any.whl", hash = "sha256:eb90c9b50d7ac688d95136318c2cb8b530bed65616d4d04d084b99d7d527a310"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-shield.git"
+reference = "feat/command-def-children"
+resolved_reference = "e02631178c03f917b666a1041296e97e423a5a6d"
 
 [[package]]
 name = "tomli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.120/terok_sandbox-0.0.120-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/command-tree"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.145"
+version = "0.0.146"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/command-tree"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.121/terok_sandbox-0.0.121-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -40,6 +40,7 @@ from .acp import (
 )
 
 # -- Commands + CLI surface ----------------------------------------------------
+from .cli import COMMANDS
 from .commands import COMMANDS as AGENT_COMMANDS, CommandDef
 
 # -- Config schema (executor-owned slice of the shared config.yml) -----------
@@ -216,6 +217,7 @@ __all__ = [
     "parse_agent_selection",
     # Command registry
     "AGENT_COMMANDS",
+    "COMMANDS",
     "VAULT_COMMANDS",
     "CommandDef",
     "mounts_dir",

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -28,6 +28,9 @@ except PackageNotFoundError:
 from terok_sandbox import ConfigScope, ConfigStack
 from terok_sandbox.doctor import CheckVerdict, DoctorCheck
 
+# -- Commands + CLI surface ----------------------------------------------------
+from ._tree import COMMANDS
+
 # -- ACP host-proxy (per-task multi-agent aggregator) -------------------------
 from .acp import (
     ACPEndpointStatus,
@@ -38,9 +41,6 @@ from .acp import (
     acp_socket_is_live,
     list_authenticated_agents,
 )
-
-# -- Commands + CLI surface ----------------------------------------------------
-from .cli import COMMANDS
 from .commands import COMMANDS as AGENT_COMMANDS, CommandDef
 
 # -- Config schema (executor-owned slice of the shared config.yml) -----------

--- a/src/terok_executor/_tree.py
+++ b/src/terok_executor/_tree.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composes executor's full [`CommandTree`][terok_sandbox.commands.CommandTree].
+
+Lives below the CLI surface so the package init can re-export the
+composed tree as ``terok_executor.COMMANDS`` (the cli module is at
+the top of the dependency graph; nothing below it may import it).
+
+Three views over one underlying ``SANDBOX_TREE`` instance:
+
+- ``terok-executor <own-verb>``        — executor's verbs (run, auth, …)
+- ``terok-executor sandbox <verb>``    — full sandbox tree, deep path
+- ``terok-executor vault <verb>``      — shortcut sharing identity with
+  the corresponding subtree under ``sandbox``
+"""
+
+from __future__ import annotations
+
+from terok_sandbox.commands import CommandDef, CommandTree
+
+from .commands import COMMANDS as OWN_COMMANDS
+from .credentials.vault_commands import SANDBOX_TREE, VAULT_COMMANDS
+
+#: Executor's top-level command tree.  See module docstring.
+COMMANDS: CommandTree = CommandTree(
+    OWN_COMMANDS
+    + (
+        CommandDef(
+            name="sandbox",
+            help="Sandbox subsystem (full deep tree — same verbs as terok-sandbox)",
+            children=SANDBOX_TREE.roots,
+        ),
+    )
+    + VAULT_COMMANDS
+)
+
+
+__all__ = ["COMMANDS"]

--- a/src/terok_executor/cli.py
+++ b/src/terok_executor/cli.py
@@ -4,18 +4,32 @@
 
 """CLI entry point for terok-executor.
 
-Built from the command registry in [`terok_executor.commands`][terok_executor.commands].
-No command logic lives here — just argument wiring and dispatch.
+Composes executor's own commands with sandbox's full tree (via
+:data:`terok_executor.credentials.vault_commands.SANDBOX_TREE`) into a
+single [`CommandTree`][terok_sandbox.commands.CommandTree], exposed
+two ways:
+
+- *Deep path* — ``terok-executor sandbox <verb>`` reaches every
+  sandbox verb verbatim, with executor's overlays applied where they
+  exist (e.g. vault).
+- *Shortcuts* — ``terok-executor vault <verb>`` resolves to the same
+  ``CommandDef`` instance as ``terok-executor sandbox vault <verb>``,
+  so wraps applied at one entry point apply at the other.
+
+[`CommandTree.wire`][terok_sandbox.commands.CommandTree.wire] /
+[`CommandTree.dispatch`][terok_sandbox.commands.CommandTree.dispatch]
+do all the argparse plumbing.
 """
 
 from __future__ import annotations
 
 import argparse
 from importlib.metadata import PackageNotFoundError, version as _meta_version
-from typing import Any
 
-from .commands import COMMANDS, ArgDef, CommandDef
-from .credentials.vault_commands import VAULT_COMMANDS
+from terok_sandbox.commands import CommandDef, CommandTree
+
+from .commands import COMMANDS as OWN_COMMANDS
+from .credentials.vault_commands import SANDBOX_TREE, VAULT_COMMANDS
 
 try:
     __version__ = _meta_version("terok-executor")
@@ -23,7 +37,23 @@ except PackageNotFoundError:
     __version__ = "0.0.0"
 
 
-# ── Public entry point ──────────────────────────────────────────────────
+#: Executor's top-level command tree.  Composed of:
+#:
+#: - executor's own verbs (``run``, ``run-tool``, ``auth``, …),
+#: - a ``sandbox`` deep-path group exposing the full sandbox tree,
+#: - sandbox shortcuts (``vault``) that share ``CommandDef`` identity
+#:   with the corresponding subtree under ``sandbox``.
+COMMANDS: CommandTree = CommandTree(
+    OWN_COMMANDS
+    + (
+        CommandDef(
+            name="sandbox",
+            help="Sandbox subsystem (full deep tree — same verbs as terok-sandbox)",
+            children=SANDBOX_TREE.roots,
+        ),
+    )
+    + VAULT_COMMANDS
+)
 
 
 def main() -> None:
@@ -33,72 +63,16 @@ def main() -> None:
         description="Single-agent task runner for hardened Podman containers",
     )
     parser.add_argument("--version", action="version", version=f"terok-executor {__version__}")
-    sub = parser.add_subparsers()
-
-    for cmd in COMMANDS:
-        _wire_command(sub, cmd)
-
-    # -- vault --
-    vault_p = sub.add_parser("vault", help="Vault management")
-    vault_sub = vault_p.add_subparsers()
-    for vault_cmd in VAULT_COMMANDS:
-        _wire_command(vault_sub, vault_cmd)
-    vault_p.set_defaults(_group_help=vault_p)
+    COMMANDS.wire(parser)
 
     args = parser.parse_args()
     if hasattr(args, "_cmd"):
-        _dispatch(args)
+        CommandTree.dispatch(args)
     elif hasattr(args, "_group_help"):
         args._group_help.print_help()
     else:
         parser.print_help()
         raise SystemExit(1)
-
-
-# ── Private helpers ─────────────────────────────────────────────────────
-
-
-def _wire_command(sub: argparse._SubParsersAction, cmd: Any) -> None:
-    """Add a [`CommandDef`][terok_executor.cli.CommandDef] to an argparse subparser group.
-
-    ``cmd`` is intentionally ``Any``: this wires both
-    :data:`terok_executor.COMMANDS` (`terok_executor.commands.CommandDef`)
-    and :data:`VAULT_COMMANDS` (`terok_sandbox.commands.CommandDef`); the
-    two have identical structural shapes but mypy treats them as distinct
-    nominal types.  The Protocol surface lives in the duck-typed reads
-    below (``cmd.name`` / ``cmd.args`` / ``arg.dest`` / …).
-    """
-    p = sub.add_parser(cmd.name, help=cmd.help)
-    for arg in cmd.args:
-        kwargs: dict = {}
-        if arg.help:
-            kwargs["help"] = arg.help
-        if arg.type is not None:
-            kwargs["type"] = arg.type
-        if arg.default is not None:
-            kwargs["default"] = arg.default
-        if arg.action is not None:
-            kwargs["action"] = arg.action
-        if arg.dest is not None:
-            kwargs["dest"] = arg.dest
-        if arg.nargs is not None:
-            kwargs["nargs"] = arg.nargs
-        p.add_argument(arg.name, **kwargs)
-    p.set_defaults(_cmd=cmd)
-
-
-def _arg_key(arg: ArgDef) -> str:
-    """Derive the kwarg name for an argument definition."""
-    return arg.dest or arg.name.lstrip("-").replace("-", "_")
-
-
-def _dispatch(args: argparse.Namespace) -> None:
-    """Extract handler kwargs from parsed args and call the handler."""
-    cmd: CommandDef = args._cmd
-    if cmd.handler is None:
-        raise SystemExit(f"Command '{cmd.name}' has no handler")
-    kwargs = {_arg_key(arg): getattr(args, _arg_key(arg), arg.default) for arg in cmd.args}
-    cmd.handler(**kwargs)
 
 
 if __name__ == "__main__":

--- a/src/terok_executor/cli.py
+++ b/src/terok_executor/cli.py
@@ -5,9 +5,9 @@
 """CLI entry point for terok-executor.
 
 Composes executor's own commands with sandbox's full tree (via
-:data:`terok_executor.credentials.vault_commands.SANDBOX_TREE`) into a
-single [`CommandTree`][terok_sandbox.commands.CommandTree], exposed
-two ways:
+[`SANDBOX_TREE`][terok_executor.credentials.vault_commands.SANDBOX_TREE])
+into a single
+[`CommandTree`][terok_sandbox.commands.CommandTree], exposed two ways:
 
 - *Deep path* — ``terok-executor sandbox <verb>`` reaches every
   sandbox verb verbatim, with executor's overlays applied where they
@@ -26,34 +26,14 @@ from __future__ import annotations
 import argparse
 from importlib.metadata import PackageNotFoundError, version as _meta_version
 
-from terok_sandbox.commands import CommandDef, CommandTree
+from terok_sandbox.commands import CommandTree
 
-from .commands import COMMANDS as OWN_COMMANDS
-from .credentials.vault_commands import SANDBOX_TREE, VAULT_COMMANDS
+from ._tree import COMMANDS
 
 try:
     __version__ = _meta_version("terok-executor")
 except PackageNotFoundError:
     __version__ = "0.0.0"
-
-
-#: Executor's top-level command tree.  Composed of:
-#:
-#: - executor's own verbs (``run``, ``run-tool``, ``auth``, …),
-#: - a ``sandbox`` deep-path group exposing the full sandbox tree,
-#: - sandbox shortcuts (``vault``) that share ``CommandDef`` identity
-#:   with the corresponding subtree under ``sandbox``.
-COMMANDS: CommandTree = CommandTree(
-    OWN_COMMANDS
-    + (
-        CommandDef(
-            name="sandbox",
-            help="Sandbox subsystem (full deep tree — same verbs as terok-sandbox)",
-            children=SANDBOX_TREE.roots,
-        ),
-    )
-    + VAULT_COMMANDS
-)
 
 
 def main() -> None:

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -3,47 +3,28 @@
 
 """Catalog of every ``terok-executor`` subcommand and its handler.
 
-The ``COMMANDS`` tuple at the bottom is the authoritative registry;
+The ``COMMANDS`` tree at the bottom is the authoritative registry;
 higher-level frontends (``terok``) import it to wire the same commands
 into their own CLI without duplicating argument definitions.
+
+[`CommandDef`][terok_sandbox.commands.CommandDef] /
+[`ArgDef`][terok_sandbox.commands.ArgDef] /
+[`CommandTree`][terok_sandbox.commands.CommandTree] are imported from
+terok-sandbox so the whole stack shares one vocabulary — adding new
+verbs in sandbox flows into executor's tree automatically without an
+overlay update.
 """
 
 from __future__ import annotations
 
 import subprocess
-from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from terok_sandbox.commands import ArgDef, CommandDef
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-
-# ── Vocabulary ──
-
-
-@dataclass(frozen=True)
-class ArgDef:
-    """Definition of a single CLI argument."""
-
-    name: str
-    help: str = ""
-    type: Callable[[str], Any] | None = None
-    default: Any = None
-    action: str | None = None
-    dest: str | None = None
-    nargs: int | str | None = None
-
-
-@dataclass(frozen=True)
-class CommandDef:
-    """Definition of a terok-executor subcommand."""
-
-    name: str
-    help: str = ""
-    handler: Callable[..., None] | None = None
-    args: tuple[ArgDef, ...] = ()
-    group: str = ""
 
 
 # ── Handlers ──

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from terok_sandbox import CommandDef
+from terok_sandbox.commands import CommandTree
 
 if TYPE_CHECKING:
     from terok_sandbox import SandboxConfig
@@ -302,56 +303,65 @@ def _handle_clean(*, cfg: SandboxConfig | None = None) -> None:  # noqa: ARG001
         print(f"Removed {provider}: {path}")
 
 
-#: Verbs where executor enriches the sandbox handler (leaked-credential
-#: scans, ``_ensure_routes`` before installs, typed credential listings,
-#: ``SystemExit`` on already-running).  Anything not in this map passes
-#: through from sandbox unchanged — that's how ``unlock`` / ``lock`` /
-#: ``seal`` reach ``terok vault`` without an executor-side handler.
-_HANDLER_OVERRIDES: dict[str, Callable[..., None]] = {
-    "start": _handle_start,
-    "stop": _handle_stop,
-    "status": _handle_status,
-    "install": _handle_install,
-    "uninstall": _handle_uninstall,
+#: Paths into sandbox's vault subtree where executor swaps in enriched
+#: handlers — leaked-credential scans, ``_ensure_routes`` before
+#: installs, typed credential listings, ``SystemExit`` on already-
+#: running.  Anything not in this map (``unlock`` / ``lock`` /
+#: ``passphrase {seal,to-keyring,destroy}``) flows through unchanged —
+#: that's how new sandbox verbs reach ``terok vault`` zero-edit.
+_VAULT_OVERRIDES: dict[tuple[str, ...], Callable[..., None]] = {
+    ("vault", "start"): _handle_start,
+    ("vault", "stop"): _handle_stop,
+    ("vault", "status"): _handle_status,
+    ("vault", "install"): _handle_install,
+    ("vault", "uninstall"): _handle_uninstall,
 }
 
 
-def _build_vault_commands() -> tuple[CommandDef, ...]:
-    """Compose ``VAULT_COMMANDS`` as an overlay over sandbox's tuple.
+def _build_sandbox_tree() -> CommandTree:
+    """Apply executor's overlays + extensions to sandbox's full command tree.
 
     Sandbox owns the verb set + argparse schema (one source of truth
-    for ``--forget``, ``--key=``, help text, etc.).  Executor overlays
-    its enriched handlers for the five shared verbs and appends the
-    two executor-only verbs (``routes`` / ``clean``).  The three
-    sandbox-only verbs (``unlock`` / ``lock`` / ``seal``) flow through
-    so they surface under ``terok vault`` instead of only under
-    ``terok-sandbox vault``.
+    for ``--key=``, help text, structural nesting of ``vault
+    passphrase``).  Executor overlays its enriched vault handlers at
+    the five paths in :data:`_VAULT_OVERRIDES` and extends the vault
+    subtree with two executor-only verbs (``routes`` / ``clean``).
+    Identity is preserved for every untouched node so a downstream
+    shortcut that splices the same subtree (terok's ``vault`` at
+    top-level) shares the wrap with the deep ``terok executor sandbox
+    vault`` path automatically.
     """
-    from dataclasses import replace
+    from terok_sandbox.commands import COMMANDS as SANDBOX_COMMANDS
 
-    from terok_sandbox import VAULT_COMMANDS as _SANDBOX_VAULT_COMMANDS
-
-    overlaid = tuple(
-        replace(cmd, handler=_HANDLER_OVERRIDES[cmd.name])
-        if cmd.name in _HANDLER_OVERRIDES
-        else cmd
-        for cmd in _SANDBOX_VAULT_COMMANDS
-    )
-    executor_only = (
-        CommandDef(
-            name="routes",
-            help="Regenerate routes.json from YAML roster",
-            handler=_handle_routes,
-            group="vault",
-        ),
-        CommandDef(
-            name="clean",
-            help="Remove leaked credential files from shared mounts",
-            handler=_handle_clean,
-            group="vault",
+    return SANDBOX_COMMANDS.overlay(_VAULT_OVERRIDES).extend_at(
+        ("vault",),
+        (
+            CommandDef(
+                name="routes",
+                help="Regenerate routes.json from YAML roster",
+                handler=_handle_routes,
+            ),
+            CommandDef(
+                name="clean",
+                help="Remove leaked credential files from shared mounts",
+                handler=_handle_clean,
+            ),
         ),
     )
-    return overlaid + executor_only
 
 
-VAULT_COMMANDS: tuple[CommandDef, ...] = _build_vault_commands()
+#: Sandbox's full command tree with executor's overlays + extensions applied.
+#: Wired in two positions of executor's CLI: under ``terok-executor sandbox``
+#: (the full deep path) and selected subtrees promoted to top level as
+#: shortcuts.  Both positions share ``CommandDef`` identity so wraps
+#: applied here propagate through every entry point that references the
+#: same node.
+SANDBOX_TREE: CommandTree = _build_sandbox_tree()
+
+
+#: Sandbox's vault group with executor's overlays applied — a 1-tuple
+#: containing the modified vault ``CommandDef``.  Surfaced at executor's
+#: top level as the ``terok-executor vault …`` shortcut; the same
+#: ``CommandDef`` instance also reaches ``terok-executor sandbox vault …``
+#: via :data:`SANDBOX_TREE`.
+VAULT_COMMANDS: tuple[CommandDef, ...] = (SANDBOX_TREE.find_at(("vault",)),)

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -324,8 +324,10 @@ def _build_sandbox_tree() -> CommandTree:
     Sandbox owns the verb set + argparse schema (one source of truth
     for ``--key=``, help text, structural nesting of ``vault
     passphrase``).  Executor overlays its enriched vault handlers at
-    the five paths in :data:`_VAULT_OVERRIDES` and extends the vault
-    subtree with two executor-only verbs (``routes`` / ``clean``).
+    the five paths in
+    [`_VAULT_OVERRIDES`][terok_executor.credentials.vault_commands._VAULT_OVERRIDES]
+    and extends the vault subtree with two executor-only verbs
+    (``routes`` / ``clean``).
     Identity is preserved for every untouched node so a downstream
     shortcut that splices the same subtree (terok's ``vault`` at
     top-level) shares the wrap with the deep ``terok executor sandbox
@@ -363,5 +365,5 @@ SANDBOX_TREE: CommandTree = _build_sandbox_tree()
 #: containing the modified vault ``CommandDef``.  Surfaced at executor's
 #: top level as the ``terok-executor vault …`` shortcut; the same
 #: ``CommandDef`` instance also reaches ``terok-executor sandbox vault …``
-#: via :data:`SANDBOX_TREE`.
+#: via [`SANDBOX_TREE`][terok_executor.credentials.vault_commands.SANDBOX_TREE].
 VAULT_COMMANDS: tuple[CommandDef, ...] = (SANDBOX_TREE.find_at(("vault",)),)

--- a/tach.toml
+++ b/tach.toml
@@ -256,12 +256,22 @@ depends_on = [
     "terok_executor.sandbox",
 ]
 
+# Composes the full executor CommandTree (own verbs + sandbox deep
+# path + shortcuts).  Lives below cli.py so the package init can
+# re-export the tree as a public symbol — cli.py is at the top of the
+# dep graph and nothing else may import it.
+[[modules]]
+path = "terok_executor._tree"
+depends_on = [
+    "terok_executor.commands",
+    "terok_executor.credentials.vault_commands",
+]
+
 # CLI entry point — wires command registry to argparse
 [[modules]]
 path = "terok_executor.cli"
 depends_on = [
-    "terok_executor.commands",
-    "terok_executor.credentials.vault_commands",
+    "terok_executor._tree",
 ]
 
 # Agent-level container health checks
@@ -275,6 +285,7 @@ depends_on = [
 [[modules]]
 path = "terok_executor"
 depends_on = [
+    "terok_executor._tree",
     "terok_executor.acp",
     "terok_executor.commands",
     "terok_executor.container.build",

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -938,40 +938,52 @@ class TestEnsureVaultRoutes:
 class TestVaultHandlerCfgSignatures:
     """All vault command handlers accept a ``cfg`` keyword argument."""
 
-    def test_all_handlers_accept_cfg(self) -> None:
+    def test_all_leaf_handlers_accept_cfg(self) -> None:
         import inspect
 
         from terok_executor.credentials.vault_commands import VAULT_COMMANDS
 
-        for cmd in VAULT_COMMANDS:
+        vault_group = VAULT_COMMANDS[0]
+        for cmd in vault_group.children:
+            # Skip the nested ``passphrase`` group; its leaves don't take cfg.
+            if cmd.children:
+                continue
             sig = inspect.signature(cmd.handler)
             assert "cfg" in sig.parameters, f"{cmd.handler.__name__} missing cfg param"
 
 
 class TestVaultCommandsOverlay:
-    """Executor's ``VAULT_COMMANDS`` overlays sandbox's set with enriched handlers.
+    """Executor's ``VAULT_COMMANDS`` overlays sandbox's vault subtree.
 
-    Sandbox owns the verb registry and argparse schema; executor only
-    overrides the five shared verbs that need enrichment and appends
-    two executor-only verbs.  The three sandbox-only verbs (``unlock``,
-    ``lock``, ``seal``) pass through so they're visible under
-    ``terok vault`` and not just ``terok-sandbox vault``.
+    Sandbox owns the verb registry and argparse schema (one source of
+    truth for ``--key=``, structural nesting of ``vault passphrase``).
+    Executor overrides handlers at the five shared paths via
+    ``CommandTree.overlay`` and extends the vault subtree with two
+    executor-only verbs (``routes`` / ``clean``).  Sandbox-only verbs
+    (``unlock`` / ``lock`` / ``passphrase {seal,to-keyring,destroy}``)
+    flow through unchanged — that's the property new sandbox commands
+    rely on to reach ``terok-executor vault …`` zero-edit.
     """
 
     def test_sandbox_only_verbs_pass_through(self) -> None:
-        """``unlock`` / ``lock`` / ``seal`` are exposed without an executor handler."""
-        from terok_sandbox import VAULT_COMMANDS as SANDBOX_VAULT_COMMANDS
+        """``unlock`` / ``lock`` (and the ``passphrase`` subgroup) pass through unchanged."""
+        from terok_sandbox.commands import COMMANDS as SANDBOX_COMMANDS
 
         from terok_executor.credentials.vault_commands import VAULT_COMMANDS
 
-        by_name = {cmd.name: cmd for cmd in VAULT_COMMANDS}
-        sandbox_by_name = {cmd.name: cmd for cmd in SANDBOX_VAULT_COMMANDS}
-        for verb in ("unlock", "lock", "seal"):
-            assert verb in by_name, f"{verb} not exposed under executor vault"
-            # The handler is sandbox's — the overlay didn't replace it.
-            assert by_name[verb].handler is sandbox_by_name[verb].handler
-            # Argparse schema (``--forget`` / ``--key=``) survives the overlay.
-            assert by_name[verb].args == sandbox_by_name[verb].args
+        sandbox_vault = SANDBOX_COMMANDS.find_at(("vault",))
+        executor_vault = VAULT_COMMANDS[0]
+        sandbox_by_name = {c.name: c for c in sandbox_vault.children}
+        executor_by_name = {c.name: c for c in executor_vault.children}
+        for verb in ("unlock", "lock"):
+            assert executor_by_name[verb].handler is sandbox_by_name[verb].handler
+            assert executor_by_name[verb].args == sandbox_by_name[verb].args
+        # Nested ``passphrase`` subgroup survives identically — every leaf
+        # routes to the sandbox handler.
+        sandbox_passphrase = {c.name: c for c in sandbox_by_name["passphrase"].children}
+        executor_passphrase = {c.name: c for c in executor_by_name["passphrase"].children}
+        for verb in ("seal", "to-keyring", "destroy"):
+            assert executor_passphrase[verb].handler is sandbox_passphrase[verb].handler
 
     def test_shared_verbs_use_executor_handlers(self) -> None:
         """``start`` / ``stop`` / ``status`` / ``install`` / ``uninstall`` route to executor."""
@@ -991,17 +1003,26 @@ class TestVaultCommandsOverlay:
             "install": _handle_install,
             "uninstall": _handle_uninstall,
         }
-        by_name = {cmd.name: cmd for cmd in VAULT_COMMANDS}
+        by_name = {cmd.name: cmd for cmd in VAULT_COMMANDS[0].children}
         for verb, handler in expected.items():
             assert by_name[verb].handler is handler, f"{verb} should use executor handler"
 
     def test_executor_only_verbs_appended(self) -> None:
-        """``routes`` and ``clean`` exist in executor's set but not sandbox's."""
-        from terok_sandbox import VAULT_COMMANDS as SANDBOX_VAULT_COMMANDS
+        """``routes`` and ``clean`` exist in executor's vault group but not sandbox's."""
+        from terok_sandbox.commands import COMMANDS as SANDBOX_COMMANDS
 
         from terok_executor.credentials.vault_commands import VAULT_COMMANDS
 
-        executor_names = {cmd.name for cmd in VAULT_COMMANDS}
-        sandbox_names = {cmd.name for cmd in SANDBOX_VAULT_COMMANDS}
+        sandbox_names = {c.name for c in SANDBOX_COMMANDS.find_at(("vault",)).children}
+        executor_names = {c.name for c in VAULT_COMMANDS[0].children}
         executor_only = executor_names - sandbox_names
         assert executor_only == {"routes", "clean"}
+
+    def test_deep_path_shares_identity_with_shortcut(self) -> None:
+        """``terok-executor sandbox vault X`` and ``terok-executor vault X`` resolve to
+        the same ``CommandDef`` — the load-bearing property for wraps to apply uniformly."""
+        from terok_executor.cli import COMMANDS
+
+        deep = COMMANDS.find_at(("sandbox", "vault"))
+        shortcut = COMMANDS.find_at(("vault",))
+        assert deep is shortcut

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -1026,3 +1026,24 @@ class TestVaultCommandsOverlay:
         deep = COMMANDS.find_at(("sandbox", "vault"))
         shortcut = COMMANDS.find_at(("vault",))
         assert deep is shortcut
+
+    def test_argparse_wires_both_paths_to_the_same_handler(self) -> None:
+        """The argparse parser must reach the same handler from both paths.
+
+        ``find_at`` proves the registry is consistent; argparse wiring
+        could still regress (e.g. someone duplicating a CommandDef
+        when constructing a parent group).  Build the actual parser
+        and confirm both ``vault status`` and ``sandbox vault status``
+        dispatch to the same handler object.
+        """
+        import argparse
+
+        from terok_executor.cli import COMMANDS
+
+        parser = argparse.ArgumentParser()
+        COMMANDS.wire(parser)
+
+        deep_args = parser.parse_args(["sandbox", "vault", "status"])
+        short_args = parser.parse_args(["vault", "status"])
+        assert deep_args._cmd is short_args._cmd
+        assert deep_args._cmd.handler is short_args._cmd.handler


### PR DESCRIPTION
## Summary

Adopts the new structural \`CommandDef\` / \`CommandTree\` API from [terok-sandbox#295](https://github.com/terok-ai/terok-sandbox/pull/295). Three concrete changes:

### 1. Single shared vocabulary

Removes executor's local \`ArgDef\` / \`CommandDef\` dataclasses; imports the unified ones from \`terok_sandbox.commands\`. Every package on the chain now shares one vocabulary, eliminating the audit-flagged variant problem.

### 2. Vault overlay rewritten against CommandTree.overlay

The old name-keyed \`_HANDLER_OVERRIDES\` dict + flat tuple iteration becomes a path-keyed overlay applied recursively across sandbox's whole vault subtree:

\`\`\`python
_VAULT_OVERRIDES = {
    (\"vault\", \"start\"):     _handle_start,
    (\"vault\", \"stop\"):      _handle_stop,
    (\"vault\", \"status\"):    _handle_status,
    (\"vault\", \"install\"):   _handle_install,
    (\"vault\", \"uninstall\"): _handle_uninstall,
}
SANDBOX_TREE = SANDBOX_COMMANDS.overlay(_VAULT_OVERRIDES).extend_at(
    (\"vault\",),
    (CommandDef(\"routes\", handler=_handle_routes),
     CommandDef(\"clean\",  handler=_handle_clean)),
)
\`\`\`

Adding a new sandbox verb (or a new subgroup under \`vault\`) flows into executor's tree zero-edit — the brittleness sandbox#294's \`passphrase\` subgroup hit is gone.

### 3. Deep nesting + shortcut surface

Executor's CLI now exposes the sandbox tree two ways:

- **Deep path**: \`terok-executor sandbox <any-sandbox-verb>\` — the full sandbox tree, with executor's vault overlays applied.
- **Shortcut**: \`terok-executor vault <verb>\` — promoted to top level for ergonomics. References the **same** \`CommandDef\` instance as \`terok-executor sandbox vault <verb>\`, so a wrap at either entry point propagates to the other.

Plus all previous top-level executor verbs (\`run\`, \`run-tool\`, \`auth\`, \`agents\`, \`build\`, \`setup\`, \`uninstall\`, \`list\`, \`stop\`, \`acp\`) — unchanged.

\`cli.py\` shrinks from a hand-rolled subparser loop to a thin shell around \`COMMANDS.wire(parser)\` + \`CommandTree.dispatch(args)\`.

## Depends on

[terok-ai/terok-sandbox#295](https://github.com/terok-ai/terok-sandbox/pull/295) — currently branch-pinned via:

\`\`\`toml
terok-sandbox = {git = \"https://github.com/sliwowitz/terok-sandbox.git\", branch = \"feat/command-tree\"}
\`\`\`

Release script flips this to the released wheel URL after sandbox merges.

## Test plan

- [x] \`make check\` — lint, tests (841 passed), tach, security, docstrings (97.2%), reuse — all green
- [x] CLI smoke: \`terok-executor --help\`, \`terok-executor sandbox vault passphrase --help\`, \`terok-executor vault --help\`
- [x] Identity test: \`COMMANDS.find_at((\"sandbox\", \"vault\")) is COMMANDS.find_at((\"vault\",))\` — confirms deep path + shortcut share the same overlaid subtree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched sandbox dependency to a development branch.

* **Refactor**
  * Overhauled CLI command registration and dispatch to use a unified command tree.
  * Consolidated command definitions so components share the same command vocabulary.
  * Reworked vault command handling to a tree-based overlay with executor-specific verbs.
  * Re-exported the composed CLI command registry for easier discovery.

* **Tests**
  * Updated vault-route tests to validate tree-based overlays and handler identity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/311)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->