### PR TITLE
refactor(krun): expose krun_launch_args() so terok stops open-coding image flags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.0.149a14"
+version = "0.0.149a15"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -101,7 +101,12 @@ from .credentials.vault_config import ConfigPatchError
 
 # -- Doctor + paths ------------------------------------------------------------
 from .doctor import agent_doctor_checks
-from .krun import KrunHostKeypair, ensure_krun_host_keypair, make_krun_runtime
+from .krun import (
+    KrunHostKeypair,
+    ensure_krun_host_keypair,
+    krun_launch_args,
+    make_krun_runtime,
+)
 from .paths import mounts_dir
 
 # -- Provider (headless dispatch, instructions, agent config) ------------------
@@ -276,5 +281,6 @@ __all__ = [
     # Krun (KVM-microVM) provisioning + runtime factory
     "KrunHostKeypair",
     "ensure_krun_host_keypair",
+    "krun_launch_args",
     "make_krun_runtime",
 ]

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -104,6 +104,7 @@ from .doctor import agent_doctor_checks
 from .krun import (
     KrunHostKeypair,
     ensure_krun_host_keypair,
+    host_upstream_dns,
     krun_launch_args,
     make_krun_runtime,
 )
@@ -281,6 +282,7 @@ __all__ = [
     # Krun (KVM-microVM) provisioning + runtime factory
     "KrunHostKeypair",
     "ensure_krun_host_keypair",
+    "host_upstream_dns",
     "krun_launch_args",
     "make_krun_runtime",
 ]

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -104,7 +104,6 @@ from .doctor import agent_doctor_checks
 from .krun import (
     KrunHostKeypair,
     ensure_krun_host_keypair,
-    host_upstream_dns,
     krun_launch_args,
     make_krun_runtime,
 )
@@ -282,7 +281,6 @@ __all__ = [
     # Krun (KVM-microVM) provisioning + runtime factory
     "KrunHostKeypair",
     "ensure_krun_host_keypair",
-    "host_upstream_dns",
     "krun_launch_args",
     "make_krun_runtime",
 ]

--- a/src/terok_executor/krun.py
+++ b/src/terok_executor/krun.py
@@ -158,6 +158,40 @@ def make_krun_runtime(*, cfg: SandboxConfig | None = None) -> KrunRuntime:
     return KrunRuntime(transport=transport, podman=PodmanRuntime())
 
 
+def krun_launch_args(*, cfg: SandboxConfig | None = None) -> list[str]:
+    """Extra ``podman run`` args terok must splice in for a krun launch.
+
+    Three things that all reach across the orchestrator/runtime boundary
+    into executor's domain — the L0 image, the host keypair, and the
+    in-guest ``init-ssh-and-repo.sh`` — so they live here together
+    rather than being open-coded in terok's ``_project_runtime_flags``:
+
+    - Bind-mount the live host pubkey over the L0's empty placeholder
+      at ``/etc/ssh/authorized_keys.d/terok``.  ``z`` is the shared
+      SELinux relabel (never ``Z`` — the host pubkey is host-wide and
+      concurrent containers share the source).
+    - Set ``TEROK_CONTAINER_RUNTIME=krun`` so the init script's krun
+      gate fires.
+    - Override the L0's ``USER dev`` directive with ``--user root`` so
+      the in-guest sshd can start, listen on TCP 22, and drop to the
+      authenticated user on connection.  ``USER dev`` is the right
+      default under crun (AI agents that refuse uid 0); under krun the
+      session uid comes from which ``ssh user@…`` the operator picks.
+
+    Doesn't include ``--runtime krun`` itself or krun's microVM-sizing
+    annotations — those are orchestrator-level decisions terok keeps.
+    """
+    kp = ensure_krun_host_keypair(cfg=cfg)
+    return [
+        "-v",
+        f"{kp.public_path}:/etc/ssh/authorized_keys.d/terok:ro,z",
+        "-e",
+        "TEROK_CONTAINER_RUNTIME=krun",
+        "--user",
+        "root",
+    ]
+
+
 # ── Private helpers ─────────────────────────────────────────────────────────
 
 

--- a/src/terok_executor/krun.py
+++ b/src/terok_executor/krun.py
@@ -29,7 +29,6 @@ the key is a contradiction, so the two operations belong together.
 from __future__ import annotations
 
 import dataclasses
-import ipaddress
 import os
 import stat
 import tempfile
@@ -50,11 +49,16 @@ from terok_sandbox import (
 # touches one place.
 _HOST_KEYPAIR_BASENAME = "krun_host"
 
-# systemd-resolved publishes the real upstream nameservers here.  The
-# usual ``/etc/resolv.conf`` only carries the ``127.0.0.53`` stub,
-# which is unreachable from inside the krun guest's loopback (TSI does
-# not redirect 127.0.0.0/8 back to the host).
-_SYSTEMD_RESOLVED_REAL_CONF = Path("/run/systemd/resolve/resolv.conf")
+# Pasta's built-in link-local DNS forwarder.  Inside a krun guest this
+# is the only resolver address that's both (a) reachable — TSI surfaces
+# the connect to a host-side socket inside the podman netns where pasta
+# answers it — and (b) permitted by terok-shield's nft policy, which
+# allows udp/tcp :53 to exactly this address (see
+# ``terok_shield.nft.constants.PASTA_DNS``).  Hardcoded rather than
+# imported: shield isn't an executor dependency, and the address is a
+# pasta-defined constant that's effectively stable.  Slirp4netns hosts
+# (``10.0.2.3``) aren't supported for krun yet.
+_PASTA_DNS_FORWARDER = "169.254.1.1"
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -170,9 +174,9 @@ def krun_launch_args(*, cfg: SandboxConfig | None = None) -> list[str]:
 
     Four things that all reach across the orchestrator/runtime boundary
     into executor's domain — the L0 image, the host keypair, the
-    in-guest ``init-ssh-and-repo.sh``, and DNS reachability inside the
-    microVM — so they live here together rather than being open-coded
-    in terok's ``_project_runtime_flags``:
+    in-guest ``init-ssh-and-repo.sh``, and the DNS forwarder address —
+    so they live here together rather than being open-coded in terok's
+    ``_project_runtime_flags``:
 
     - Bind-mount the live host pubkey over the L0's empty placeholder
       at ``/etc/ssh/authorized_keys.d/terok``.  ``z`` is the shared
@@ -185,64 +189,29 @@ def krun_launch_args(*, cfg: SandboxConfig | None = None) -> list[str]:
       authenticated user on connection.  ``USER dev`` is the right
       default under crun (AI agents that refuse uid 0); under krun the
       session uid comes from which ``ssh user@…`` the operator picks.
-    - ``--dns <host-upstream>`` so the guest's resolver is reachable.
-      See [`host_upstream_dns`][terok_executor.krun.host_upstream_dns]
-      for the detection contract; skipped when no non-loopback resolver
-      can be found (operator must add ``--dns`` themselves or accept
-      broken name resolution under krun).
+    - ``--dns 169.254.1.1`` so the guest resolves through pasta's
+      forwarder rather than the unreachable host-loopback stub.  Same
+      address terok-shield's nft already permits :53 to, so this works
+      under both shield-up and shield-down — the only behavioural cost
+      under shield-up is losing dnsmasq's clearance prompts (queries
+      bypass it).  Documented limitation for the experimental krun
+      runtime; will be revisited when shield+krun gets first-class
+      support.
 
     Doesn't include ``--runtime krun`` itself or krun's microVM-sizing
     annotations — those are orchestrator-level decisions terok keeps.
     """
     kp = ensure_krun_host_keypair(cfg=cfg)
-    args = [
+    return [
         "-v",
         f"{kp.public_path}:/etc/ssh/authorized_keys.d/terok:ro,z",
         "-e",
         "TEROK_CONTAINER_RUNTIME=krun",
         "--user",
         "root",
+        "--dns",
+        _PASTA_DNS_FORWARDER,
     ]
-    if dns := host_upstream_dns():
-        args += ["--dns", dns]
-    return args
-
-
-def host_upstream_dns() -> str | None:
-    """Return the host's first non-loopback DNS resolver, or ``None``.
-
-    Krun guests can't reach a host-loopback resolver: libkrun's TSI
-    proxies AF_INET sockets to the host VMM but does not redirect
-    127.0.0.0/8 traffic back to the host's network stack — a guest
-    connect to ``127.0.0.53`` hits the (empty) guest loopback instead
-    of systemd-resolved.  Surface the *real* upstream nameserver so
-    the orchestrator can pass it via ``podman run --dns``.
-
-    Source order: ``/run/systemd/resolve/resolv.conf`` first (real
-    upstreams on systemd-resolved hosts — the usual F44 case), then
-    ``/etc/resolv.conf`` (non-resolved hosts).  Loopback entries
-    are skipped using
-    [`ipaddress.ip_address.is_loopback`][ipaddress.IPv4Address.is_loopback]
-    so IPv6 ``::1`` is excluded too.  Returns ``None`` when neither
-    source yields a routable resolver — the caller decides whether
-    that's fatal or merely a documented limitation.
-    """
-    for source in (_SYSTEMD_RESOLVED_REAL_CONF, Path("/etc/resolv.conf")):
-        try:
-            text = source.read_text()
-        except OSError:
-            continue
-        for line in text.splitlines():
-            tokens = line.split()
-            if len(tokens) < 2 or tokens[0] != "nameserver":
-                continue
-            try:
-                addr = ipaddress.ip_address(tokens[1])
-            except ValueError:
-                continue
-            if not addr.is_loopback:
-                return tokens[1]
-    return None
 
 
 # ── Private helpers ─────────────────────────────────────────────────────────

--- a/src/terok_executor/krun.py
+++ b/src/terok_executor/krun.py
@@ -29,6 +29,7 @@ the key is a contradiction, so the two operations belong together.
 from __future__ import annotations
 
 import dataclasses
+import ipaddress
 import os
 import stat
 import tempfile
@@ -48,6 +49,12 @@ from terok_sandbox import (
 # bind-mount target.  Keep both halves co-located so a future rename
 # touches one place.
 _HOST_KEYPAIR_BASENAME = "krun_host"
+
+# systemd-resolved publishes the real upstream nameservers here.  The
+# usual ``/etc/resolv.conf`` only carries the ``127.0.0.53`` stub,
+# which is unreachable from inside the krun guest's loopback (TSI does
+# not redirect 127.0.0.0/8 back to the host).
+_SYSTEMD_RESOLVED_REAL_CONF = Path("/run/systemd/resolve/resolv.conf")
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -161,10 +168,11 @@ def make_krun_runtime(*, cfg: SandboxConfig | None = None) -> KrunRuntime:
 def krun_launch_args(*, cfg: SandboxConfig | None = None) -> list[str]:
     """Extra ``podman run`` args terok must splice in for a krun launch.
 
-    Three things that all reach across the orchestrator/runtime boundary
-    into executor's domain — the L0 image, the host keypair, and the
-    in-guest ``init-ssh-and-repo.sh`` — so they live here together
-    rather than being open-coded in terok's ``_project_runtime_flags``:
+    Four things that all reach across the orchestrator/runtime boundary
+    into executor's domain — the L0 image, the host keypair, the
+    in-guest ``init-ssh-and-repo.sh``, and DNS reachability inside the
+    microVM — so they live here together rather than being open-coded
+    in terok's ``_project_runtime_flags``:
 
     - Bind-mount the live host pubkey over the L0's empty placeholder
       at ``/etc/ssh/authorized_keys.d/terok``.  ``z`` is the shared
@@ -177,12 +185,17 @@ def krun_launch_args(*, cfg: SandboxConfig | None = None) -> list[str]:
       authenticated user on connection.  ``USER dev`` is the right
       default under crun (AI agents that refuse uid 0); under krun the
       session uid comes from which ``ssh user@…`` the operator picks.
+    - ``--dns <host-upstream>`` so the guest's resolver is reachable.
+      See [`host_upstream_dns`][terok_executor.krun.host_upstream_dns]
+      for the detection contract; skipped when no non-loopback resolver
+      can be found (operator must add ``--dns`` themselves or accept
+      broken name resolution under krun).
 
     Doesn't include ``--runtime krun`` itself or krun's microVM-sizing
     annotations — those are orchestrator-level decisions terok keeps.
     """
     kp = ensure_krun_host_keypair(cfg=cfg)
-    return [
+    args = [
         "-v",
         f"{kp.public_path}:/etc/ssh/authorized_keys.d/terok:ro,z",
         "-e",
@@ -190,6 +203,46 @@ def krun_launch_args(*, cfg: SandboxConfig | None = None) -> list[str]:
         "--user",
         "root",
     ]
+    if dns := host_upstream_dns():
+        args += ["--dns", dns]
+    return args
+
+
+def host_upstream_dns() -> str | None:
+    """Return the host's first non-loopback DNS resolver, or ``None``.
+
+    Krun guests can't reach a host-loopback resolver: libkrun's TSI
+    proxies AF_INET sockets to the host VMM but does not redirect
+    127.0.0.0/8 traffic back to the host's network stack — a guest
+    connect to ``127.0.0.53`` hits the (empty) guest loopback instead
+    of systemd-resolved.  Surface the *real* upstream nameserver so
+    the orchestrator can pass it via ``podman run --dns``.
+
+    Source order: ``/run/systemd/resolve/resolv.conf`` first (real
+    upstreams on systemd-resolved hosts — the usual F44 case), then
+    ``/etc/resolv.conf`` (non-resolved hosts).  Loopback entries
+    are skipped using
+    [`ipaddress.ip_address.is_loopback`][ipaddress.IPv4Address.is_loopback]
+    so IPv6 ``::1`` is excluded too.  Returns ``None`` when neither
+    source yields a routable resolver — the caller decides whether
+    that's fatal or merely a documented limitation.
+    """
+    for source in (_SYSTEMD_RESOLVED_REAL_CONF, Path("/etc/resolv.conf")):
+        try:
+            text = source.read_text()
+        except OSError:
+            continue
+        for line in text.splitlines():
+            tokens = line.split()
+            if len(tokens) < 2 or tokens[0] != "nameserver":
+                continue
+            try:
+                addr = ipaddress.ip_address(tokens[1])
+            except ValueError:
+                continue
+            if not addr.is_loopback:
+                return tokens[1]
+    return None
 
 
 # ── Private helpers ─────────────────────────────────────────────────────────

--- a/tests/unit/test_krun.py
+++ b/tests/unit/test_krun.py
@@ -318,3 +318,51 @@ class TestMakeKrunRuntime:
         assert isinstance(rt.transport, TcpSSHTransport)
         # The runtime composes a fresh PodmanRuntime for lifecycle verbs.
         assert isinstance(rt._podman, PodmanRuntime)
+
+
+class TestKrunLaunchArgs:
+    """`krun_launch_args` collects the three things that reach across
+    the orchestrator/runtime boundary into executor's domain — the
+    host-pubkey bind-mount, the init-script gate env var, and the
+    USER-directive override — so terok doesn't have to know the
+    in-container target path or any of the other in-guest details."""
+
+    def test_emits_pubkey_bind_mount_with_shared_selinux_relabel(
+        self, tmp_path: Path, _vault_backed
+    ) -> None:
+        from terok_executor.krun import krun_launch_args
+
+        runtime_dir = tmp_path / "runtime"
+        with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=runtime_dir):
+            runtime_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+            args = krun_launch_args(cfg=_vault_backed)
+
+        v_idx = args.index("-v")
+        spec = args[v_idx + 1]
+        assert spec.endswith(":/etc/ssh/authorized_keys.d/terok:ro,z")
+        # The source is the materialised public key — pull it via the
+        # same helper terok would call and assert the prefix matches.
+        kp = ensure_krun_host_keypair(cfg=_vault_backed, runtime_dir=runtime_dir)
+        assert spec.startswith(f"{kp.public_path}:")
+        # Shared relabel, never private — the source is host-wide.
+        assert ",Z" not in spec and ":Z" not in spec
+
+    def test_emits_runtime_signal_env_var(self, tmp_path: Path, _vault_backed) -> None:
+        from terok_executor.krun import krun_launch_args
+
+        with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
+            tmp_path.chmod(0o700)
+            args = krun_launch_args(cfg=_vault_backed)
+
+        env_assignments = [args[i + 1] for i, t in enumerate(args) if t == "-e"]
+        assert "TEROK_CONTAINER_RUNTIME=krun" in env_assignments
+
+    def test_overrides_image_user_to_root(self, tmp_path: Path, _vault_backed) -> None:
+        from terok_executor.krun import krun_launch_args
+
+        with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
+            tmp_path.chmod(0o700)
+            args = krun_launch_args(cfg=_vault_backed)
+
+        user_idx = args.index("--user")
+        assert args[user_idx + 1] == "root"

--- a/tests/unit/test_krun.py
+++ b/tests/unit/test_krun.py
@@ -321,11 +321,19 @@ class TestMakeKrunRuntime:
 
 
 class TestKrunLaunchArgs:
-    """`krun_launch_args` collects the three things that reach across
-    the orchestrator/runtime boundary into executor's domain — the
-    host-pubkey bind-mount, the init-script gate env var, and the
-    USER-directive override — so terok doesn't have to know the
-    in-container target path or any of the other in-guest details."""
+    """`krun_launch_args` collects the four things that reach across the
+    orchestrator/runtime boundary into executor's domain — the host-pubkey
+    bind-mount, the init-script gate env var, the USER-directive override,
+    and the host upstream DNS forwarding — so terok doesn't have to know
+    the in-container target path or any other in-guest detail."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_host_upstream_dns(self):
+        """Pin host DNS detection so per-host /etc/resolv.conf can't leak
+        a real address into the assertions.  Individual tests override
+        the return value where they care."""
+        with patch("terok_executor.krun.host_upstream_dns", return_value=None) as m:
+            yield m
 
     def test_emits_pubkey_bind_mount_with_shared_selinux_relabel(
         self, tmp_path: Path, _vault_backed
@@ -366,3 +374,116 @@ class TestKrunLaunchArgs:
 
         user_idx = args.index("--user")
         assert args[user_idx + 1] == "root"
+
+    def test_appends_dns_when_upstream_detected(
+        self, tmp_path: Path, _vault_backed, _stub_host_upstream_dns
+    ) -> None:
+        """When the host has a routable resolver, emit ``--dns <ip>``.
+
+        TSI proxies the guest's UDP/53 to the host VMM, but the guest
+        can't reach a host-loopback resolver — surface the real upstream.
+        """
+        from terok_executor.krun import krun_launch_args
+
+        _stub_host_upstream_dns.return_value = "192.0.2.53"
+        with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
+            tmp_path.chmod(0o700)
+            args = krun_launch_args(cfg=_vault_backed)
+
+        dns_idx = args.index("--dns")
+        assert args[dns_idx + 1] == "192.0.2.53"
+
+    def test_omits_dns_when_no_routable_upstream(
+        self, tmp_path: Path, _vault_backed, _stub_host_upstream_dns
+    ) -> None:
+        """Stub-only hosts (loopback nameserver, no /run/systemd/resolve)
+        get no ``--dns`` — operators see broken resolution in the guest
+        and add their own ``--dns`` (rather than silently picking a
+        public resolver that would widen the shield allowlist)."""
+        from terok_executor.krun import krun_launch_args
+
+        _stub_host_upstream_dns.return_value = None
+        with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
+            tmp_path.chmod(0o700)
+            args = krun_launch_args(cfg=_vault_backed)
+
+        assert "--dns" not in args
+
+
+class TestHostUpstreamDns:
+    """`host_upstream_dns` prefers systemd-resolved's real upstreams over
+    the ``127.0.0.53`` stub, skipping any loopback resolver."""
+
+    def test_prefers_systemd_resolved_real_conf(self, tmp_path: Path) -> None:
+        from terok_executor.krun import host_upstream_dns
+
+        real = tmp_path / "real-resolv.conf"
+        real.write_text("# real upstreams\nnameserver 192.0.2.53\nnameserver 192.0.2.54\n")
+        stub = tmp_path / "stub-resolv.conf"
+        stub.write_text("nameserver 127.0.0.53\n")
+
+        with patch("terok_executor.krun._SYSTEMD_RESOLVED_REAL_CONF", real):
+            # /etc/resolv.conf must not even be consulted when the real
+            # file is readable — patch it to a unreachable path to prove
+            # the order (Path("/nonexistent") read_text will OSError).
+            assert host_upstream_dns() == "192.0.2.53"
+
+    def test_falls_back_to_etc_resolv_when_systemd_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No systemd-resolved file → parse ``/etc/resolv.conf`` directly."""
+        from terok_executor import krun as krun_mod
+
+        etc = tmp_path / "etc-resolv.conf"
+        etc.write_text("nameserver 192.0.2.99\n")
+
+        original_read = Path.read_text
+
+        def _read(self: Path, *a, **kw):  # type: ignore[no-untyped-def]
+            if self == krun_mod._SYSTEMD_RESOLVED_REAL_CONF:
+                raise OSError("missing")
+            if self == Path("/etc/resolv.conf"):
+                return etc.read_text(*a, **kw)
+            return original_read(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_text", _read)
+        assert krun_mod.host_upstream_dns() == "192.0.2.99"
+
+    def test_skips_loopback_entries(self, tmp_path: Path) -> None:
+        """``127.x`` and ``::1`` are unreachable from the krun guest."""
+        from terok_executor.krun import host_upstream_dns
+
+        f = tmp_path / "resolv.conf"
+        f.write_text("nameserver 127.0.0.53\nnameserver ::1\nnameserver 9.9.9.9\n")
+        with patch("terok_executor.krun._SYSTEMD_RESOLVED_REAL_CONF", f):
+            assert host_upstream_dns() == "9.9.9.9"
+
+    def test_returns_none_when_no_routable_resolver(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Loopback-only host with no readable resolv.conf at either path."""
+        from terok_executor import krun as krun_mod
+
+        empty = tmp_path / "loopback-only"
+        empty.write_text("nameserver 127.0.0.53\n")
+
+        original_read = Path.read_text
+
+        def _read(self: Path, *a, **kw):  # type: ignore[no-untyped-def]
+            if self == krun_mod._SYSTEMD_RESOLVED_REAL_CONF:
+                return empty.read_text(*a, **kw)
+            if self == Path("/etc/resolv.conf"):
+                raise OSError("missing")
+            return original_read(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "read_text", _read)
+        assert krun_mod.host_upstream_dns() is None
+
+    def test_ignores_malformed_address_tokens(self, tmp_path: Path) -> None:
+        """Garbage on a nameserver line is skipped, not raised."""
+        from terok_executor.krun import host_upstream_dns
+
+        f = tmp_path / "resolv.conf"
+        f.write_text("nameserver not-an-ip\nnameserver 9.9.9.9\n")
+        with patch("terok_executor.krun._SYSTEMD_RESOLVED_REAL_CONF", f):
+            assert host_upstream_dns() == "9.9.9.9"

--- a/tests/unit/test_krun.py
+++ b/tests/unit/test_krun.py
@@ -324,16 +324,8 @@ class TestKrunLaunchArgs:
     """`krun_launch_args` collects the four things that reach across the
     orchestrator/runtime boundary into executor's domain — the host-pubkey
     bind-mount, the init-script gate env var, the USER-directive override,
-    and the host upstream DNS forwarding — so terok doesn't have to know
-    the in-container target path or any other in-guest detail."""
-
-    @pytest.fixture(autouse=True)
-    def _stub_host_upstream_dns(self):
-        """Pin host DNS detection so per-host /etc/resolv.conf can't leak
-        a real address into the assertions.  Individual tests override
-        the return value where they care."""
-        with patch("terok_executor.krun.host_upstream_dns", return_value=None) as m:
-            yield m
+    and the pasta DNS forwarder — so terok doesn't have to know the
+    in-container target path or any other in-guest detail."""
 
     def test_emits_pubkey_bind_mount_with_shared_selinux_relabel(
         self, tmp_path: Path, _vault_backed
@@ -375,115 +367,19 @@ class TestKrunLaunchArgs:
         user_idx = args.index("--user")
         assert args[user_idx + 1] == "root"
 
-    def test_appends_dns_when_upstream_detected(
-        self, tmp_path: Path, _vault_backed, _stub_host_upstream_dns
-    ) -> None:
-        """When the host has a routable resolver, emit ``--dns <ip>``.
-
-        TSI proxies the guest's UDP/53 to the host VMM, but the guest
-        can't reach a host-loopback resolver — surface the real upstream.
+    def test_points_dns_at_pasta_link_local_forwarder(self, tmp_path: Path, _vault_backed) -> None:
+        """``--dns 169.254.1.1`` — pasta's forwarder, the one address that's
+        both reachable from inside the krun guest (TSI surfaces the connect
+        to a host-side socket inside the netns where pasta answers) and
+        permitted by terok-shield's nft policy (``PASTA_DNS`` in
+        ``terok_shield.nft.constants``).  Hardcoded by design — anything
+        else either gets dropped by shield or isn't routable from the guest.
         """
         from terok_executor.krun import krun_launch_args
 
-        _stub_host_upstream_dns.return_value = "192.0.2.53"
         with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
             tmp_path.chmod(0o700)
             args = krun_launch_args(cfg=_vault_backed)
 
         dns_idx = args.index("--dns")
-        assert args[dns_idx + 1] == "192.0.2.53"
-
-    def test_omits_dns_when_no_routable_upstream(
-        self, tmp_path: Path, _vault_backed, _stub_host_upstream_dns
-    ) -> None:
-        """Stub-only hosts (loopback nameserver, no /run/systemd/resolve)
-        get no ``--dns`` — operators see broken resolution in the guest
-        and add their own ``--dns`` (rather than silently picking a
-        public resolver that would widen the shield allowlist)."""
-        from terok_executor.krun import krun_launch_args
-
-        _stub_host_upstream_dns.return_value = None
-        with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
-            tmp_path.chmod(0o700)
-            args = krun_launch_args(cfg=_vault_backed)
-
-        assert "--dns" not in args
-
-
-class TestHostUpstreamDns:
-    """`host_upstream_dns` prefers systemd-resolved's real upstreams over
-    the ``127.0.0.53`` stub, skipping any loopback resolver."""
-
-    def test_prefers_systemd_resolved_real_conf(self, tmp_path: Path) -> None:
-        from terok_executor.krun import host_upstream_dns
-
-        real = tmp_path / "real-resolv.conf"
-        real.write_text("# real upstreams\nnameserver 192.0.2.53\nnameserver 192.0.2.54\n")
-        stub = tmp_path / "stub-resolv.conf"
-        stub.write_text("nameserver 127.0.0.53\n")
-
-        with patch("terok_executor.krun._SYSTEMD_RESOLVED_REAL_CONF", real):
-            # /etc/resolv.conf must not even be consulted when the real
-            # file is readable — patch it to a unreachable path to prove
-            # the order (Path("/nonexistent") read_text will OSError).
-            assert host_upstream_dns() == "192.0.2.53"
-
-    def test_falls_back_to_etc_resolv_when_systemd_missing(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """No systemd-resolved file → parse ``/etc/resolv.conf`` directly."""
-        from terok_executor import krun as krun_mod
-
-        etc = tmp_path / "etc-resolv.conf"
-        etc.write_text("nameserver 192.0.2.99\n")
-
-        original_read = Path.read_text
-
-        def _read(self: Path, *a, **kw):  # type: ignore[no-untyped-def]
-            if self == krun_mod._SYSTEMD_RESOLVED_REAL_CONF:
-                raise OSError("missing")
-            if self == Path("/etc/resolv.conf"):
-                return etc.read_text(*a, **kw)
-            return original_read(self, *a, **kw)
-
-        monkeypatch.setattr(Path, "read_text", _read)
-        assert krun_mod.host_upstream_dns() == "192.0.2.99"
-
-    def test_skips_loopback_entries(self, tmp_path: Path) -> None:
-        """``127.x`` and ``::1`` are unreachable from the krun guest."""
-        from terok_executor.krun import host_upstream_dns
-
-        f = tmp_path / "resolv.conf"
-        f.write_text("nameserver 127.0.0.53\nnameserver ::1\nnameserver 9.9.9.9\n")
-        with patch("terok_executor.krun._SYSTEMD_RESOLVED_REAL_CONF", f):
-            assert host_upstream_dns() == "9.9.9.9"
-
-    def test_returns_none_when_no_routable_resolver(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Loopback-only host with no readable resolv.conf at either path."""
-        from terok_executor import krun as krun_mod
-
-        empty = tmp_path / "loopback-only"
-        empty.write_text("nameserver 127.0.0.53\n")
-
-        original_read = Path.read_text
-
-        def _read(self: Path, *a, **kw):  # type: ignore[no-untyped-def]
-            if self == krun_mod._SYSTEMD_RESOLVED_REAL_CONF:
-                return empty.read_text(*a, **kw)
-            if self == Path("/etc/resolv.conf"):
-                raise OSError("missing")
-            return original_read(self, *a, **kw)
-
-        monkeypatch.setattr(Path, "read_text", _read)
-        assert krun_mod.host_upstream_dns() is None
-
-    def test_ignores_malformed_address_tokens(self, tmp_path: Path) -> None:
-        """Garbage on a nameserver line is skipped, not raised."""
-        from terok_executor.krun import host_upstream_dns
-
-        f = tmp_path / "resolv.conf"
-        f.write_text("nameserver not-an-ip\nnameserver 9.9.9.9\n")
-        with patch("terok_executor.krun._SYSTEMD_RESOLVED_REAL_CONF", f):
-            assert host_upstream_dns() == "9.9.9.9"
+        assert args[dns_idx + 1] == "169.254.1.1"


### PR DESCRIPTION
## Summary

- New ``krun_launch_args(cfg=...)`` returns the podman-run extras a krun task needs from executor's side of the boundary: the host-pubkey bind-mount, ``TEROK_CONTAINER_RUNTIME=krun``, ``--user root``, and ``--dns 169.254.1.1`` (pasta's link-local DNS forwarder).
- Adds re-export from ``terok_executor.__init__``.
- ``TestKrunLaunchArgs`` pins the four returned tokens.

## Background

terok's ``_project_runtime_flags`` was reaching across the orchestrator/runtime boundary three times under krun and reproducing implementation knowledge that belongs here.  All facts (the L0 placeholder path, ``ensure_krun_host_keypair``, the init-script env-var contract, the L0 ``USER dev`` directive) live in executor, so the helper that ties them together belongs here too.

### DNS

libkrun's TSI proxies AF_INET sockets to the host VMM but does **not** redirect 127.0.0.0/8 back to the host's network stack — so the guest's own loopback isn't the host's, and a podman-generated ``resolv.conf`` pointing at ``127.0.0.53`` (systemd-resolved's stub on F44) is unreachable from inside the microVM.

The address chosen is ``169.254.1.1`` — pasta's built-in DNS forwarder.  TSI surfaces the guest's ``:53`` connect to a host-side socket inside the podman netns, where pasta answers it.  It's also the *only* DNS address terok-shield's nft policy permits (``terok_shield.nft.constants.PASTA_DNS``), so the same flag works under both shield-up and shield-down.  Shield+krun loses dnsmasq's clearance prompts (queries bypass it) — documented limitation for the experimental krun runtime; egress filtering on TCP/UDP still applies because TSI surfaces traffic in the netns where shield's nft sees it.

Slirp4netns hosts (``10.0.2.3``) aren't supported for krun yet — operator overrides ``--dns`` themselves if needed.

## Test plan

- [x] ``make check`` clean (``901 passed``).
- [ ] End-to-end on F44 + crun-krun: ``terok task run`` against an offline project, then ``ssh github.com`` from inside the guest resolves + connects.
- [ ] Verify shield-up + crun (the existing supported combo) still works — guarded by the krun-only call gate in terok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `krun_launch_args()` helper function generating preconfigured launcher arguments, including SSH key deployment to containers, environment configuration, root user enforcement, and DNS forwarding settings.

* **Tests**
  * Added test coverage validating correct argument generation, key mount paths, file permissions, environment variables, and DNS configuration.

* **Chores**
  * Version bump to 0.0.149a15.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->