### PR TITLE
fix(krun): drop runtime /root/.ssh wiring — sshd's AuthorizedKeysFile is global

### DIFF
--- a/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
@@ -27,37 +27,27 @@ set -euo pipefail
 # of init fails (DNS-inside-guest is a separate follow-up).
 #
 # The gate is ``TEROK_CONTAINER_RUNTIME=krun`` — set by terok's
-# ``_project_runtime_flags`` only when launching under krun.  An
-# explicit runtime signal rather than inferring from the bind-mount,
-# so a botched L0 with a non-empty placeholder can't accidentally
-# expose sshd under crun.
+# ``_project_runtime_flags`` only when launching under krun, alongside
+# the ``--user root`` override that gives this block the write access
+# it needs (the L0's ``USER dev`` is the right default under crun for
+# AI agents that refuse uid 0, but under krun sshd needs to start as
+# root and drop to the authenticated user on connection).
 #
-# Under krun the container is uid 0 inside the guest — libkrun ignores
-# the L0's ``USER dev`` directive (and ``--userns=keep-id``), so this
-# block runs as root and ``sudo`` would fail anyway under libkrun's
-# virtio-fs (the host-side virtio-fs server runs unprivileged on the
-# host and can't honour setuid exec).  See docs/runtimes.md.  Sshd
-# itself runs as root, listens on 22, and drops to the authenticated
-# user on connection — same model as any multi-user host.
-#
-# Operators can log in as ``dev`` (default, for AI agents that refuse
-# uid 0) or as ``root`` (escape hatch for tasks that need privileged
-# ops — sudo doesn't work, this is the workaround).  The two paths
-# share the same bind-mounted authorized_keys file; the root path is
-# wired in here (not baked into the L0) so a crun-mode image carries
-# nothing that would authorise a root ssh session.  ``-o`` overrides
-# the L0's restrictive ``PermitRootLogin no`` + ``AllowUsers dev``
-# baked defaults — first-wins, and ``-o`` is processed before the
-# config file.
+# Sshd runs as root, listens on 22, and authenticates against
+# ``/etc/ssh/authorized_keys.d/terok`` (set globally as
+# ``AuthorizedKeysFile`` in the baked sshd_config.d/00-terok.conf, so
+# both ``dev`` and ``root`` SSH logins look the same file up — no
+# per-home wiring needed).  The bind-mounted host pubkey overlays
+# that file at task launch.  ``-o`` overrides relax the baked
+# ``PermitRootLogin no`` + ``AllowUsers dev`` for this sshd instance
+# only — first-wins, ``-o`` is processed before the config file.
 #
 # The supervisor loop restarts sshd if it crashes (panic, OOM, etc.);
 # ``setsid`` puts the loop in its own session so SIGHUP from the outer
 # init shell (which exits after ``exec bash`` below) can't take it down.
 if [[ "${TEROK_CONTAINER_RUNTIME:-}" == "krun" ]]; then
   echo ">> starting sshd supervisor on TCP 22 (krun mode — root + dev login)"
-  mkdir -p /run/sshd /root/.ssh
-  ln -sf /etc/ssh/authorized_keys.d/terok /root/.ssh/authorized_keys
-  chmod 700 /root/.ssh
+  mkdir -p /run/sshd
   setsid bash -c '
     while :; do
       /usr/sbin/sshd -D -e \

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -655,24 +655,15 @@ class TestTemplateRendering:
         at the next failed ``terok login``:
 
         - ``TEROK_CONTAINER_RUNTIME`` — the explicit gate (set by terok
-          only under krun; absent under crun ⇒ no sshd ⇒ none of the
-          krun-specific behaviour below activates)
+          only under krun; absent under crun ⇒ no sshd)
         - ``/usr/sbin/sshd`` — the actual binary invocation
         - ``setsid`` — the supervisor loop runs in a detached session so
           the outer init shell exiting can't take it down
-        - **no** ``sudo`` inside the krun gate block — the container PID 1
-          is already root under krun (libkrun ignores the L0's ``USER dev``
-          directive) and ``sudo`` would fail anyway under libkrun's
-          virtio-fs (the host-side server can't honour setuid exec)
         - ``AllowUsers dev root`` + ``PermitRootLogin without-password``
           override flags — sshd is started with these as ``-o`` args
           (first-wins) so both the dev (default for agents that refuse
-          uid 0) and root (escape hatch for tasks that need privileged
-          ops) login paths work
-        - ``/root/.ssh/authorized_keys`` symlink — root-login plumbing
-          is created here at runtime (not baked into the L0) so a
-          crun-mode image carries nothing that would authorise a root
-          ssh session
+          uid 0) and root login paths work; the baked sshd_config keeps
+          the restrictive defaults the override relaxes
         """
         script_path = (
             Path(__file__).resolve().parent.parent.parent
@@ -686,20 +677,14 @@ class TestTemplateRendering:
         assert "TEROK_CONTAINER_RUNTIME" in text
         assert "/usr/sbin/sshd" in text
         assert "setsid" in text
-        # Extract just the krun-gate block so unrelated future sudo uses
-        # elsewhere in the script don't false-positive this guard.
+        # Extract just the krun-gate block so unrelated checks elsewhere
+        # in the script don't false-positive these assertions.
         block_start = text.find('"${TEROK_CONTAINER_RUNTIME:-}" == "krun"')
         assert block_start >= 0, "krun gate disappeared"
         block_end = text.find("\nfi\n", block_start)
         block = text[block_start:block_end]
-        assert "sudo" not in block, (
-            "sudo crept back into the krun sshd block — won't work on libkrun's virtiofs"
-        )
-        # Both login paths and their wiring belong to the krun branch and
-        # nowhere else (so the crun image's L0 stays root-login-free).
         assert "AllowUsers dev root" in block
         assert "PermitRootLogin without-password" in block
-        assert "/root/.ssh/authorized_keys" in block
 
     def test_l0_hardens_sshd_to_pubkey_only_dev_only_no_forwarding(self) -> None:
         """The sshd config drop-in collapses the surface to a single


### PR DESCRIPTION
## Summary

Empirical re-test on Silverblue showed my whole krun-permission story was wrong: the rootfs is *not* read-only and virtio-fs *can* honour root-owned writes.  What was actually happening: the L0's ``USER dev`` directive runs the container as dev (host-uid 1000), and dev can't write to root-owned paths.  Normal Unix perms.

The paired terok-side change (terok#995) adds ``--user root`` to the krun-launch flags, which gives the in-guest sshd what it needs.  Once we're starting as root, the runtime ``/root/.ssh`` symlink + chmod + ln chain in ``init-ssh-and-repo.sh`` becomes unnecessary — sshd's baked ``AuthorizedKeysFile /etc/ssh/authorized_keys.d/terok`` is a *global* directive, applied to every authenticating user.  Root login auth reads the same bind-mounted file as dev login auth, no per-home wiring needed.

## Diff

- ``init-ssh-and-repo.sh`` krun gate block: drop the ``mkdir /root/.ssh``, the ``ln -s … authorized_keys``, and the ``chmod 700``.  Keep ``mkdir /run/sshd`` (sshd's PID-file dir) and the supervisor + ``-o AllowUsers``/``PermitRootLogin`` overrides.
- Comment block reframed: no more claims about libkrun ignoring USER or sudo being unfix­able — those were my misreading.  Just states what the script does and why.
- Test ``test_init_script_carries_krun_sshd_supervisor`` updated: drop the ``/root/.ssh/authorized_keys`` and ``no sudo`` assertions (the first was tied to the removed code; the second was based on the wrong theory).  Keeps the load-bearing token pins (``TEROK_CONTAINER_RUNTIME``, ``/usr/sbin/sshd``, ``setsid``, the override flags).

## Crun impact: zero

The whole block is gated by ``TEROK_CONTAINER_RUNTIME=krun``.  Terok only sets that under krun.  Under crun the block doesn't execute and nothing here matters.

## Test plan

- [x] ``make check`` clean — 897 unit tests pass
- [ ] On Silverblue, with terok#995 merged + executor sync: ``terok task run terok-k`` boots cleanly, ``ssh dev@…`` and ``ssh root@…`` both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined SSH authentication configuration in container initialization by eliminating manual setup of SSH directories and authorization files. Updated to utilize pre-configured authorization settings for improved reliability and maintainability.

* **Tests**
  * Refined test validations to focus on SSH daemon launch configuration flags while removing checks for setup procedures that were eliminated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->