### PR TITLE
fix(l0): rpm sudo PAM override — use `sufficient`, gate on shadow mode

### DIFF
--- a/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
@@ -55,7 +55,16 @@ RUN set -eux; \
     echo 'dev ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/dev; \
     chmod 0440 /etc/sudoers.d/dev; \
     visudo -cf /etc/sudoers.d/dev; \
-{% if family == "rpm" %}    printf '%s\n' '#%PAM-1.0' 'auth [success=1 default=ignore] pam_succeed_if.so ruser = dev' 'auth include system-auth' 'account [success=1 default=ignore] pam_succeed_if.so ruser = dev' 'account include system-auth' 'password include system-auth' 'session include system-auth' > /etc/pam.d/sudo; \
+{% if family == "rpm" %}    if [ "$(stat -c '%a' /etc/shadow)" = "0" ]; then \
+        printf '%s\n' '#%PAM-1.0' \
+            'auth sufficient pam_succeed_if.so ruser = dev' \
+            'auth include system-auth' \
+            'account sufficient pam_succeed_if.so ruser = dev' \
+            'account include system-auth' \
+            'password include system-auth' \
+            'session include system-auth' \
+            > /etc/pam.d/sudo; \
+    fi; \
 {% endif %}    mkdir -p /workspace /home/dev/.ssh; \
     chown -R dev:dev /home/dev /workspace; \
     chmod 700 /home/dev/.ssh; \

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -487,15 +487,24 @@ class TestTemplateRendering:
         # doesn't reliably grant that cap to setuid-root binaries, so
         # pam_unix's helper (unix_chkpwd) returns AUTHINFO_UNAVAIL and sudo
         # refuses even with NOPASSWD.  Override sudo's PAM file with a stack
-        # that skips the auth/account checks for `dev` only (via
-        # pam_succeed_if + success=1), leaving the rest of the stack intact
-        # for root and any other caller.
+        # that short-circuits the auth/account checks for `dev` only (via
+        # ``sufficient pam_succeed_if`` on the calling user), leaving the
+        # stack intact for root and any other caller.
+        #
+        # ``sufficient`` (= ``[success=done default=ignore]``) is required
+        # rather than a bare ``[success=1 default=ignore]``: the latter only
+        # jumps, it does *not* contribute a positive status to the dispatch
+        # accumulator (libpam/pam_dispatch.c), so the stack would end at
+        # PAM_MUST_FAIL_CODE (= PAM_PERM_DENIED) with no preceding
+        # required-class success.  ``done`` both contributes SUCCESS and
+        # terminates the stack — which is what we want here.
         rpm = render_l0("registry.fedoraproject.org/fedora:43", family="rpm")
-        # ``ruser`` (calling user), not ``user`` (target user, which is root
-        # for plain ``sudo ls``) — otherwise the override never matches and
-        # the stack falls through to the broken pam_unix account check.
-        assert "[success=1 default=ignore] pam_succeed_if.so ruser = dev" in rpm
+        assert "sufficient pam_succeed_if.so ruser = dev" in rpm
         assert "> /etc/pam.d/sudo" in rpm
+        # Self-targets via shadow mode so we don't gratuitously rewrite
+        # /etc/pam.d/sudo on openSUSE/SLES (rpm-family but uses a shadow
+        # group like Debian, so pam_unix works fine).
+        assert "stat -c '%a' /etc/shadow" in rpm
 
     def test_l0_deb_does_not_override_sudo_pam(self) -> None:
         # Debian-family bases use a shadow group and pam_unix works fine; the


### PR DESCRIPTION
## Summary

Two follow-ups to #329:

### 1. `[success=1 default=ignore]` → `sufficient`

The bare `[success=1 default=ignore]` jump action performs the jump but does **not** contribute a positive status to libpam's dispatch accumulator (see `libpam/pam_dispatch.c:259-298` — the JUMP branch only updates status/impression when `use_cached_chain` is true).  With no preceding required-class success, the stack ends at `_PAM_UNDEF` / `PAM_MUST_FAIL_CODE` (= `PAM_PERM_DENIED`), and sudo refuses:

```
$ sudo -n true
sudo: PAM account management error: Permission denied
sudo: a password is required
```

(Diagnosed live on a Fedora 43 container via a `pam_exec`-based probe; the probe accidentally worked only because its preceding `required pam_exec.so` contributed `_PAM_ACTION_OK`.)

Use `sufficient` instead — libpam expands it to `[success=done default=ignore]`, and the `done` action both contributes `PAM_SUCCESS` **and** terminates the stack.

### 2. Self-target via shadow mode (don't gratuitously hit openSUSE)

The root cause only affects rpm distros that ship `/etc/shadow` as `root:root 0000` and rely on `CAP_DAC_OVERRIDE` for reads:

| rpm family | shadow mode | rootless podman | needs override? |
|---|---|---|---|
| Fedora / RHEL / Rocky / Alma / Oracle / Amazon | `0000 root:root` | broken | yes |
| openSUSE / SLES | `0640 root:shadow` | works | no |

Gate the override on `[ "$(stat -c '%a' /etc/shadow)" = "0" ]` so openSUSE/SLES keep their original `/etc/pam.d/sudo`.

## Rendered output

```dockerfile
    if [ "$(stat -c '%a' /etc/shadow)" = "0" ]; then \
        printf '%s\n' '#%PAM-1.0' \
            'auth sufficient pam_succeed_if.so ruser = dev' \
            'auth include system-auth' \
            'account sufficient pam_succeed_if.so ruser = dev' \
            'account include system-auth' \
            'password include system-auth' \
            'session include system-auth' \
            > /etc/pam.d/sudo; \
    fi;
```

## Test plan

- [x] `poetry run pytest tests/unit/test_build.py` — 146 passed; updated `test_l0_rpm_overrides_sudo_pam_stack` asserts both `sufficient pam_succeed_if.so ruser = dev` and `stat -c '%a' /etc/shadow`.
- [x] Live verification on Fedora 43 container: `sed -i 's/\[success=1 default=ignore\]/sufficient/g' /etc/pam.d/sudo` then `sudo -n true` → exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined sudo authentication behavior for the development user: the PAM override is now conditionally created based on shadow file permissions and uses a "sufficient" control to ensure correct authentication flow.

* **Tests**
  * Updated unit tests and explanations to validate the revised PAM behavior and control-flow semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->