### PR TITLE
chore(image): make fedora:44 the default L0 base

### DIFF
--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING
 
 from terok_sandbox.commands import ArgDef, CommandDef
 
+from .container.build import DEFAULT_BASE_IMAGE
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -215,7 +217,7 @@ def _handle_run(
     git_identity_from_host: bool = False,
     shared_dir: str | None = None,
     shared_mount: str = "/shared",
-    base: str = "ubuntu:24.04",
+    base: str = DEFAULT_BASE_IMAGE,
     family: str | None = None,
     timezone: str | None = None,
     yes: bool = False,
@@ -296,7 +298,7 @@ def _handle_run_tool(
     name: str | None = None,
     timeout: int = 600,
     tool_args: list[str] | None = None,
-    base: str = "ubuntu:24.04",
+    base: str = DEFAULT_BASE_IMAGE,
     family: str | None = None,
     timezone: str | None = None,
     yes: bool = False,
@@ -334,7 +336,6 @@ def _handle_auth(
     base_image: str | None = None,
 ) -> None:
     """Run auth flow for an agent."""
-    from .container.build import DEFAULT_BASE_IMAGE
     from .credentials.auth import AUTH_PROVIDERS, authenticate, store_api_key
 
     if api_key is not None:
@@ -398,7 +399,7 @@ def _handle_agents(*, show_all: bool = False) -> None:
 
 def _handle_build(
     *,
-    base: str = "ubuntu:24.04",
+    base: str = DEFAULT_BASE_IMAGE,
     family: str | None = None,
     agents: str = "all",
     rebuild: bool = False,
@@ -506,7 +507,7 @@ def _handle_setup(
     root: bool = False,
     no_sandbox: bool = False,
     no_images: bool = False,
-    base: str = "ubuntu:24.04",
+    base: str = DEFAULT_BASE_IMAGE,
     family: str | None = None,
     cfg: SandboxConfig | None = None,
 ) -> None:
@@ -540,7 +541,7 @@ def _handle_uninstall(
     root: bool = False,
     no_sandbox: bool = False,
     keep_images: bool = False,
-    base: str = "ubuntu:24.04",
+    base: str = DEFAULT_BASE_IMAGE,
     cfg: SandboxConfig | None = None,
 ) -> None:
     """Remove everything ``terok-executor setup`` installed.
@@ -658,7 +659,11 @@ RUN_COMMAND = CommandDef(
             default="/shared",
             help="Container mount point for shared dir (default: /shared)",
         ),
-        ArgDef(name="--base", default="ubuntu:24.04", help="Base OS image (default: ubuntu:24.04)"),
+        ArgDef(
+            name="--base",
+            default=DEFAULT_BASE_IMAGE,
+            help=f"Base OS image (default: {DEFAULT_BASE_IMAGE})",
+        ),
         ArgDef(
             name="--family",
             default=None,
@@ -700,7 +705,11 @@ RUN_TOOL_COMMAND = CommandDef(
         ArgDef(name="--name", help="Container name override"),
         ArgDef(name="--timeout", type=int, default=600, help="Timeout in seconds (default: 600)"),
         ArgDef(name="tool_args", nargs="*", help="Extra args passed to the tool (after --)"),
-        ArgDef(name="--base", default="ubuntu:24.04", help="Base OS image (default: ubuntu:24.04)"),
+        ArgDef(
+            name="--base",
+            default=DEFAULT_BASE_IMAGE,
+            help=f"Base OS image (default: {DEFAULT_BASE_IMAGE})",
+        ),
         ArgDef(
             name="--family",
             default=None,
@@ -738,7 +747,7 @@ AUTH_COMMAND = CommandDef(
         ArgDef(name="--api-key", help="Store an API key directly (skip interactive auth)"),
         ArgDef(
             name="--base-image",
-            help="Override the L1 base image (default: ubuntu:24.04 — set per-host once F44 ships)",
+            help=f"Override the L1 base image (default: {DEFAULT_BASE_IMAGE})",
         ),
     ),
 )
@@ -757,7 +766,11 @@ BUILD_COMMAND = CommandDef(
     help="Build L0+L1 container images",
     handler=_handle_build,
     args=(
-        ArgDef(name="--base", default="ubuntu:24.04", help="Base OS image (default: ubuntu:24.04)"),
+        ArgDef(
+            name="--base",
+            default=DEFAULT_BASE_IMAGE,
+            help=f"Base OS image (default: {DEFAULT_BASE_IMAGE})",
+        ),
         ArgDef(
             name="--family",
             default=None,
@@ -842,8 +855,8 @@ SETUP_COMMAND = CommandDef(
         ),
         ArgDef(
             name="--base",
-            default="ubuntu:24.04",
-            help="Base OS image to build L0+L1 on top of (default: ubuntu:24.04)",
+            default=DEFAULT_BASE_IMAGE,
+            help=f"Base OS image to build L0+L1 on top of (default: {DEFAULT_BASE_IMAGE})",
         ),
         ArgDef(
             name="--family",
@@ -877,8 +890,8 @@ UNINSTALL_COMMAND = CommandDef(
         ),
         ArgDef(
             name="--base",
-            default="ubuntu:24.04",
-            help="Base OS image whose L0+L1 cache should be removed (default: ubuntu:24.04)",
+            default=DEFAULT_BASE_IMAGE,
+            help=f"Base OS image whose L0+L1 cache should be removed (default: {DEFAULT_BASE_IMAGE})",
         ),
     ),
 )

--- a/src/terok_executor/config_schema.py
+++ b/src/terok_executor/config_schema.py
@@ -39,7 +39,7 @@ class RawImageSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    base_image: str = Field(default="ubuntu:24.04", description="Base container image for builds")
+    base_image: str = Field(default="fedora:44", description="Base container image for builds")
     family: Literal["deb", "rpm"] | None = Field(
         default=None,
         description=(

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -23,9 +23,9 @@ Usage as a library::
 
     from terok_executor import build_base_images
 
-    images = build_base_images("ubuntu:24.04")
-    # images.l0 = "terok-l0:ubuntu-24.04"
-    # images.l1 = "terok-l1-cli:ubuntu-24.04"
+    images = build_base_images("fedora:44")
+    # images.l0 = "terok-l0:fedora-44"
+    # images.l1 = "terok-l1-cli:fedora-44"
 
 The L0/L1 templates select between Debian/Ubuntu (``apt``) and Fedora-like
 (``dnf``) package managers via a ``family`` Jinja2 variable resolved by
@@ -58,7 +58,7 @@ from jinja2 import BaseLoader, Environment
 
 # ── Vocabulary ──
 
-DEFAULT_BASE_IMAGE = "ubuntu:24.04"
+DEFAULT_BASE_IMAGE = "fedora:44"
 """Default base OS image when none is specified."""
 
 AGENTS_LABEL = "ai.terok.agents"
@@ -91,8 +91,17 @@ def _decode_label_escapes(text: str) -> str:
     return _ESCAPE_RE.sub(lambda m: m.group().encode("ascii").decode("unicode_escape"), text)
 
 
-_DEFAULT_TAG = "ubuntu-24.04"
-"""Pre-sanitized tag fragment for the default base image."""
+_DEFAULT_TAG = "fedora-44"
+"""Pre-sanitized tag fragment for the default base image.
+
+Must stay in sync with the slug of
+[`DEFAULT_BASE_IMAGE`][terok_executor.container.build.DEFAULT_BASE_IMAGE]
+— i.e. the result of feeding ``DEFAULT_BASE_IMAGE`` through the same
+sanitiser ``_base_tag`` applies.  This fallback is reached only when
+the input collapses to an empty string after sanitisation (pathological
+inputs such as ``_base_tag("???")``); normal empty/whitespace input
+short-circuits earlier via ``_normalize_base_image``.
+"""
 
 _MAX_TAG_LEN = 120
 """Cap on the tag portion of an OCI image reference.
@@ -109,7 +118,7 @@ _AGENT_DIGEST_LEN = 12
 # is either a literal ``"deb"``/``"rpm"`` or a tag-aware resolver — used
 # for NVIDIA, where the same repo path ships both Ubuntu (apt) and UBI
 # (dnf) variants and only the tag distinguishes them.
-# "Officially tested" (per AGENTS.md): ubuntu:24.04, fedora:43,
+# "Officially tested" (per AGENTS.md): fedora:44, ubuntu:24.04,
 # quay.io/podman/stable, nvcr.io/nvidia/nvhpc.  Other images in the
 # same family path will match but are unsupported.
 _NVIDIA_UBI_TAG_RE: re.Pattern[str] = re.compile(r"ubi\d+", re.IGNORECASE)
@@ -148,13 +157,13 @@ class ImageSet:
     """L0 + L1 image tags produced by a build."""
 
     l0: str
-    """L0 base dev image tag (e.g. ``terok-l0:ubuntu-24.04``)."""
+    """L0 base dev image tag (e.g. ``terok-l0:fedora-44``)."""
 
     l1: str
-    """L1 agent CLI image tag (e.g. ``terok-l1-cli:ubuntu-24.04``)."""
+    """L1 agent CLI image tag (e.g. ``terok-l1-cli:fedora-44``)."""
 
     l1_sidecar: str | None = None
-    """L1 sidecar image tag, if built (e.g. ``terok-l1-sidecar:ubuntu-24.04``)."""
+    """L1 sidecar image tag, if built (e.g. ``terok-l1-sidecar:fedora-44``)."""
 
 
 # ── Public entry points ──
@@ -263,7 +272,7 @@ def build_base_images(
     non-existent) directory instead.
 
     Args:
-        base_image: Base OS image (e.g. ``ubuntu:24.04``, ``nvidia/cuda:...``).
+        base_image: Base OS image (e.g. ``fedora:44``, ``nvidia/cuda:...``).
         family: Override for the package family (``"deb"`` or ``"rpm"``).
             ``None`` means detect from *base_image* via [`detect_family`][terok_executor.container.build.detect_family].
         agents: Roster entries to install, as the literal string ``"all"``
@@ -394,7 +403,7 @@ def build_sidecar_image(
         build_dir: Build context directory (must be empty or absent).
 
     Returns:
-        The sidecar image tag (e.g. ``terok-l1-sidecar:ubuntu-24.04``).
+        The sidecar image tag (e.g. ``terok-l1-sidecar:fedora-44``).
 
     Raises:
         BuildError: If podman is missing, the family cannot be resolved,
@@ -670,7 +679,7 @@ def l1_image_tag(base_image: str, agents: tuple[str, ...] | None = None) -> str:
     """Return the L1 agent CLI image tag for *base_image* and a selection.
 
     When *agents* is ``None``, returns the unsuffixed **default-alias**
-    (e.g. ``terok-l1-cli:ubuntu-24.04``).  This alias points at whichever
+    (e.g. ``terok-l1-cli:fedora-44``).  This alias points at whichever
     L1 was last built with ``tag_as_default=True`` — i.e. the L1 that
     holds the user's configured default agent selection.  Project /
     per-agent / partial builds get only their suffixed tag and never
@@ -736,7 +745,7 @@ def _split_image_ref(ref: str) -> tuple[str, str]:
 
     Strips an optional ``@digest`` suffix first, then peels off the
     trailing ``:tag`` only when the last ``:`` lies after the last ``/``
-    — so ``localhost:5000/ubuntu:24.04`` keeps the registry port intact
+    — so ``localhost:5000/fedora:44`` keeps the registry port intact
     in *name* and yields ``"24.04"`` as *tag*.  Refs without a tag
     return an empty string for *tag*.
     """

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -62,7 +62,7 @@ class AgentRunner:
         sandbox: Sandbox | None = None,
         runtime: ContainerRuntime | None = None,
         roster: AgentRoster | None = None,
-        base_image: str = "ubuntu:24.04",
+        base_image: str = "fedora:44",
         family: str | None = None,
         cfg: SandboxConfig | None = None,
     ) -> None:

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -44,10 +44,10 @@ class TestImageNaming:
         assert _base_tag("ubuntu:24.04") == "ubuntu-24.04"
 
     def test_empty_falls_back(self) -> None:
-        assert _base_tag("") == "ubuntu-24.04"
+        assert _base_tag("") == "fedora-44"
 
     def test_whitespace_falls_back(self) -> None:
-        assert _base_tag("   ") == "ubuntu-24.04"
+        assert _base_tag("   ") == "fedora-44"
 
     def test_nvidia_cuda(self) -> None:
         tag = _base_tag("nvidia/cuda:12.4.1-devel-ubuntu24.04")
@@ -148,10 +148,10 @@ class TestNormalization:
         assert _normalize_base_image("  ubuntu:24.04  ") == "ubuntu:24.04"
 
     def test_empty_to_default(self) -> None:
-        assert _normalize_base_image("") == "ubuntu:24.04"
+        assert _normalize_base_image("") == "fedora:44"
 
     def test_none_to_default(self) -> None:
-        assert _normalize_base_image(None) == "ubuntu:24.04"
+        assert _normalize_base_image(None) == "fedora:44"
 
     def test_passthrough(self) -> None:
         assert _normalize_base_image("nvidia/cuda:12.4") == "nvidia/cuda:12.4"
@@ -808,8 +808,13 @@ class TestDefaultAliasTagging:
     def test_default_build_omits_alias(self, tmp_path: Path) -> None:
         from unittest.mock import patch
 
-        from terok_executor.container.build import build_base_images
+        from terok_executor.container.build import (
+            DEFAULT_BASE_IMAGE,
+            build_base_images,
+            l1_image_tag,
+        )
 
+        default_alias = l1_image_tag(DEFAULT_BASE_IMAGE)
         build_dir = tmp_path / "ctx"
         with (
             patch("terok_executor.container.build._check_podman"),
@@ -818,14 +823,21 @@ class TestDefaultAliasTagging:
         ):
             build_base_images(build_dir=build_dir)
         l1_cmd = mock_run.call_args_list[1][0][0]
-        # No -t terok-l1-cli:ubuntu-24.04 (the unsuffixed alias) on the L1 build
-        assert "terok-l1-cli:ubuntu-24.04" not in l1_cmd
+        # No -t for the unsuffixed default alias on the L1 build.  Compute
+        # the alias from DEFAULT_BASE_IMAGE so this test stays correct
+        # across base-image bumps without churning the assertion.
+        assert default_alias not in l1_cmd
 
     def test_tag_as_default_includes_alias(self, tmp_path: Path) -> None:
         from unittest.mock import patch
 
-        from terok_executor.container.build import build_base_images
+        from terok_executor.container.build import (
+            DEFAULT_BASE_IMAGE,
+            build_base_images,
+            l1_image_tag,
+        )
 
+        default_alias = l1_image_tag(DEFAULT_BASE_IMAGE)
         build_dir = tmp_path / "ctx"
         with (
             patch("terok_executor.container.build._check_podman"),
@@ -834,8 +846,8 @@ class TestDefaultAliasTagging:
         ):
             build_base_images(build_dir=build_dir, tag_as_default=True)
         l1_cmd = mock_run.call_args_list[1][0][0]
-        # Both the suffixed tag AND the unsuffixed alias appear as -t targets
-        assert "terok-l1-cli:ubuntu-24.04" in l1_cmd
+        # Both the suffixed tag AND the unsuffixed default alias appear as -t targets.
+        assert default_alias in l1_cmd
 
 
 class TestImageAgents:
@@ -1135,8 +1147,8 @@ class TestDetectFamily:
             detect_family("ubuntu:24.04", override="alpine")
 
     def test_blank_falls_back_to_default(self) -> None:
-        # _normalize_base_image turns blank into ubuntu:24.04 → deb.
-        assert detect_family("") == "deb"
+        # _normalize_base_image turns blank into fedora:44 → rpm.
+        assert detect_family("") == "rpm"
 
 
 class TestRenderFamilyAware:

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -80,6 +80,6 @@ def test_view_tolerates_terok_owned_top_level_sections() -> None:
 def test_view_default_construction_is_empty() -> None:
     """An empty ``config.yml`` validates with safe defaults across both layers."""
     view = ExecutorConfigView.model_validate({})
-    assert view.image.base_image == "ubuntu:24.04"
+    assert view.image.base_image == "fedora:44"
     assert view.paths.root is None
     assert view.shield.audit is True

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -53,7 +53,7 @@ class TestAgentRunner:
 
     def test_default_construction(self) -> None:
         runner = AgentRunner()
-        assert runner._base_image == "ubuntu:24.04"
+        assert runner._base_image == "fedora:44"
 
     def test_custom_base_image(self) -> None:
         runner = AgentRunner(base_image="nvidia/cuda:12.4")


### PR DESCRIPTION
## Summary

Flip \`DEFAULT_BASE_IMAGE\` from \`ubuntu:24.04\` to \`fedora:44\` together with every other site that encoded the same default — pydantic schema, AgentRunner / commands defaults, CLI ArgDef defaults + help strings, and the "officially tested" registry comment.

The same change cascades into terok's host-wide \`terok auth\` flow: \`get_global_image_base_image()\` reads \`DEFAULT_BASE_IMAGE\` when the user hasn't pinned \`image.base_image\`, so the taskless auth container also lands on fedora:44 without forcing a parallel default L1 just for auth.

## What lands

- \`container/build.py\` — \`DEFAULT_BASE_IMAGE = "fedora:44"\` + the four matching docstring / comment examples
- \`container/runner.py\` — \`AgentRunner.__init__\` default
- \`config_schema.py\` — pydantic \`Field(default=...)\` on \`base_image\`
- \`commands.py\` — six handler-fn defaults + four CLI ArgDef defaults + four help-string mentions (one stale "set per-host once F44 ships" hint deleted)
- 8 tests that pinned the old default get matching one-liner updates

## Test fixtures intentionally left alone

Many tests use \`ubuntu:24.04\` as a generic image-string for parser / family-detection / template-rendering coverage — those aren't pinning "what version is current" and would just churn without value.

## Paired with terok-ai/terok#975

Which bumps the user-facing default Fedora reference in terok itself (wizard, README, docs, help text) from \`fedora:43\` to \`fedora:44\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Default container base image changed from Ubuntu 24.04 to Fedora 44 across commands, config defaults, and CLI help text. Existing CLI options and config still allow custom base images.
* **Tests**
  * Updated unit tests and examples to reflect the new Fedora 44 default and its impact on image naming and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->