### PR TITLE
fix(l0): match calling user (ruser) in sudo PAM override

### DIFF
--- a/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
@@ -55,7 +55,7 @@ RUN set -eux; \
     echo 'dev ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/dev; \
     chmod 0440 /etc/sudoers.d/dev; \
     visudo -cf /etc/sudoers.d/dev; \
-{% if family == "rpm" %}    printf '%s\n' '#%PAM-1.0' 'auth [success=1 default=ignore] pam_succeed_if.so user = dev' 'auth include system-auth' 'account [success=1 default=ignore] pam_succeed_if.so user = dev' 'account include system-auth' 'password include system-auth' 'session include system-auth' > /etc/pam.d/sudo; \
+{% if family == "rpm" %}    printf '%s\n' '#%PAM-1.0' 'auth [success=1 default=ignore] pam_succeed_if.so ruser = dev' 'auth include system-auth' 'account [success=1 default=ignore] pam_succeed_if.so ruser = dev' 'account include system-auth' 'password include system-auth' 'session include system-auth' > /etc/pam.d/sudo; \
 {% endif %}    mkdir -p /workspace /home/dev/.ssh; \
     chown -R dev:dev /home/dev /workspace; \
     chmod 700 /home/dev/.ssh; \

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -491,7 +491,10 @@ class TestTemplateRendering:
         # pam_succeed_if + success=1), leaving the rest of the stack intact
         # for root and any other caller.
         rpm = render_l0("registry.fedoraproject.org/fedora:43", family="rpm")
-        assert "[success=1 default=ignore] pam_succeed_if.so user = dev" in rpm
+        # ``ruser`` (calling user), not ``user`` (target user, which is root
+        # for plain ``sudo ls``) — otherwise the override never matches and
+        # the stack falls through to the broken pam_unix account check.
+        assert "[success=1 default=ignore] pam_succeed_if.so ruser = dev" in rpm
         assert "> /etc/pam.d/sudo" in rpm
 
     def test_l0_deb_does_not_override_sudo_pam(self) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #327.  The PAM override I added there used
`pam_succeed_if user = dev`, which checks `PAM_USER` — sudo sets that
to the **target** user (root for plain `sudo ls`), not the caller.  So
the bypass never matched, the stack fell through to `system-auth`, and
account validation failed on the same broken shadow read — just with a
different PAM-mapped message:

```
$ sudo ls
sudo: PAM account management error: Permission denied
sudo: a password is required
```

(Confirmed on the `quay.io/podman/stable` base, also rpm-family.)

## Fix

Switch to `ruser = dev`.  `pam_succeed_if`'s `ruser` field reads
`PAM_RUSER`, which sudo sets to the calling user — so the override
matches whenever dev invokes sudo, regardless of target.

## Test plan

- [x] `poetry run pytest tests/unit/test_build.py` — 146 passed including the updated `test_l0_rpm_overrides_sudo_pam_stack` asserting `ruser = dev`.
- [ ] Rebuild a project image on Fedora 43 / podman:stable, exec in, run `sudo ls` as dev — should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sudo authentication user identification handling in development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->