### PR TITLE
chore(deps): branch-pin terok-sandbox for the SELinux-surfacing chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ also the "Changelog" link in PyPI metadata.
 
 [rel]: https://github.com/terok-ai/terok-executor/releases
 
+## v0.0.148 — SELinux Rules Hint
+
+## What's Changed
+* chore(deps): branch-pin terok-sandbox for the SELinux-surfacing chain in https://github.com/terok-ai/terok-executor/pull/313
+
+**Full Changelog**: https://github.com/terok-ai/terok-executor/compare/v0.0.147...v0.0.148
+
 ## v0.0.147 — The State of the Shields
 
 ## What's Changed

--- a/poetry.lock
+++ b/poetry.lock
@@ -3222,9 +3222,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.122-py3-none-any.whl", hash = "sha256:9610ccf55491de1cf17941a8d29757919614241c687547fb539f489fa4874df7"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3236,12 +3235,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.122/terok_sandbox-0.0.122-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/selinux-setup-surfacing"
+resolved_reference = "0cb0cc58baa45d3c9053a3583dfc0507d8b4b972"
 
 [[package]]
 name = "terok-shield"
@@ -3659,4 +3660,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "f592270339a374c11d0f3c6cdf38cbf0548dd855fe74ed4adbfa476b8b99c3f5"
+content-hash = "ffb4e981cc14e18f2ede30d937fa57821184c982ae7e63607999a9f2229f83a1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3217,13 +3217,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/ter
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.122"
+version = "0.0.123"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.123-py3-none-any.whl", hash = "sha256:0e2a8bd3eda875a0707cd1832d05708fbe3b59575df0cc71e7d7da761bf81766"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3235,14 +3236,12 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/selinux-setup-surfacing"
-resolved_reference = "0cb0cc58baa45d3c9053a3583dfc0507d8b4b972"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.123/terok_sandbox-0.0.123-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3660,4 +3659,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "ffb4e981cc14e18f2ede30d937fa57821184c982ae7e63607999a9f2229f83a1"
+content-hash = "b52f489979ca714e106296502579e35a9743f7b30a00e867c596803c15fc060a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok-executor"
-version = "0.0.147"
+version = "0.0.148"
 description = "Single-agent task runner for hardened Podman containers"
 readme = "README.md"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/selinux-setup-surfacing"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.123/terok_sandbox-0.0.123-py3-none-any.whl"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://terok-ai.github.io/terok-executor/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.122/terok_sandbox-0.0.122-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/selinux-setup-surfacing"}
 "ruamel.yaml" = ">=0.18"
 Jinja2 = ">=3.1"
 tomli-w = ">=1.0"


### PR DESCRIPTION
Pin-sync companion to [terok-ai/terok-sandbox#298](https://github.com/terok-ai/terok-sandbox/pull/298). When terok branches its sandbox pin during a merge window, executor must point at the same source — otherwise poetry rejects the conflicting URL/git pins.

No code changes. Sandbox#298's only consumer-visible behaviour change is a new exit code 5 (\"manual host configuration needed\") from \`_handle_sandbox_setup\` when SELinux policy is missing on a socket-mode host; \`ensure_sandbox_ready\` calls that handler directly and the exit code propagates through unchanged.

Pin currently:

\`\`\`toml
terok-sandbox = {git = \"https://github.com/sliwowitz/terok-sandbox.git\", branch = \"feat/selinux-setup-surfacing\"}
\`\`\`

Release script flips back to the released wheel URL once sandbox#298 merges + releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency to use a Git branch source instead of a pinned release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/313)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->