### PR TITLE
feat(commands): split `agents` into `list` + `set` subverbs

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -25,9 +25,28 @@ Tools run alongside an agent in a separate container:
 ## Listing agents
 
 ```bash
-terok-executor agents            # coding agents only
-terok-executor agents --all      # include tools (gh, glab, coderabbit, sonarcloud)
+terok-executor agents list           # coding agents only
+terok-executor agents list --all     # include tools (gh, glab, coderabbit, sonarcloud)
 ```
+
+## Setting the global default
+
+The same selection string that `terok-executor build --agents …` accepts
+also drives the global default that's baked into L1 images when a
+project does not override `image.agents`:
+
+```bash
+terok-executor agents set                # interactive picker
+terok-executor agents set all            # every roster entry
+terok-executor agents set claude,vibe    # explicit list
+terok-executor agents set all,-vibe      # everything except vibe
+```
+
+The value lands in `~/.config/terok/config.yml` under `image.agents` by
+default — `/etc/terok/config.yml` when running as root, or whatever
+`TEROK_CONFIG_FILE` points at when that env var is set.
+Validation runs against the installed roster up front, so the file
+never references a name that won't resolve at build time.
 
 ## Authentication
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ Security = "https://github.com/terok-ai/terok-executor/security/policy"
 terok-executor = "terok_executor.cli:main"
 
 [tool.poetry]
-version = "0.0.149a8"
+version = "0.0.149a9"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -41,7 +41,20 @@ from .acp import (
     acp_socket_is_live,
     list_authenticated_agents,
 )
-from .commands import COMMANDS as AGENT_COMMANDS, CommandDef
+from .commands import (
+    COMMANDS as AGENT_COMMANDS,
+    CommandDef,
+    prompt_agents_selection,
+    validate_agent_selection,
+)
+
+# -- Global config writers (executor-owned slices of config.yml) ---------------
+from .config import (
+    get_global_image_agents,
+    get_global_image_base_image,
+    set_global_image_agents,
+    writable_config_path,
+)
 
 # -- Config schema (executor-owned slice of the shared config.yml) -----------
 from .config_schema import ExecutorConfigView, RawImageSection
@@ -191,6 +204,11 @@ __all__ = [
     # Config schema (executor-owned slice of the shared config.yml)
     "ExecutorConfigView",
     "RawImageSection",
+    # Global config writers (executor-owned slices of config.yml)
+    "get_global_image_agents",
+    "get_global_image_base_image",
+    "set_global_image_agents",
+    "writable_config_path",
     # Build: image construction + resource staging
     "AGENTS_LABEL",
     "DEFAULT_BASE_IMAGE",
@@ -226,6 +244,8 @@ __all__ = [
     "COMMANDS",
     "VAULT_COMMANDS",
     "CommandDef",
+    "prompt_agents_selection",
+    "validate_agent_selection",
     "mounts_dir",
     "scan_leaked_credentials",
     "ConfigPatchError",

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -346,12 +346,13 @@ def _handle_auth(
             raise SystemExit(f"Unknown provider: {agent}. Available: {available}")
         store_api_key(agent, api_key.strip())
     else:
+        from .config import get_global_image_base_image
         from .container.build import ensure_default_l1
         from .paths import mounts_dir
 
         # Lazy: if the user picks API key from the OAuth-or-API-key prompt,
         # ensure_default_l1 is never invoked and we don't pay for an L1 build.
-        base = base_image or DEFAULT_BASE_IMAGE
+        base = base_image or get_global_image_base_image() or DEFAULT_BASE_IMAGE
         authenticate(
             None,
             agent,
@@ -365,7 +366,7 @@ def _handle_auth(
     write_vault_config(agent)
 
 
-def _handle_agents(*, show_all: bool = False) -> None:
+def _handle_agents_list(*, show_all: bool = False) -> None:
     """List registered agents."""
     import sys
 
@@ -395,6 +396,54 @@ def _handle_agents(*, show_all: bool = False) -> None:
     print(f"{'NAME':<{w_name}}  {'LABEL':<{w_label}}  TYPE")
     for name, label, kind in rows:
         print(f"{name:<{w_name}}  {label:<{w_label}}  {kind}")
+
+
+def prompt_agents_selection() -> str:
+    """Print the installed roster and read one line of executor grammar.
+
+    Empty input → ``"all"``.  Non-interactive stdin (closed pipe) exits
+    with a hint to pass the selection positionally instead.
+    """
+    from .roster.loader import get_roster
+
+    roster = get_roster()
+    providers = roster.providers
+    print("\nAvailable agents:")
+    for name in sorted(roster.agent_names):
+        provider = providers.get(name)
+        label = provider.label if provider is not None else name
+        print(f"  · {name}  — {label}")
+    try:
+        raw = input("\nType a comma list, or '-name' to exclude [all]: ").strip()
+    except EOFError as exc:
+        raise SystemExit(
+            "No interactive stdin available.  Pass the selection positionally "
+            "instead, e.g. `terok agents set all`."
+        ) from exc
+    return raw or "all"
+
+
+def validate_agent_selection(raw: str) -> None:
+    """Reject *raw* with ``SystemExit(2)`` if it names roster entries we don't have."""
+    import sys
+
+    from .roster.loader import get_roster, parse_agent_selection
+
+    try:
+        get_roster().resolve_selection(parse_agent_selection(raw))
+    except ValueError as exc:
+        print(f"Invalid agent selection: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+
+def _handle_agents_set(*, selection: str | None = None) -> None:
+    """Write the global ``image.agents`` default to ``config.yml``."""
+    from .config import set_global_image_agents
+
+    raw = selection if selection is not None else prompt_agents_selection()
+    validate_agent_selection(raw)
+    path = set_global_image_agents(raw)
+    print(f"Wrote image.agents = {raw!r} to {path}")
 
 
 def _handle_build(
@@ -747,17 +796,49 @@ AUTH_COMMAND = CommandDef(
         ArgDef(name="--api-key", help="Store an API key directly (skip interactive auth)"),
         ArgDef(
             name="--base-image",
-            help=f"Override the L1 base image (default: {DEFAULT_BASE_IMAGE})",
+            help=(
+                "Override the L1 base image "
+                f"(default: image.base_image from config.yml, else {DEFAULT_BASE_IMAGE})"
+            ),
         ),
     ),
 )
 
 AGENTS_COMMAND = CommandDef(
     name="agents",
-    help="List registered agents (use --all to include tools like gh, glab)",
-    handler=_handle_agents,
-    args=(
-        ArgDef(name="--all", action="store_true", dest="show_all", help="Include tools (gh, glab)"),
+    help="Inspect the agent roster and set the build-time default selection",
+    children=(
+        CommandDef(
+            name="list",
+            help="List registered agents (use --all to include tools like gh, glab)",
+            handler=_handle_agents_list,
+            args=(
+                ArgDef(
+                    name="--all",
+                    action="store_true",
+                    dest="show_all",
+                    help="Include tools (gh, glab)",
+                ),
+            ),
+        ),
+        CommandDef(
+            name="set",
+            help="Set the global image.agents default in config.yml (interactive when no arg)",
+            handler=_handle_agents_set,
+            args=(
+                ArgDef(
+                    name="selection",
+                    nargs="?",
+                    default=None,
+                    help=(
+                        "Agent selection in the executor's canonical grammar: "
+                        '"all", a comma list ("claude,vibe"), or "all,-name" '
+                        'to exclude one ("all,-vibe").  Interactive picker '
+                        "when omitted."
+                    ),
+                ),
+            ),
+        ),
     ),
 )
 

--- a/src/terok_executor/config.py
+++ b/src/terok_executor/config.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reads and writes the executor's slice of the global ``config.yml`` (``image:``).
+
+The ``image:`` section is the executor's schema slice — ``base_image``
+seeds every L0/L1 build's FROM line, ``agents`` picks which roster
+entries are baked in.  Readers return the merged effective value;
+``None`` distinguishes "operator hasn't chosen yet" from any explicit
+value.  The writer goes through
+[`yaml_update_section`][terok_sandbox.yaml_update_section] so the
+on-disk replace is atomic and the file mode stays 0o600.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from terok_sandbox import yaml_update_section
+from terok_sandbox.paths import namespace_config_dir, read_config_section
+
+__all__ = [
+    "get_global_image_agents",
+    "get_global_image_base_image",
+    "set_global_image_agents",
+    "writable_config_path",
+]
+
+
+def get_global_image_agents() -> str | None:
+    """Return the effective ``image.agents``, or ``None`` when unset.
+
+    ``None`` distinguishes "field absent" from ``"all"`` (the explicit
+    "every roster entry" selector).
+    """
+    return read_config_section("image").get("agents") or None
+
+
+def get_global_image_base_image() -> str | None:
+    """Return the explicit ``image.base_image``, or ``None`` when unset.
+
+    Callers apply the schema fallback themselves
+    ([`DEFAULT_BASE_IMAGE`][terok_executor.DEFAULT_BASE_IMAGE]) — keeping
+    that constant out of this module preserves the foundation-layer
+    boundary (config sits below container/build).
+    """
+    return read_config_section("image").get("base_image") or None
+
+
+def set_global_image_agents(selection: str) -> Path:
+    """Write *selection* into ``image.agents`` and return the file path.
+
+    Caller validates *selection* up-front (typically via
+    [`validate_agent_selection`][terok_executor.validate_agent_selection]).
+    """
+    path = writable_config_path()
+    yaml_update_section(path, "image", {"agents": selection})
+    return path
+
+
+def writable_config_path() -> Path:
+    """Return the path the next config write should target.
+
+    Honours ``TEROK_CONFIG_FILE`` when set; otherwise the user-scope
+    file under [`namespace_config_dir`][terok_sandbox.paths.namespace_config_dir].
+    """
+    env = os.getenv("TEROK_CONFIG_FILE")
+    if env:
+        return Path(env).expanduser()
+    return namespace_config_dir() / "config.yml"

--- a/tach.toml
+++ b/tach.toml
@@ -43,6 +43,12 @@ depends_on = []
 path = "terok_executor.vault_addr"
 depends_on = []
 
+# Global config.yml writers (executor-owned sections — currently image.agents).
+# Depends only on terok_sandbox (external).
+[[modules]]
+path = "terok_executor.config"
+depends_on = []
+
 # ── roster/ — agent catalog ─────────────────────────────────────────
 
 # Runtime dataclasses — pure data, zero deps
@@ -246,6 +252,7 @@ depends_on = [
 path = "terok_executor.commands"
 depends_on = [
     "terok_executor.acp",
+    "terok_executor.config",
     "terok_executor.container.build",
     "terok_executor.container.runner",
     "terok_executor.credentials.auth",
@@ -288,6 +295,7 @@ depends_on = [
     "terok_executor._tree",
     "terok_executor.acp",
     "terok_executor.commands",
+    "terok_executor.config",
     "terok_executor.container.build",
     "terok_executor.container.cache",
     "terok_executor.container.env",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -30,11 +30,11 @@ def _run_cli(*args: str) -> tuple[str, str, int]:
     return stdout.getvalue(), stderr.getvalue(), code
 
 
-class TestAgentsCommand:
-    """Verify ``terok-executor agents`` output."""
+class TestAgentsListCommand:
+    """Verify ``terok-executor agents list`` output."""
 
     def test_agents_lists_agents_only(self) -> None:
-        out, _, rc = _run_cli("agents")
+        out, _, rc = _run_cli("agents", "list")
         assert rc == 0
         assert "claude" in out
         assert "codex" in out
@@ -43,21 +43,21 @@ class TestAgentsCommand:
         assert not any(line.startswith("gh ") for line in data_lines)
 
     def test_agents_all_includes_tools(self) -> None:
-        out, _, rc = _run_cli("agents", "--all")
+        out, _, rc = _run_cli("agents", "list", "--all")
         assert rc == 0
         assert "gh" in out
         assert "glab" in out
         assert "tool" in out
 
     def test_agents_shows_kind_types(self) -> None:
-        out, _, _ = _run_cli("agents", "--all")
+        out, _, _ = _run_cli("agents", "list", "--all")
         assert "native" in out
         assert "opencode" in out
         assert "bridge" in out
         assert "tool" in out
 
     def test_agents_has_header(self) -> None:
-        out, _, _ = _run_cli("agents")
+        out, _, _ = _run_cli("agents", "list")
         assert "NAME" in out
         assert "LABEL" in out
         assert "TYPE" in out
@@ -69,9 +69,16 @@ class TestAgentsCommand:
         assert "usage:" in combined
         assert "agents" in combined
 
+    def test_bare_agents_shows_group_help(self) -> None:
+        """``terok-executor agents`` with no subverb prints the group's help."""
+        out, err, _ = _run_cli("agents")
+        combined = (out + err).lower()
+        assert "list" in combined
+        assert "set" in combined
+
     def test_agents_column_alignment(self) -> None:
         """Header and data columns should be aligned."""
-        out, _, _ = _run_cli("agents")
+        out, _, _ = _run_cli("agents", "list")
         lines = out.strip().split("\n")
         assert "LABEL" in lines[0], "Header missing LABEL column"
         label_col = lines[0].index("LABEL")
@@ -81,6 +88,54 @@ class TestAgentsCommand:
     def test_unknown_subcommand_exits_nonzero(self) -> None:
         _, _, rc = _run_cli("nonexistent")
         assert rc != 0
+
+
+class TestAgentsSetCommand:
+    """Verify ``terok-executor agents set`` writes and validates."""
+
+    @pytest.fixture
+    def override_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Route writes through a per-test config.yml and clear sandbox's cache."""
+        cfg = tmp_path / "config.yml"
+        monkeypatch.setenv("TEROK_CONFIG_FILE", str(cfg))
+
+        from terok_sandbox import paths as sandbox_paths
+
+        sandbox_paths._config_section_cache.clear()
+        return cfg
+
+    def test_set_writes_selection(self, override_config: Path) -> None:
+        out, _, rc = _run_cli("agents", "set", "claude")
+        assert rc == 0
+        assert override_config.read_text(encoding="utf-8").strip().endswith("agents: claude")
+        assert str(override_config) in out
+
+    def test_set_accepts_all(self, override_config: Path) -> None:
+        _, _, rc = _run_cli("agents", "set", "all")
+        assert rc == 0
+        assert "agents: all" in override_config.read_text(encoding="utf-8")
+
+    def test_set_accepts_exclude_form(self, override_config: Path) -> None:
+        _, _, rc = _run_cli("agents", "set", "all,-vibe")
+        assert rc == 0
+        # ruamel may quote the value because of the comma; check substring.
+        assert "all,-vibe" in override_config.read_text(encoding="utf-8")
+
+    def test_set_rejects_unknown_agent(self, override_config: Path) -> None:
+        _, err, rc = _run_cli("agents", "set", "nonexistent-agent")
+        assert rc != 0
+        assert "Invalid agent selection" in err
+        # File should not be created on validation failure.
+        assert not override_config.exists()
+
+    def test_set_prompts_when_no_arg(
+        self, override_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty positional → interactive prompt; empty input falls back to ``all``."""
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+        _, _, rc = _run_cli("agents", "set")
+        assert rc == 0
+        assert "agents: all" in override_config.read_text(encoding="utf-8")
 
 
 class TestSharedDirArgs:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the executor's global-config write helpers.
+
+[`set_global_image_agents`][terok_executor.set_global_image_agents] is
+the surface every "set the default agents" entry point routes through —
+``terok-executor agents set``, the terok wrapper's mirror, and the TUI
+modal.  Round-trip preservation and parent-dir auto-creation are the
+contracts the callers rely on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from terok_executor.config import (
+    get_global_image_agents,
+    get_global_image_base_image,
+    set_global_image_agents,
+    writable_config_path,
+)
+
+
+@pytest.fixture
+def override_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point `TEROK_CONFIG_FILE` at a per-test path and clear sandbox's reader cache.
+
+    Sandbox's [`read_config_section`][terok_sandbox.paths.read_config_section]
+    caches results across calls, so a stale cache from an earlier test
+    would mask the freshly-written file.  Reset before the test so the
+    reader sees an empty starting state.
+    """
+    cfg = tmp_path / "config.yml"
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(cfg))
+
+    from terok_sandbox import paths as sandbox_paths
+
+    sandbox_paths._config_section_cache.clear()
+    return cfg
+
+
+class TestWritableConfigPath:
+    """The path picker honours TEROK_CONFIG_FILE and falls back to namespace dir."""
+
+    def test_honours_env_override(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``TEROK_CONFIG_FILE`` wins over the namespace lookup."""
+        target = tmp_path / "custom.yml"
+        monkeypatch.setenv("TEROK_CONFIG_FILE", str(target))
+        assert writable_config_path() == target
+
+    def test_falls_back_to_namespace_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No override → ``namespace_config_dir() / 'config.yml'``."""
+        monkeypatch.delenv("TEROK_CONFIG_FILE", raising=False)
+        from terok_sandbox.paths import namespace_config_dir
+
+        assert writable_config_path() == namespace_config_dir() / "config.yml"
+
+
+class TestSetGlobalImageAgents:
+    """End-to-end write semantics: creates parent, preserves comments, round-trips."""
+
+    def test_creates_file_when_missing(self, override_config: Path) -> None:
+        """Missing target file is created, parent dirs included."""
+        assert not override_config.exists()
+        path = set_global_image_agents("claude,vibe")
+        assert path == override_config
+        assert override_config.read_text(encoding="utf-8").strip().startswith("image:")
+
+    def test_creates_parent_dirs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Deeply-nested parent is created."""
+        target = tmp_path / "deep" / "nested" / "config.yml"
+        monkeypatch.setenv("TEROK_CONFIG_FILE", str(target))
+        set_global_image_agents("all")
+        assert target.is_file()
+
+    def test_updates_existing_image_section(self, override_config: Path) -> None:
+        """Updating an existing image.agents key replaces the value, keeps siblings."""
+        override_config.write_text(
+            "image:\n  base_image: ubuntu:24.04\n  agents: claude\n", encoding="utf-8"
+        )
+        set_global_image_agents("all,-vibe")
+        content = override_config.read_text(encoding="utf-8")
+        assert "agents: all,-vibe" in content
+        assert "base_image: ubuntu:24.04" in content
+
+    def test_preserves_other_top_level_sections(self, override_config: Path) -> None:
+        """A pre-existing unrelated top-level section survives the write."""
+        override_config.write_text(
+            "tui:\n  default_tmux: true\nimage:\n  agents: claude\n", encoding="utf-8"
+        )
+        set_global_image_agents("vibe")
+        content = override_config.read_text(encoding="utf-8")
+        assert "default_tmux: true" in content
+        assert "agents: vibe" in content
+
+    def test_preserves_comments(self, override_config: Path) -> None:
+        """``ruamel.yaml`` round-trip keeps top-level comments and ordering."""
+        override_config.write_text(
+            "# Top comment\nimage:\n  # inline comment\n  agents: claude\n",
+            encoding="utf-8",
+        )
+        set_global_image_agents("vibe")
+        content = override_config.read_text(encoding="utf-8")
+        assert "# Top comment" in content
+        assert "# inline comment" in content
+        assert "agents: vibe" in content
+
+
+class TestGetGlobalImageAgents:
+    """The merged-stack reader resolves ``None`` for absent, value for present."""
+
+    def test_returns_none_when_unset(self, override_config: Path) -> None:  # noqa: ARG002
+        """No file → ``None``; distinguishes from explicit ``"all"``."""
+        assert get_global_image_agents() is None
+
+    def test_round_trip_after_set(self, override_config: Path) -> None:  # noqa: ARG002
+        """``set`` then ``get`` returns the value that was written."""
+        set_global_image_agents("claude,vibe")
+        # Reset cache so the freshly-written file is re-read.
+        from terok_sandbox import paths as sandbox_paths
+
+        sandbox_paths._config_section_cache.clear()
+        assert get_global_image_agents() == "claude,vibe"
+
+
+class TestGetGlobalImageBaseImage:
+    """The merged-stack reader resolves ``None`` for absent, value for present."""
+
+    def test_returns_none_when_unset(self, override_config: Path) -> None:  # noqa: ARG002
+        """No file → ``None``; callers apply the schema fallback themselves."""
+        assert get_global_image_base_image() is None
+
+    def test_returns_explicit_value(self, override_config: Path) -> None:
+        """An explicit ``image.base_image`` is returned verbatim."""
+        override_config.write_text("image:\n  base_image: ubuntu:24.04\n", encoding="utf-8")
+        assert get_global_image_base_image() == "ubuntu:24.04"

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -747,10 +747,21 @@ class TestCommandRegistry:
     """Verify the command registry is well-formed."""
 
     def test_all_commands_have_handlers(self) -> None:
+        """Every *leaf* CommandDef must have a handler; groups (children) need none."""
         from terok_executor.commands import COMMANDS
 
+        def _walk_leaves(cmd: object, path: str = "") -> None:
+            qualified = f"{path}{cmd.name}"  # type: ignore[attr-defined]
+            if cmd.is_group:  # type: ignore[attr-defined]
+                for child in cmd.children:  # type: ignore[attr-defined]
+                    _walk_leaves(child, f"{qualified} ")
+            else:
+                assert cmd.handler is not None, (  # type: ignore[attr-defined]
+                    f"Leaf command '{qualified}' has no handler"
+                )
+
         for cmd in COMMANDS:
-            assert cmd.handler is not None, f"Command '{cmd.name}' has no handler"
+            _walk_leaves(cmd)
 
     def test_run_command_has_agent_arg(self) -> None:
         from terok_executor.commands import RUN_COMMAND


### PR DESCRIPTION
## Summary

- `agents` becomes a CommandDef group; verbs split into `agents list [--all]` (existing behavior, renamed leaf) and `agents set [SELECTION]` (writes the global `image.agents` default to `config.yml`).
- New `terok_executor.config` module exposes `get_global_image_agents`, `set_global_image_agents`, and `writable_config_path` for downstream callers (terok wrapper, TUI modal) so they can use the same code path without subprocess.
- `set` validates against the installed roster up front via `parse_agent_selection` + `AgentRoster.resolve_selection` — bad names are rejected before the file is touched.
- Interactive picker when `SELECTION` is omitted: lists installed agents, accepts the same comma-list grammar that `build --agents` and the new-project wizard already use. Empty input defaults to `all`.
- ruamel.yaml round-trip writer preserves existing comments, ordering, and unrelated top-level sections.

No backward-compat shim — per the project's compatibility posture, the renamed verb is a clean break.

## Why

terok's TUI/CLI is gaining on-demand entry points for editing the agent selection (global default + per-project override). The wrapper layer in terok wants to delegate to one canonical code path; this PR plants it where it belongs (the executor owns the `image.agents` schema slice).

## Test plan

- [x] `make check` clean: lint, ruff format, tach, docstrings (97.1%), reuse, security, full pytest (873 + 14 new = 887 pass)
- [x] `terok-executor agents list [--all]` parity with old `agents` behavior
- [x] `terok-executor agents set claude,vibe` writes the expected YAML
- [x] `terok-executor agents set` (no arg) prompts and accepts a comma list
- [x] Unknown agent name rejected; file not created
- [x] `ruamel.yaml` round-trip preserves comments and sibling top-level sections (tested in `test_config.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `agents` subcommands: `list` (with `--all`) and `set`, interactive picker, selection validation, and persisting a global `image.agents` default.
  * Auth flows now default to the global `image.base_image` when no base image is provided.

* **Documentation**
  * Updated CLI examples and guidance on establishing the global `image.agents` default, interactive vs explicit setting, and build-time validation.

* **Tests**
  * Expanded coverage for listing, setting, validation, persistence, and base-image retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->