### PR TITLE
docs: state __init__.py + __all__ as the public API contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,11 @@ those run on a dedicated test machine.
 - SPDX copyright: author name "Jiri Vyskocil".  Add a new
   `SPDX-FileCopyrightText` line only for a previously unlisted
   contributor making a substantive change.
+- Public API surface: ``__init__.py`` + ``__all__`` is the contract.
+  Symbols listed in ``__all__`` are stable across minor releases;
+  anything underscore-prefixed or absent from ``__all__`` is internal
+  and may change without notice.  Review the list before each release
+  — stable APIs stay small because growing them costs.
 
 ## Docs
 


### PR DESCRIPTION
## Summary

- Add one bullet to `AGENTS.md` (Code style) documenting the established Python convention: `__init__.py` + `__all__` is the contract; symbols outside `__all__` (or underscore-prefixed) are internal.
- The repo already follows this convention. No code changes — this just writes down the rule so future contributors can spot when the surface drifts.
- Matching docs PRs filed for `terok`, `terok-sandbox`, `terok-clearance`, `terok-shield`.

## Why

Periodic public-API review is the cheap check that keeps inter-package coupling small. A written one-liner gives that review a citation, and explicitly names the signal ("surface growing → think before adding").

## Test plan
- [x] No code touched — docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API stability documentation to clarify which public symbols are guaranteed stable across releases and which are considered internal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->