### PR TITLE
chore(pyproject): pin static version below packages so dynver build is a no-op

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ Security = "https://github.com/terok-ai/terok-executor/security/policy"
 terok-executor = "terok_executor.cli:main"
 
 [tool.poetry]
-version = "0.0.149a13"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
@@ -54,6 +53,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
+version = "0.0.149a13"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"


### PR DESCRIPTION
## Summary

`poetry-dynamic-versioning` rewrites `pyproject.toml` at every build and restores the `version` key at the bottom of `[tool.poetry]`, not where it originally sat. Running `pipx install .` (or any `poetry build`) from a clean clone therefore left a dirty worktree:

```diff
 [tool.poetry]
-version = "X.Y.Z"
 classifiers = [ ... ]
 packages = [ ... ]
+version = "X.Y.Z"
```

Pre-positioning `version` where dynver restores it makes the build idempotent against the file. Verified locally: `cp pyproject.toml /tmp/before && poetry build && diff /tmp/before pyproject.toml` is empty.

## Release-script impact

terok-warden/terok-toolbox bumps this key on tag day. The new location is still inside `[tool.poetry]`, so a regex like `^version = "..."` keeps matching. If the script looks at line number rather than section context, it will need a one-line update.

## Test plan

- [x] `poetry build` leaves `pyproject.toml` unchanged.
- [ ] Same on consumer side via `pipx install .` from clean clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configuration metadata reorganization with no functional changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->