### PR TITLE
fix(doctor): drop misleading "vault bypass" wording + annotate systemd-creds tier with +TPM2

### DIFF
--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -226,11 +227,13 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
         # binding visible without needing to read ``systemd-creds
         # list`` manually.
         if status.passphrase_source == "systemd-creds":
-            try:
+            # Best-effort probe — a missing or hanging ``systemd-creds``
+            # binary must not break ``vault status``.  ``suppress`` is
+            # the explicit "intentional swallow" so static analysers
+            # don't flag the bare pass.
+            with suppress(Exception):
                 if systemd_creds_has_tpm2():
                     tier_line = f"{tier_line} (+TPM2)"
-            except Exception:  # noqa: BLE001 — TPM probe is best-effort
-                pass
         print(tier_line)
     if status.credentials_stored:
         print(f"Credentials: {_format_credentials(status, cfg)}")

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -184,7 +184,12 @@ def _format_credentials(status: object, cfg: SandboxConfig | None = None) -> str
 
 def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
     """Show vault status."""
-    from terok_sandbox import get_vault_status, is_vault_systemd_available, sanitize_tty
+    from terok_sandbox import (
+        get_vault_status,
+        is_vault_systemd_available,
+        sanitize_tty,
+        systemd_creds_has_tpm2,
+    )
 
     from terok_executor.paths import mounts_dir
 
@@ -213,7 +218,20 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
     if status.locked:
         print("Passphrase:  (no tier resolved — run `terok vault unlock`)")
     elif status.passphrase_source is not None:
-        print(f"Passphrase:  resolved via {status.passphrase_source}")
+        tier_line = f"Passphrase:  resolved via {status.passphrase_source}"
+        # Surface the TPM2 binding when systemd-creds is the resolved
+        # tier and the host actually has a TPM2 device — operators
+        # using systemd-creds explicitly opted into the higher-end
+        # sealing mode; showing the (+TPM2) annotation makes the
+        # binding visible without needing to read ``systemd-creds
+        # list`` manually.
+        if status.passphrase_source == "systemd-creds":
+            try:
+                if systemd_creds_has_tpm2():
+                    tier_line = f"{tier_line} (+TPM2)"
+            except Exception:  # noqa: BLE001 — TPM probe is best-effort
+                pass
+        print(tier_line)
     if status.credentials_stored:
         print(f"Credentials: {_format_credentials(status, cfg)}")
     else:

--- a/src/terok_executor/doctor.py
+++ b/src/terok_executor/doctor.py
@@ -296,7 +296,11 @@ def _make_base_url_checks(roster: AgentRoster, token_broker_port: int | None) ->
                 """Check if base URL points to the active vault endpoint."""
                 val = stdout.strip()
                 if not val:
-                    return CheckVerdict("warn", f"{env_var}: not set — vault bypass possible")
+                    # Just "not set" — the original "vault bypass possible"
+                    # was misleading: an agent can override the env var
+                    # any time, so this isn't a bypass *signal*; it just
+                    # means the agent doesn't know where the vault lives.
+                    return CheckVerdict("warn", f"{env_var}: not set")
                 if urlparse(val).netloc == host:
                     return CheckVerdict("ok", f"{env_var}: routed through {mode} ({pname})")
                 return CheckVerdict(

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -423,6 +423,92 @@ class TestVaultCommandHandlers:
         assert "Locked:      no" in out
         assert "resolved via systemd-creds" in out
 
+    @patch("terok_sandbox.systemd_creds_has_tpm2", return_value=True)
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_annotates_systemd_creds_with_tpm2_suffix(
+        self, mock_status, _sd, _scan, _tpm2, capsys
+    ) -> None:
+        """``systemd-creds`` tier + a TPM2 device → ``(+TPM2)`` suffix on the Passphrase line."""
+        mock_status.return_value = MagicMock(
+            mode="systemd",
+            running=True,
+            socket_path="/run/proxy.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source="systemd-creds",
+            locked=False,
+            plaintext_passphrase_path=None,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        out = capsys.readouterr().out
+        assert "resolved via systemd-creds (+TPM2)" in out
+
+    @patch("terok_sandbox.systemd_creds_has_tpm2", return_value=False)
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_omits_tpm2_suffix_when_unavailable(
+        self, mock_status, _sd, _scan, _tpm2, capsys
+    ) -> None:
+        """``systemd-creds`` tier + no TPM2 → bare ``resolved via systemd-creds`` line."""
+        mock_status.return_value = MagicMock(
+            mode="systemd",
+            running=True,
+            socket_path="/run/proxy.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source="systemd-creds",
+            locked=False,
+            plaintext_passphrase_path=None,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        out = capsys.readouterr().out
+        assert "resolved via systemd-creds" in out
+        assert "(+TPM2)" not in out
+
+    @patch(
+        "terok_sandbox.systemd_creds_has_tpm2",
+        side_effect=RuntimeError("systemd-creds binary missing"),
+    )
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_swallows_tpm2_probe_failure(
+        self, mock_status, _sd, _scan, _tpm2, capsys
+    ) -> None:
+        """A raised TPM2 probe must not break ``vault status`` — bare line, no exception."""
+        mock_status.return_value = MagicMock(
+            mode="systemd",
+            running=True,
+            socket_path="/run/proxy.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source="systemd-creds",
+            locked=False,
+            plaintext_passphrase_path=None,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        out = capsys.readouterr().out
+        assert "resolved via systemd-creds" in out
+        assert "(+TPM2)" not in out
+
     @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
     @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
     @patch("terok_sandbox.get_vault_status")


### PR DESCRIPTION
Bundles two sickbay-polish items the user flagged ahead of the imminent release.

### 1) Base URL wording: drop \"vault bypass possible\"

User feedback on \`terok sickbay\`'s per-task report: the \"not set — vault bypass possible\" wording was misleading.  An agent can change the env var at any time, so an unset value isn't a bypass *signal* — it just means the agent doesn't know where the vault lives.

Trim the detail to plain \`\"{env_var}: not set\"\`.  No semantic change — still a \`warn\`, still surfaced in sickbay.

### 2) TPM2 annotation in \`vault status\`

When the resolved passphrase tier is \`systemd-creds\` AND the host has a TPM2 device usable by systemd-creds, append \`(+TPM2)\` to the \`Passphrase:\` line:

\`\`\`
Passphrase:  resolved via systemd-creds (+TPM2)
\`\`\`

Sandbox already exports \`systemd_creds_has_tpm2\`; this just surfaces the binding where operators are already looking, without needing them to run \`systemd-creds list\` manually.  Best-effort: TPM2 probe failures are swallowed (the suffix simply doesn't render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified diagnostic for an unset base URL to remove misleading wording suggesting a bypass; it now simply reports "not set".

* **New Features**
  * Passphrase status output now appends " (+TPM2)" when a best-effort TPM2 presence check succeeds for system-managed passphrases; probe failures are ignored to avoid noisy errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->