### PR TITLE
fix(l0): override sudo's PAM stack on rpm bases to bypass shadow reads

### DIFF
--- a/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
@@ -55,7 +55,7 @@ RUN set -eux; \
     echo 'dev ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/dev; \
     chmod 0440 /etc/sudoers.d/dev; \
     visudo -cf /etc/sudoers.d/dev; \
-{% if family == "rpm" %}    printf '%s\n' '#%PAM-1.0' 'auth sufficient pam_permit.so' 'account sufficient pam_permit.so' 'password include system-auth' 'session include system-auth' > /etc/pam.d/sudo; \
+{% if family == "rpm" %}    printf '%s\n' '#%PAM-1.0' 'auth [success=1 default=ignore] pam_succeed_if.so user = dev' 'auth include system-auth' 'account [success=1 default=ignore] pam_succeed_if.so user = dev' 'account include system-auth' 'password include system-auth' 'session include system-auth' > /etc/pam.d/sudo; \
 {% endif %}    mkdir -p /workspace /home/dev/.ssh; \
     chown -R dev:dev /home/dev /workspace; \
     chmod 700 /home/dev/.ssh; \

--- a/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
@@ -38,12 +38,6 @@ RUN set -eux; \
       if getent group "$uid_owner" >/dev/null; then groupmod -n dev "$uid_owner" || true; fi; \
       usermod -l dev "$uid_owner"; \
       usermod -d /home/dev -m dev; \
-      # usermod -l only updates /etc/passwd.  On bases whose UID-1000 user \
-      # ships no /etc/shadow entry (e.g. quay.io/podman/stable, fedora:43), \
-      # pam_unix later fails getspnam("dev") and breaks sudo with a confusing \
-      # "Authentication service cannot retrieve authentication info" error. \
-      # Force a locked shadow row so the account exists for PAM to look up. \
-      usermod -p '!' dev; \
       # usermod -l / groupmod -n don't touch /etc/sub{u,g}id; rewrite \
       # those entries so pre-configured rootless ranges (e.g. the podman \
       # image's `podman:100000:65536`) keep working under the new name. \
@@ -61,7 +55,8 @@ RUN set -eux; \
     echo 'dev ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/dev; \
     chmod 0440 /etc/sudoers.d/dev; \
     visudo -cf /etc/sudoers.d/dev; \
-    mkdir -p /workspace /home/dev/.ssh; \
+{% if family == "rpm" %}    printf '%s\n' '#%PAM-1.0' 'auth sufficient pam_permit.so' 'account sufficient pam_permit.so' 'password include system-auth' 'session include system-auth' > /etc/pam.d/sudo; \
+{% endif %}    mkdir -p /workspace /home/dev/.ssh; \
     chown -R dev:dev /home/dev /workspace; \
     chmod 700 /home/dev/.ssh; \
     chmod 0777 /workspace

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -481,14 +481,24 @@ class TestTemplateRendering:
         content = render_l0("nvidia/cuda:12.4.1-devel-ubuntu24.04")
         assert "FROM" in content
 
-    def test_l0_forces_shadow_entry_after_rename(self) -> None:
-        # Bases whose UID-1000 user has no /etc/shadow row (quay.io/podman/stable,
-        # fedora:43) silently produce a renamed dev user that pam_unix can't look
-        # up — sudo then fails with "PAM account management error: Authentication
-        # service cannot retrieve authentication info".  ``usermod -p '!' dev``
-        # writes a locked shadow row regardless of what the base shipped.
-        content = render_l0()
-        assert "usermod -p '!' dev" in content
+    def test_l0_rpm_overrides_sudo_pam_stack(self) -> None:
+        # Fedora ships /etc/shadow root:root mode 0000, relying on
+        # CAP_DAC_OVERRIDE for every read.  Inside rootless podman, the kernel
+        # doesn't reliably grant that cap to setuid-root binaries, so
+        # pam_unix's helper (unix_chkpwd) returns AUTHINFO_UNAVAIL and sudo
+        # refuses even with NOPASSWD.  Replace sudo's PAM file with a stack
+        # that doesn't depend on shadow reads.
+        rpm = render_l0("registry.fedoraproject.org/fedora:43", family="rpm")
+        assert "auth sufficient pam_permit.so" in rpm
+        assert "account sufficient pam_permit.so" in rpm
+        assert "> /etc/pam.d/sudo" in rpm
+
+    def test_l0_deb_does_not_override_sudo_pam(self) -> None:
+        # Debian-family bases use a shadow group and pam_unix works fine; the
+        # override is rpm-only.
+        deb = render_l0("ubuntu:24.04", family="deb")
+        assert "pam_permit.so" not in deb
+        assert "/etc/pam.d/sudo" not in deb
 
     def test_l0_validates_sudoers(self) -> None:
         # ``visudo -cf`` fails the build on a malformed sudoers drop-in, which

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -486,18 +486,19 @@ class TestTemplateRendering:
         # CAP_DAC_OVERRIDE for every read.  Inside rootless podman, the kernel
         # doesn't reliably grant that cap to setuid-root binaries, so
         # pam_unix's helper (unix_chkpwd) returns AUTHINFO_UNAVAIL and sudo
-        # refuses even with NOPASSWD.  Replace sudo's PAM file with a stack
-        # that doesn't depend on shadow reads.
+        # refuses even with NOPASSWD.  Override sudo's PAM file with a stack
+        # that skips the auth/account checks for `dev` only (via
+        # pam_succeed_if + success=1), leaving the rest of the stack intact
+        # for root and any other caller.
         rpm = render_l0("registry.fedoraproject.org/fedora:43", family="rpm")
-        assert "auth sufficient pam_permit.so" in rpm
-        assert "account sufficient pam_permit.so" in rpm
+        assert "[success=1 default=ignore] pam_succeed_if.so user = dev" in rpm
         assert "> /etc/pam.d/sudo" in rpm
 
     def test_l0_deb_does_not_override_sudo_pam(self) -> None:
         # Debian-family bases use a shadow group and pam_unix works fine; the
         # override is rpm-only.
         deb = render_l0("ubuntu:24.04", family="deb")
-        assert "pam_permit.so" not in deb
+        assert "pam_succeed_if.so" not in deb
         assert "/etc/pam.d/sudo" not in deb
 
     def test_l0_validates_sudoers(self) -> None:


### PR DESCRIPTION
## Summary

On Fedora-family bases, `sudo` fails inside rootless-podman containers even though sudoers grants `NOPASSWD: ALL`:

```
$ sudo echo 1
sudo: PAM account management error: Authentication service cannot retrieve authentication info
sudo: a password is required
```

### Root cause

- Fedora ships `/etc/shadow` as `root:root` mode `0000`, relying on `CAP_DAC_OVERRIDE` for every read.
- Inside rootless-podman user namespaces, the kernel does **not** reliably grant `CAP_DAC_OVERRIDE` to setuid-root binaries; `pam_unix`'s helper `unix_chkpwd` then cannot `getspnam(\"dev\")` and returns `PAM_AUTHINFO_UNAVAIL` (exit code 9).
- `sudo` calls `pam_acct_mgmt` even for `NOPASSWD` users; it fails and `sudo` bails with the message above.

Confirmed empirically inside an affected container:
- `chage -l dev` and `passwd -S dev` work (they open `/etc/shadow` directly via `commonio` while still in the setuid context before privilege drop).
- `/sbin/unix_chkpwd dev chkexpiry` returns exit 9 with `-1` daysleft — `getspnam` returned NULL in the helper's context.

### Why not #274's approach

PR #274 added `usermod -p '!' dev` to \"force a locked shadow row\". This is a no-op: `usermod`'s `update_shadow()` calls `spw_locate(user)` and **returns early** when no row exists — it never creates one. Removing the line as part of this PR.

### The fix

`sudoers` already enforces policy and the container is the trust boundary, so replace `sudo`'s PAM file with a stack that doesn't depend on shadow reads:

```
#%PAM-1.0
auth       sufficient   pam_permit.so
account    sufficient   pam_permit.so
password   include      system-auth
session    include      system-auth
```

Only applied to rpm-family bases (`{% if family == \"rpm\" %}`). Debian-family bases ship `/etc/shadow` as `root:shadow 0640` and `unix_chkpwd` works fine.

## Test plan

- [x] `poetry run pytest tests/unit/test_build.py` — 146 passed including the new `test_l0_rpm_overrides_sudo_pam_stack` and `test_l0_deb_does_not_override_sudo_pam`.
- [x] `poetry run pytest tests/unit/` — 849 passed; 4 preexisting `test_preflight` failures (missing `nft`, unrelated, same as #274).
- [x] `ruff check` clean; `tach check` clean; `docstr-coverage` 97.0%; `bandit -ll` no medium/high; `reuse lint` clean.
- [ ] Build a project image on a Fedora 43 base, exec into it, run `sudo -nl` as `dev` — should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development Docker image user setup to stop forcing a locked shadow password for the dev account.
  * Modified PAM sudo configuration behavior: RPM-based images now apply a sudo PAM override; DEB-based images retain the previous behavior.

* **Tests**
  * Updated build tests to validate RPM vs DEB distribution-specific PAM/sudo behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->