### PR TITLE
test(unit): isolate $HOME / XDG_* in unit conftest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,17 @@ those run on a dedicated test machine.
   and may change without notice.  Review the list before each release
   — stable APIs stay small because growing them costs.
 
+## Tests
+
+- **Path isolation**: tests must never touch the operator's real
+  filesystem.  All on-disk fixtures route through `tmp_path` /
+  `tmp_path_factory`.  The autouse `_isolate_user_paths` fixture in
+  `tests/unit/conftest.py` redirects `HOME` and the `XDG_*` chain to
+  a fresh tmp dir, so default-config code paths (``SandboxConfig()``,
+  ``_mock_sandbox()`` helpers, etc.) land in tmp by construction —
+  don't bypass it, and add to `_TEROK_PATH_OVERRIDE_ENV_VARS` when
+  introducing a new `TEROK_*_DIR` knob.
+
 ## Docs
 
 - Markdown files under `docs/` are lowercase by convention; root-level

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,17 +16,74 @@ chain.  Tests that seed a real SQLCipher file at ``cfg.db_path``
 should construct ``CredentialDB(cfg.db_path, passphrase=TEST_VAULT_PASSPHRASE)``
 so the on-disk file uses the same key the autouse fixture opens it
 with.
+
+A second autouse fixture (``_isolate_user_paths``) redirects ``HOME``
+and every ``XDG_*`` / ``TEROK_*_DIR`` knob to a per-test ``tmp_path``
+so that any code path constructing a default ``SandboxConfig()`` (the
+``_mock_sandbox()`` helper in ``test_runner.py``, the helpers in
+``test_acp_roster.py``, etc.) resolves under tmp instead of mutating
+the operator's real ``~/.config/terok``.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 TEST_VAULT_PASSPHRASE = "unit-test-passphrase"  # nosec: B105 — fixture, not a real secret
 """Passphrase used everywhere a unit test seeds or opens the vault DB."""
+
+
+# Terok-specific env vars that override path resolution.  The autouse
+# isolation fixture unsets each so resolution falls back through the
+# tmp-rooted ``HOME`` / ``XDG_*`` chain — never to the operator's real
+# state.
+_TEROK_PATH_OVERRIDE_ENV_VARS = (
+    "TEROK_CONFIG_DIR",
+    "TEROK_STATE_DIR",
+    "TEROK_VAULT_DIR",
+    "TEROK_RUNTIME_DIR",
+    "TEROK_ROOT",
+    "TEROK_SANDBOX_LIVE_DIR",
+    "TEROK_SANDBOX_STATE_DIR",
+    "TEROK_SANDBOX_RUNTIME_DIR",
+    "TEROK_EXECUTOR_STATE_DIR",
+    "TEROK_PORT_REGISTRY_DIR",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_user_paths(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Redirect ``HOME`` and every ``XDG_*`` / ``TEROK_*_DIR`` knob to a fresh tmp dir.
+
+    Without this, tests that exercise default-config code paths
+    (``SandboxConfig()`` with no overrides, ``_mock_sandbox()`` helpers,
+    etc.) fall through to the operator's real ``~/.config/terok/`` and
+    XDG state dirs — silently passing on a clean machine and mutating
+    those files on a populated one.  ``test_setup_gate_calls_sandbox``
+    in particular calls ``runner._setup_gate()`` which does
+    ``cfg.gate_base_path.mkdir(parents=True)`` — without isolation
+    that's a real ``~/.local/share/terok/gate/...`` creation.
+
+    Uses ``tmp_path_factory`` rather than ``tmp_path`` so the fake home
+    lives outside the per-test ``tmp_path``: storage tests like
+    ``test_finds_both_tasks`` iterate their own ``tmp_path`` looking
+    for task dirs and would otherwise see a stray ``fake-home`` entry.
+    """
+    fake_home = tmp_path_factory.mktemp("fake-home")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(fake_home / ".config"))
+    monkeypatch.setenv("XDG_DATA_HOME", str(fake_home / ".local" / "share"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(fake_home / ".local" / "state"))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(fake_home / ".cache"))
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(fake_home / "run"))
+    for var in _TEROK_PATH_OVERRIDE_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
 
 
 @pytest.fixture(autouse=True)
@@ -38,8 +95,6 @@ def _stub_credential_db_passphrase() -> Iterator[None]:
     exactly the same file.  ``prompt_on_tty`` is accepted (and
     ignored) to match the real signature.
     """
-    from pathlib import Path
-
     from terok_sandbox import CredentialDB
 
     def _open_method(


### PR DESCRIPTION
## Summary

Adds an autouse `_isolate_user_paths` fixture to `tests/unit/conftest.py` that redirects `HOME` and every `XDG_*` to a fresh `tmp_path_factory.mktemp("fake-home")`, and unsets every `TEROK_*_DIR` override.  Without this, tests that exercise default-config code paths fall through to the operator's real `~/.config/terok/...` and XDG state dirs.

Companion to [terok-sandbox#343](https://github.com/terok-ai/terok-sandbox/pull/343), which adds the same fixture to sandbox's unit conftest.  The two projects each maintain their own `tests/unit/conftest.py`; the fix has to land in both.

## Worst offender this catches

`TestGateIntegration::test_setup_gate_calls_sandbox` (`test_runner.py:694`) calls `runner._setup_gate()` which does `cfg.gate_base_path.mkdir(parents=True)`.  Without isolation that's an unconditional write to a real `~/.local/share/terok/gate/...` on every test run.  The bare `_mock_sandbox()` helper at `test_runner.py:819` is reused by ~43 tests in `TestAgentRunner` and `TestLaunchPrepared`, all constructing default `SandboxConfig()` that resolves to real user paths.  Same shape for the helpers in `test_acp_roster.py`.

## Why `tmp_path_factory` and not `tmp_path`

A first iteration used `tmp_path / "fake-home"` for the redirect, but that broke storage tests that iterate their own `tmp_path` looking for task dirs (`test_storage.py::TestGetTasksStorage::test_finds_both_tasks` — found 3 dirs because of the stray `fake-home`).  `tmp_path_factory.mktemp(...)` creates each test's fake home outside the per-test `tmp_path`, so they don't pollute each other.

## Test plan

- [x] `make check` clean — 949/949 unit tests pass, lint/tach/docstrings/security/SPDX all green.
- [x] `test_setup_gate_calls_sandbox` no longer touches real `~/.local/share/terok/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by redirecting filesystem paths and environment variables to temporary test directories, preventing test runs from accessing or modifying user configuration and state files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->