### PR TITLE
fix(krun): bake /root/.ssh + PID-file workaround — virtiofs can't honour runtime root-owned writes

### DIFF
--- a/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
@@ -42,27 +42,31 @@ set -euo pipefail
 #
 # Operators can log in as ``dev`` (default, for AI agents that refuse
 # uid 0) or as ``root`` (escape hatch for tasks that need privileged
-# ops — sudo doesn't work, this is the workaround).  The two paths
-# share the same bind-mounted authorized_keys file; the root path is
-# wired in here (not baked into the L0) so a crun-mode image carries
-# nothing that would authorise a root ssh session.  ``-o`` overrides
+# ops — sudo doesn't work, this is the workaround).  ``-o`` overrides
 # the L0's restrictive ``PermitRootLogin no`` + ``AllowUsers dev``
-# baked defaults — first-wins, and ``-o`` is processed before the
-# config file.
+# baked defaults for this sshd instance only — first-wins, and ``-o``
+# is processed before the config file.
+#
+# ``PidFile=/dev/null`` because under krun the rootfs is virtio-fs and
+# the host-side server runs as the operator (uid 1000); guest-root can't
+# create the PID file's parent dir or a root-owned PID file inside it
+# (every metadata op comes back EACCES).  Writing the PID line to
+# /dev/null is a no-op write that succeeds — sshd doesn't fail-start
+# over a missing PID file.  ``/root/.ssh`` + the authorized_keys symlink
+# for the root-login path are baked into the L0 for the same reason
+# (the build runs under crun, where ownership ops work).
 #
 # The supervisor loop restarts sshd if it crashes (panic, OOM, etc.);
 # ``setsid`` puts the loop in its own session so SIGHUP from the outer
 # init shell (which exits after ``exec bash`` below) can't take it down.
 if [[ "${TEROK_CONTAINER_RUNTIME:-}" == "krun" ]]; then
   echo ">> starting sshd supervisor on TCP 22 (krun mode — root + dev login)"
-  mkdir -p /run/sshd /root/.ssh
-  ln -sf /etc/ssh/authorized_keys.d/terok /root/.ssh/authorized_keys
-  chmod 700 /root/.ssh
   setsid bash -c '
     while :; do
       /usr/sbin/sshd -D -e \
         -o "AllowUsers dev root" \
-        -o "PermitRootLogin without-password"
+        -o "PermitRootLogin without-password" \
+        -o "PidFile=/dev/null"
       echo "[sshd-supervisor] sshd exited (code $?); restarting in 1s" >&2
       sleep 1
     done

--- a/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l0.dev.Dockerfile.template
@@ -106,6 +106,15 @@ RUN set -eux; \
 # acceptable: clients use ``StrictHostKeyChecking=no`` +
 # ``UserKnownHostsFile=/dev/null``, and the per-task host port is
 # loopback-bound (experimental-runtime tradeoff).
+#
+# Root-login plumbing (``/root/.ssh`` + symlink) is baked at build time
+# rather than written by the init script.  Under krun the rootfs is
+# virtio-fs and the host-side server runs as the operator (uid 1000), so
+# guest-root *cannot* create root-owned dirs/symlinks at runtime — every
+# such attempt comes back EACCES.  Doing it during ``podman build`` (which
+# runs under crun, where ownership ops work) sidesteps the constraint.
+# Dormant under crun: sshd doesn't run, the sshd_config above sets
+# ``PermitRootLogin no``, and the trust file ships empty.
 RUN install -d -m 0755 /etc/ssh/sshd_config.d \
     && install -d -m 0755 /etc/ssh/authorized_keys.d \
     && printf '%s\n' \
@@ -125,7 +134,9 @@ RUN install -d -m 0755 /etc/ssh/sshd_config.d \
         > /etc/ssh/sshd_config.d/00-terok.conf \
     && : > /etc/ssh/authorized_keys.d/terok \
     && chmod 0644 /etc/ssh/authorized_keys.d/terok \
-    && ssh-keygen -A
+    && ssh-keygen -A \
+    && install -d -m 0700 -o root -g root /root/.ssh \
+    && ln -sf /etc/ssh/authorized_keys.d/terok /root/.ssh/authorized_keys
 
 WORKDIR /workspace
 

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -664,15 +664,16 @@ class TestTemplateRendering:
           is already root under krun (libkrun ignores the L0's ``USER dev``
           directive) and ``sudo`` would fail anyway under libkrun's
           virtio-fs (the host-side server can't honour setuid exec)
+        - **no** ``mkdir`` / ``ln`` inside the krun gate block — runtime
+          writes to root-owned paths also EACCES on libkrun's virtio-fs;
+          the L0 image carries the ``/root/.ssh`` dir + authorized_keys
+          symlink so the script doesn't need to create them
         - ``AllowUsers dev root`` + ``PermitRootLogin without-password``
           override flags — sshd is started with these as ``-o`` args
           (first-wins) so both the dev (default for agents that refuse
-          uid 0) and root (escape hatch for tasks that need privileged
-          ops) login paths work
-        - ``/root/.ssh/authorized_keys`` symlink — root-login plumbing
-          is created here at runtime (not baked into the L0) so a
-          crun-mode image carries nothing that would authorise a root
-          ssh session
+          uid 0) and root login paths work
+        - ``PidFile=/dev/null`` — sshd's default PID-file write would also
+          EACCES on the rootfs; ``/dev/null`` is a no-op write on devtmpfs
         """
         script_path = (
             Path(__file__).resolve().parent.parent.parent
@@ -686,20 +687,36 @@ class TestTemplateRendering:
         assert "TEROK_CONTAINER_RUNTIME" in text
         assert "/usr/sbin/sshd" in text
         assert "setsid" in text
-        # Extract just the krun-gate block so unrelated future sudo uses
-        # elsewhere in the script don't false-positive this guard.
+        # Extract just the krun-gate block so unrelated future sudo/mkdir
+        # uses elsewhere in the script don't false-positive these guards.
         block_start = text.find('"${TEROK_CONTAINER_RUNTIME:-}" == "krun"')
         assert block_start >= 0, "krun gate disappeared"
         block_end = text.find("\nfi\n", block_start)
         block = text[block_start:block_end]
         assert "sudo" not in block, (
-            "sudo crept back into the krun sshd block — won't work on libkrun's virtiofs"
+            "sudo crept back into the krun sshd block — won't work on libkrun's virtio-fs"
         )
-        # Both login paths and their wiring belong to the krun branch and
-        # nowhere else (so the crun image's L0 stays root-login-free).
+        assert "mkdir" not in block and "ln -s" not in block, (
+            "mkdir / ln crept back into the krun sshd block — guest-root can't "
+            "create root-owned paths via libkrun's virtio-fs (host-side server "
+            "runs as the operator); these belong in the L0 image instead"
+        )
+        # The runtime override flags + PID-file workaround.
         assert "AllowUsers dev root" in block
         assert "PermitRootLogin without-password" in block
-        assert "/root/.ssh/authorized_keys" in block
+        assert "PidFile=/dev/null" in block
+
+    def test_l0_bakes_root_login_plumbing(self) -> None:
+        """``/root/.ssh`` + the ``authorized_keys`` symlink to the
+        bind-mount target are created at build time (not by the init
+        script) because under krun the rootfs is virtio-fs and guest-root
+        can't create root-owned dirs/symlinks at runtime — every such
+        attempt returns EACCES.  Dormant under crun: sshd doesn't run,
+        the baked sshd_config still says ``PermitRootLogin no``, and the
+        authorized_keys file ships empty."""
+        content = render_l0("ubuntu:24.04", family="deb")
+        assert "/root/.ssh" in content
+        assert "ln -sf /etc/ssh/authorized_keys.d/terok /root/.ssh/authorized_keys" in content
 
     def test_l0_hardens_sshd_to_pubkey_only_dev_only_no_forwarding(self) -> None:
         """The sshd config drop-in collapses the surface to a single


### PR DESCRIPTION
## Summary

Next layer of the krun saga.  After #344 the init script's output finally got to the new ``(krun mode — root + dev login)`` echo, but immediately died on:

```
mkdir: cannot create directory '/root/.ssh': Permission denied
```

The rootfs is virtio-fs and the host-side server runs as the operator (uid 1000), so guest-root *cannot* create root-owned dirs/symlinks at runtime — every metadata op comes back EACCES.  This is the same constraint that broke ``sudo`` earlier; it also covers ``mkdir``, ``ln -s``, ``chmod``, ``setcap``.

## Fix

Two parts, both predicated on "writes that need root ownership have to happen at build time, not runtime":

- **Bake ``/root/.ssh`` + the ``authorized_keys`` symlink into the L0 image** at build time.  ``podman build`` runs under crun where ownership ops work; the dir + symlink land in the image with root:root.  Init script drops the runtime ``mkdir``/``ln`` calls.

- **Pass ``-o PidFile=/dev/null``** to the sshd invocation.  Sshd's default PID-file write would EACCES too (root-owned create on virtio-fs).  ``/dev/null`` is a no-op write on devtmpfs and sshd doesn't fail-start over a missing PID file.

## Crun impact: still zero

The new L0 bits are dormant under crun.  Triple defence — the symlink alone authorises nothing because:
1. Under crun the init script's krun gate is false ⇒ sshd doesn't run.
2. The baked ``/etc/ssh/sshd_config.d/00-terok.conf`` still says ``PermitRootLogin no`` + ``AllowUsers dev`` (the runtime ``-o`` overrides only apply to the krun-launched sshd).
3. The ``authorized_keys.d/terok`` file ships empty.

## Test plan

- [x] ``make check`` clean
- [x] 898 unit tests pass
- [x] Test updates:
  - ``test_init_script_carries_krun_sshd_supervisor`` extended: now asserts **no** ``mkdir`` / ``ln -s`` in the krun gate block (the move to L0) and **yes** ``PidFile=/dev/null``
  - New ``test_l0_bakes_root_login_plumbing`` — pins the ``/root/.ssh`` dir + symlink in the rendered L0 Dockerfile
- [ ] Manual on Silverblue: ``terok image build && terok task run terok-k`` should boot past the previous EACCES; ``ssh dev@…`` and ``ssh root@…`` both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH daemon initialization reliability in container environments
  * Fixed SSH configuration handling in virtualization scenarios

* **Tests**
  * Updated test coverage for SSH setup validation in development container builds

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->