### PR TITLE
fix(krun): sshd runs as root, dropping to dev (or root) on auth

### DIFF
--- a/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
@@ -32,17 +32,37 @@ set -euo pipefail
 # so a botched L0 with a non-empty placeholder can't accidentally
 # expose sshd under crun.
 #
+# Under krun the container is uid 0 inside the guest — libkrun ignores
+# the L0's ``USER dev`` directive (and ``--userns=keep-id``), so this
+# block runs as root and ``sudo`` would fail anyway under libkrun's
+# virtio-fs (the host-side virtio-fs server runs unprivileged on the
+# host and can't honour setuid exec).  See docs/runtimes.md.  Sshd
+# itself runs as root, listens on 22, and drops to the authenticated
+# user on connection — same model as any multi-user host.
+#
+# Operators can log in as ``dev`` (default, for AI agents that refuse
+# uid 0) or as ``root`` (escape hatch for tasks that need privileged
+# ops — sudo doesn't work, this is the workaround).  The two paths
+# share the same bind-mounted authorized_keys file; the root path is
+# wired in here (not baked into the L0) so a crun-mode image carries
+# nothing that would authorise a root ssh session.  ``-o`` overrides
+# the L0's restrictive ``PermitRootLogin no`` + ``AllowUsers dev``
+# baked defaults — first-wins, and ``-o`` is processed before the
+# config file.
+#
 # The supervisor loop restarts sshd if it crashes (panic, OOM, etc.);
 # ``setsid`` puts the loop in its own session so SIGHUP from the outer
-# init shell (which exits after ``exec bash`` below) can't take it
-# down.  ``/run/sshd`` is sshd's privsep chroot — package-created on
-# rpm but not always on deb, so we mkdir defensively.
+# init shell (which exits after ``exec bash`` below) can't take it down.
 if [[ "${TEROK_CONTAINER_RUNTIME:-}" == "krun" ]]; then
-  echo ">> starting sshd supervisor on TCP 22 (krun mode)"
-  sudo mkdir -p /run/sshd
-  sudo setsid bash -c '
+  echo ">> starting sshd supervisor on TCP 22 (krun mode — root + dev login)"
+  mkdir -p /run/sshd /root/.ssh
+  ln -sf /etc/ssh/authorized_keys.d/terok /root/.ssh/authorized_keys
+  chmod 700 /root/.ssh
+  setsid bash -c '
     while :; do
-      /usr/sbin/sshd -D -e
+      /usr/sbin/sshd -D -e \
+        -o "AllowUsers dev root" \
+        -o "PermitRootLogin without-password"
       echo "[sshd-supervisor] sshd exited (code $?); restarting in 1s" >&2
       sleep 1
     done

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -650,15 +650,29 @@ class TestTemplateRendering:
 
     def test_init_script_carries_krun_sshd_supervisor(self) -> None:
         """``init-ssh-and-repo.sh`` is what actually starts sshd under krun
-        (no systemd to do it).  Pin the three load-bearing tokens so a
-        regression that silently strips the launch is caught at build time
-        rather than at the next failed ``terok login``:
+        (no systemd to do it).  Pin the load-bearing tokens so a regression
+        that silently strips the launch is caught at build time rather than
+        at the next failed ``terok login``:
 
         - ``TEROK_CONTAINER_RUNTIME`` — the explicit gate (set by terok
-          only under krun; absent under crun ⇒ no sshd)
+          only under krun; absent under crun ⇒ no sshd ⇒ none of the
+          krun-specific behaviour below activates)
         - ``/usr/sbin/sshd`` — the actual binary invocation
         - ``setsid`` — the supervisor loop runs in a detached session so
           the outer init shell exiting can't take it down
+        - **no** ``sudo`` inside the krun gate block — the container PID 1
+          is already root under krun (libkrun ignores the L0's ``USER dev``
+          directive) and ``sudo`` would fail anyway under libkrun's
+          virtio-fs (the host-side server can't honour setuid exec)
+        - ``AllowUsers dev root`` + ``PermitRootLogin without-password``
+          override flags — sshd is started with these as ``-o`` args
+          (first-wins) so both the dev (default for agents that refuse
+          uid 0) and root (escape hatch for tasks that need privileged
+          ops) login paths work
+        - ``/root/.ssh/authorized_keys`` symlink — root-login plumbing
+          is created here at runtime (not baked into the L0) so a
+          crun-mode image carries nothing that would authorise a root
+          ssh session
         """
         script_path = (
             Path(__file__).resolve().parent.parent.parent
@@ -672,6 +686,20 @@ class TestTemplateRendering:
         assert "TEROK_CONTAINER_RUNTIME" in text
         assert "/usr/sbin/sshd" in text
         assert "setsid" in text
+        # Extract just the krun-gate block so unrelated future sudo uses
+        # elsewhere in the script don't false-positive this guard.
+        block_start = text.find('"${TEROK_CONTAINER_RUNTIME:-}" == "krun"')
+        assert block_start >= 0, "krun gate disappeared"
+        block_end = text.find("\nfi\n", block_start)
+        block = text[block_start:block_end]
+        assert "sudo" not in block, (
+            "sudo crept back into the krun sshd block — won't work on libkrun's virtiofs"
+        )
+        # Both login paths and their wiring belong to the krun branch and
+        # nowhere else (so the crun image's L0 stays root-login-free).
+        assert "AllowUsers dev root" in block
+        assert "PermitRootLogin without-password" in block
+        assert "/root/.ssh/authorized_keys" in block
 
     def test_l0_hardens_sshd_to_pubkey_only_dev_only_no_forwarding(self) -> None:
         """The sshd config drop-in collapses the surface to a single


### PR DESCRIPTION
## Summary

Real-world test on libkrun 1.17 turned up two upstream constraints that break the previous ``sudo``-based sshd launch end-to-end:

1. **libkrun ignores the L0's ``USER dev`` directive (and ``--userns=keep-id``)** — the container PID 1 runs as **uid 0** inside the guest, regardless of what podman was told.  Verified empirically:

   ```
   $ podman run --rm --runtime krun -it terok-k:l2-cli bash -c 'id'
   uid=0(root) gid=0(root) groups=0(root)
   $ podman run --rm                -it terok-k:l2-cli bash -c 'id'   # crun
   uid=1000(dev) gid=1000(dev) groups=1000(dev)
   ```

2. **libkrun's virtio-fs server runs unprivileged on the host**, so it can't honour setuid-exec from the guest — exec'ing ``/usr/bin/sudo`` fails with EACCES even when the caller is the (faked) guest root, and even ``setcap`` / ``chmod`` on the binary fail with EPERM.

Both are libkrun architectural properties, not configurable from podman or terok.  No workaround inside the container will recover sudo under krun.

## Fix

Lean into "we're already root in the guest" instead of fighting it:

- Sshd starts **as root** (no sudo needed, we *are* root), listens on 22.
- Authenticates against the bind-mounted ``/etc/ssh/authorized_keys.d/terok``, drops to the authenticated user for the session.
- ``-o`` flags override the L0's restrictive ``PermitRootLogin no`` + ``AllowUsers dev`` for *this sshd instance only* (first-wins, ``-o`` is processed before ``sshd_config.d/00-terok.conf``).

Two login paths share the same authorized_keys file:

- ``ssh dev@…`` (default — for AI agents that refuse uid 0)
- ``ssh root@…`` (escape hatch — for tasks that need privileged ops, since sudo isn't available)

Root-login plumbing (the symlink at ``/root/.ssh/authorized_keys`` + the override flags) is wired in at **init time, not baked into the L0**, so a crun-mode image carries nothing that would authorise a root ssh session.

## Crun impact: zero

The whole block is gated by ``[[ \"\${TEROK_CONTAINER_RUNTIME:-}\" == \"krun\" ]]`` (set by terok only under krun); the L0 stays byte-identical between runtimes; under crun nothing in the block executes.

The L0's ``00-terok.conf`` still bakes ``PermitRootLogin no`` + ``AllowUsers dev`` as the *defaults* — correct for crun (where sshd never runs) and overridden only for the krun-launched sshd instance.

## Test plan

- [x] ``make check`` clean
- [x] 897 unit tests pass
- [x] ``test_init_script_carries_krun_sshd_supervisor`` extended to pin: no ``sudo`` in the krun block; ``AllowUsers dev root``; ``PermitRootLogin without-password``; ``/root/.ssh/authorized_keys``
- [x] ``test_l0_hardens_sshd_to_pubkey_only_dev_only_no_forwarding`` unchanged — pins the L0 defaults (``PermitRootLogin no``, ``AllowUsers dev``) the runtime overrides relax
- [ ] Manual on Silverblue: ``terok task run terok-k`` then both ``ssh dev@127.0.0.1 -p <port>`` and ``ssh root@127.0.0.1 -p <port>`` open shells

## Companion docs PR

Docs (``docs/runtimes.md``) will land in terok separately — the limitations are upstream-libkrun and want to be documented at the runtime level, not the L0 level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH initialization in container environments to properly handle mounted authorized keys.
  * Restricted SSH root access to key-based authentication only for enhanced security.

* **Tests**
  * Enhanced test coverage for SSH configuration and security requirements in containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->