### PR TITLE
feat(vault): surface transport + live listeners in `terok vault status`

### DIFF
--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -195,6 +195,9 @@ def _format_credentials(status: object, cfg: SandboxConfig | None = None) -> str
 def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
     """Show vault status."""
     from terok_sandbox import (
+        SandboxConfig as _SandboxConfig,
+        get_ssh_signer_port,
+        get_token_broker_port,
         get_vault_status,
         is_vault_systemd_available,
         sanitize_tty,
@@ -203,7 +206,12 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
 
     from terok_executor.paths import mounts_dir
 
-    status = get_vault_status(cfg=cfg)
+    # Keep a concrete cfg in hand so the socket-mode branch can surface
+    # the SSH-signer socket path alongside the broker socket without a
+    # second sandbox round-trip; ``get_vault_status`` does its own
+    # resolution internally and is unaffected.
+    working_cfg = cfg or _SandboxConfig()
+    status = get_vault_status(cfg=working_cfg)
     state = "running" if status.running else "stopped"
     # Path fields land in a terminal that interprets ANSI/control chars.
     # The values originate from the vault daemon's config / live state —
@@ -211,9 +219,46 @@ def _handle_status(*, cfg: SandboxConfig | None = None) -> None:
     # manipulated systemd unit could plant control sequences that would
     # otherwise spoof prompts or rewrite the screen.  Sanitise at the
     # render boundary; matches what ``terok-sandbox vault status`` does.
-    print(f"Mode:        {sanitize_tty(status.mode)}")
+    #
+    # Two orthogonal facts about the vault, each on its own line:
+    # ``Activation:`` is the lifecycle channel (``systemd`` / ``daemon`` /
+    # ``none``) — how the vault is *managed*.  ``Transport:`` is the wire
+    # protocol containers use (``tcp`` / ``socket``) — how clients *reach*
+    # it.  The historical single-line ``Mode:`` overloaded both axes onto
+    # one label, which read as "transport" for almost every user and made
+    # the TCP-mode rendering misleading (no port surfaced, only the
+    # fast-path Unix probe — see commentary on the ``Socket:`` line
+    # below).
+    print(f"Activation:  {sanitize_tty(status.mode)}")
+    # Tight allow-list — keeps an unexpected value (or a ``MagicMock`` in
+    # tests that haven't bothered to set ``transport``) from leaking a
+    # raw repr into operator-facing output.
+    transport = status.transport if status.transport in ("tcp", "socket") else None
+    print(f"Transport:   {transport or '(not configured)'}")
     print(f"Status:      {state}")
-    print(f"Socket:      {sanitize_tty(str(status.socket_path))}")
+    # TCP mode: surface the actual listeners that container traffic
+    # rides.  In TCP mode the daemon still binds ``vault.sock`` as a
+    # local fast-path probe target (host-side ``ensure_reachable``
+    # tries it before the TCP probe), but no container or external
+    # client ever reaches that socket — flag it so the line doesn't
+    # imply otherwise.
+    if transport == "tcp":
+        broker_port = get_token_broker_port(cfg=working_cfg)
+        signer_port = get_ssh_signer_port(cfg=working_cfg)
+        if broker_port is not None:
+            print(f"TCP broker:  127.0.0.1:{broker_port}")
+        if signer_port is not None:
+            print(f"TCP signer:  127.0.0.1:{signer_port}")
+        socket_annotation = "  (fast-path probe only)"
+    else:
+        socket_annotation = ""
+    print(f"Socket:      {sanitize_tty(str(status.socket_path))}{socket_annotation}")
+    # Socket-mode: the SSH signer rides a sibling Unix socket that
+    # containers connect to directly via the per-task bind mount.
+    # Surface it so the rendering is symmetric with the broker
+    # ``Socket:`` line (both transports, both signer endpoints visible).
+    if transport == "socket":
+        print(f"SSH signer:  {sanitize_tty(str(working_cfg.ssh_signer_socket_path))}")
     print(f"DB:          {sanitize_tty(str(status.db_path))}")
     print(
         f"Routes:      {sanitize_tty(str(status.routes_path))}"

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -567,6 +567,131 @@ class TestVaultCommandHandlers:
         assert "plaintext" not in captured.err
         assert "plaintext" not in captured.out
 
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_ssh_signer_port", return_value=18702)
+    @patch("terok_sandbox.get_token_broker_port", return_value=18701)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_tcp_mode_surfaces_ports_and_annotates_socket(
+        self, mock_status, _broker, _signer, _sd, _scan, capsys
+    ) -> None:
+        """TCP-mode status surfaces ``TCP broker:`` / ``TCP signer:`` and tags the Unix socket.
+
+        In TCP mode every container reaches the vault via the TCP listeners;
+        the daemon still binds ``vault.sock`` as a local fast-path probe
+        target but no client traffic touches it.  The renderer must
+        therefore show both ports and disambiguate the socket line, or
+        operators reading the output will conclude TCP mode "doesn't have"
+        ports just because the headline ``Socket:`` line is the only
+        endpoint visible.
+        """
+        mock_status.return_value = MagicMock(
+            mode="systemd",
+            running=True,
+            transport="tcp",
+            socket_path="/run/user/1000/terok/sandbox/vault.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source="systemd-creds",
+            locked=False,
+            plaintext_passphrase_path=None,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        out = capsys.readouterr().out
+        assert "Activation:  systemd" in out
+        assert "Transport:   tcp" in out
+        assert "TCP broker:  127.0.0.1:18701" in out
+        assert "TCP signer:  127.0.0.1:18702" in out
+        assert "(fast-path probe only)" in out
+        # And the renamed label fully replaced the legacy one.
+        assert "Mode:        systemd" not in out
+
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_socket_mode_surfaces_signer_socket(
+        self, mock_status, _sd, _scan, capsys, tmp_path
+    ) -> None:
+        """Socket-mode status surfaces the SSH signer socket alongside the broker socket.
+
+        Containers in socket mode reach the SSH signer via its own Unix
+        socket (bind-mounted into ``/run/terok/ssh-agent.sock``); the
+        broker socket is a sibling endpoint, not a replacement.  Both
+        endpoints land in the rendered output so operators can match
+        what they see here against the per-container env vars.
+        """
+        from terok_sandbox import SandboxConfig
+
+        cfg = SandboxConfig(
+            state_dir=tmp_path / "state",
+            runtime_dir=tmp_path / "run",
+            vault_dir=tmp_path / "vault",
+            services_mode="socket",
+        )
+        mock_status.return_value = MagicMock(
+            mode="systemd",
+            running=True,
+            transport="socket",
+            socket_path=cfg.vault_socket_path,
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=3,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source="keyring",
+            locked=False,
+            plaintext_passphrase_path=None,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status(cfg=cfg)
+        out = capsys.readouterr().out
+        assert "Transport:   socket" in out
+        assert f"SSH signer:  {cfg.ssh_signer_socket_path}" in out
+        # Socket-mode rendering must NOT carry the TCP-only embellishments.
+        assert "TCP broker:" not in out
+        assert "TCP signer:" not in out
+        assert "(fast-path probe only)" not in out
+
+    @patch("terok_executor.credentials.vault_commands.scan_leaked_credentials", return_value=[])
+    @patch("terok_sandbox.is_vault_systemd_available", return_value=False)
+    @patch("terok_sandbox.get_vault_status")
+    def test_status_falls_back_to_not_configured_when_transport_unknown(
+        self, mock_status, _sd, _scan, capsys
+    ) -> None:
+        """``status.transport is None`` (vault not running) → ``Transport: (not configured)``.
+
+        Also guards against renderer regression on any unexpected ``transport``
+        value: the allow-list in the renderer keeps a stray repr from
+        leaking onto operator-facing output.
+        """
+        mock_status.return_value = MagicMock(
+            mode="none",
+            running=False,
+            transport=None,
+            socket_path="/run/proxy.sock",
+            db_path="/data/creds.db",
+            routes_path="/data/routes.json",
+            routes_configured=0,
+            credentials_stored=(),
+            ssh_keys_stored=0,
+            passphrase_source=None,
+            locked=False,
+            plaintext_passphrase_path=None,
+        )
+        from terok_executor.credentials.vault_commands import _handle_status
+
+        _handle_status()
+        out = capsys.readouterr().out
+        assert "Transport:   (not configured)" in out
+        assert "TCP broker:" not in out
+        assert "SSH signer:" not in out
+
     @patch("terok_sandbox.install_vault_systemd")
     @patch("terok_executor.credentials.vault_commands._ensure_routes")
     @patch("terok_sandbox.is_vault_systemd_available", return_value=True)


### PR DESCRIPTION
## Summary

- ``terok vault status``'s headline ``Mode:`` line conflated two orthogonal axes — lifecycle activation (`systemd` / `daemon` / `none`) and wire transport (`tcp` / `socket`).  Read as transport by every operator who didn't dig into the code, which made TCP-mode output actively misleading: the only endpoint surfaced was the daemon's local fast-path Unix probe socket, and the actual TCP listeners that all container traffic rides were invisible.
- Split the two axes: ``Mode:`` → ``Activation:`` (no semantic change, just unambiguous naming) plus a new ``Transport:`` line carrying ``tcp`` / ``socket`` / ``(not configured)``.  Allow-listed so an unexpected value (or an unset ``MagicMock`` field in tests) can't leak a raw repr.
- Surface the real listeners per transport:
  - **TCP mode**: adds ``TCP broker: 127.0.0.1:<port>`` and ``TCP signer: 127.0.0.1:<port>``; annotates the still-bound ``Socket:`` line as ``(fast-path probe only)`` so operators don't read it as the wire endpoint.
  - **Socket mode**: adds ``SSH signer: <path>`` next to ``Socket:`` so both endpoints containers actually mount land in the same rendered block.

Before / after — same vault, TCP mode:

```diff
-Mode:        systemd
+Activation:  systemd
+Transport:   tcp
 Status:      running
-Socket:      /run/user/1000/terok/sandbox/vault.sock
+TCP broker:  127.0.0.1:18701
+TCP signer:  127.0.0.1:18702
+Socket:      /run/user/1000/terok/sandbox/vault.sock  (fast-path probe only)
 DB:          ...
```

## Test plan

- [x] `make lint` clean
- [x] `make tach` clean
- [x] `make typecheck` (mypy) clean
- [x] `make security` (bandit) — 0 medium/high
- [x] `make docstrings` — 98.0%
- [x] `make reuse` clean
- [x] `make test-unit` — 947/947 pass (3 new status-renderer tests covering TCP, socket, and the unknown-transport fallback)
- [x] Manual eyeball on a real Fedora SilverBlue host in both transports — output renders as the diff above, no `<MagicMock ...>` regressions, no warning regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced vault status output with improved formatting and transport-specific details.
  * Status command now displays separate lines for Activation, Transport type, and relevant endpoints based on configuration (TCP ports or socket paths).

* **Tests**
  * Added comprehensive test coverage for vault status output across TCP, socket, and unconfigured transport modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->