### PR TITLE
chore: drop stale PR-pin commentary from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,6 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 dependencies = [
-    # Pinned to the sliwowitz fork branch carrying the sandbox-owned
-    # ``run:`` config section (sliwowitz/terok-sandbox PR / branch
-    # feat/run-section-on-sandbox).  Restore the release-wheel pin
-    # before this PR merges.
     "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a10/terok_sandbox-0.0.124a10-py3-none-any.whl",
     "ruamel.yaml>=0.18",
     "Jinja2>=3.1",


### PR DESCRIPTION
## Summary

The 4-line comment block above the `terok-sandbox` dependency in #338 explained that the URL was temporarily pointed at sliwowitz's PR branch and asked the reader to restore the release-wheel pin before merging.

The release script bumped the URL to the release-wheel pin without touching the comment, so the comment shipped as a lie when #338 merged.

Drop it.  The pin is a release-wheel URL — readable as exactly what it is, with no need for a narrator.

Sandbox + terok pyproject.toml files have already been audited and are clean (terok was fixed in terok#986; sandbox never had any).

## Test plan

- [x] `make lint` clean
- [x] `poetry lock` consistent (comment-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified configuration by removing obsolete documentation comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->