### PR TITLE
feat(launch): plumb runtime through launch_prepared; --dns docstring

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3274,9 +3274,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.124a13-py3-none-any.whl", hash = "sha256:0a2cecf6accd55964249eba25ed290b7f74554db403475317059c256983fc7fb"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3289,11 +3288,13 @@ pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a4/terok_clearance-0.6.14a4-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a4/terok_shield-0.6.42a4-py3-none-any.whl"}
+terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", rev = "feat/krun-dnsmasq-bind"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a13/terok_sandbox-0.0.124a13-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/shield-runtime-thread"
+resolved_reference = "cd7454499ef1615c56953cf64c9783a54eacc13b"
 
 [[package]]
 name = "terok-shield"
@@ -3302,17 +3303,18 @@ description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_shield-0.6.42a4-py3-none-any.whl", hash = "sha256:4d9751f814785ac202944a10239dadbde352e2e814e9509b56d5393a06870a08"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a4/terok_shield-0.6.42a4-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-shield.git"
+reference = "feat/krun-dnsmasq-bind"
+resolved_reference = "e4fd7b9918b3fc930ac42194c607dc0ba0f541cc"
 
 [[package]]
 name = "tomli"
@@ -3711,4 +3713,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "0d7621829e36ec774bfae40178b47226c6acfe63f43cad7dec392b8b27fe1ae1"
+content-hash = "b05b5eb99c5edfbbe6d6b97283248cd71d9c4f3fc24dde59f6d6fc61c495d5ca"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3269,13 +3269,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a4/t
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.124a13"
+version = "0.0.124a14"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.124a14-py3-none-any.whl", hash = "sha256:92f9014d74e7e5c6ea79859edc5796f30ab5f3ab625a9153450a7a442880fde0"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3288,33 +3289,30 @@ pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a4/terok_clearance-0.6.14a4-py3-none-any.whl"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", rev = "feat/krun-dnsmasq-bind"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a5/terok_shield-0.6.42a5-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/shield-runtime-thread"
-resolved_reference = "cd7454499ef1615c56953cf64c9783a54eacc13b"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a14/terok_sandbox-0.0.124a14-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.42a4"
+version = "0.6.42a5"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_shield-0.6.42a5-py3-none-any.whl", hash = "sha256:4e670fb7040bb39e9c1a2ec449db7fe82dd99678d9841ce97c08a146af127604"},
+]
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-shield.git"
-reference = "feat/krun-dnsmasq-bind"
-resolved_reference = "e4fd7b9918b3fc930ac42194c607dc0ba0f541cc"
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a5/terok_shield-0.6.42a5-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -3713,4 +3711,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "b05b5eb99c5edfbbe6d6b97283248cd71d9c4f3fc24dde59f6d6fc61c495d5ca"
+content-hash = "59bf049c209d12fe5f4f1547cd0121150ad0caa07f76cc08ac27790f38b962f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 dependencies = [
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/shield-runtime-thread",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a14/terok_sandbox-0.0.124a14-py3-none-any.whl",
     "ruamel.yaml>=0.18",
     "Jinja2>=3.1",
     "tomli-w>=1.0",
@@ -53,7 +53,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.0.149a17"
+version = "0.0.149a18"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a13/terok_sandbox-0.0.124a13-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/shield-runtime-thread",
     "ruamel.yaml>=0.18",
     "Jinja2>=3.1",
     "tomli-w>=1.0",

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -325,6 +325,7 @@ class AgentRunner:
         extra_args: list[str] | None = None,
         hostname: str | None = None,
         annotations: Mapping[str, str] | None = None,
+        runtime: str | None = None,
     ) -> str:
         """Launch a container from a caller-prepared env, volumes, image, and command.
 
@@ -360,6 +361,14 @@ class AgentRunner:
                 [`SAFE_ANNOTATION_KEYS`][terok_sandbox.sandbox.SAFE_ANNOTATION_KEYS].
                 Typed channel for orchestrator metadata the shield reads,
                 distinct from the freeform *extra_args*.
+            runtime: OCI runtime selector forwarded to
+                [`RunSpec.runtime`][terok_sandbox.sandbox.RunSpec.runtime].
+                ``None`` (default) leaves the choice to podman; ``"krun"``
+                selects the libkrun microVM backend and also drives
+                shield's dnsmasq bind selection.  Prefer this over
+                passing ``--runtime`` via *extra_args* — sandbox emits
+                the flag itself and shield reads the value to pick the
+                right firewall topology.
 
         Returns:
             The container name (same as *name*).
@@ -385,6 +394,7 @@ class AgentRunner:
             sealed=sealed,
             hostname=hostname,
             annotations=annotations or {},
+            runtime=runtime,
         )
 
         try:

--- a/src/terok_executor/krun.py
+++ b/src/terok_executor/krun.py
@@ -189,14 +189,8 @@ def krun_launch_args(*, cfg: SandboxConfig | None = None) -> list[str]:
       authenticated user on connection.  ``USER dev`` is the right
       default under crun (AI agents that refuse uid 0); under krun the
       session uid comes from which ``ssh user@…`` the operator picks.
-    - ``--dns 169.254.1.1`` so the guest resolves through pasta's
-      forwarder rather than the unreachable host-loopback stub.  Same
-      address terok-shield's nft already permits :53 to, so this works
-      under both shield-up and shield-down — the only behavioural cost
-      under shield-up is losing dnsmasq's clearance prompts (queries
-      bypass it).  Documented limitation for the experimental krun
-      runtime; will be revisited when shield+krun gets first-class
-      support.
+    - ``--dns 169.254.1.1`` — kept for shield-bypass; under shield-up
+      the bind-mounted resolv.conf overrides this anyway.
 
     Doesn't include ``--runtime krun`` itself or krun's microVM-sizing
     annotations — those are orchestrator-level decisions terok keeps.

--- a/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok_executor/resources/scripts/init-ssh-and-repo.sh
@@ -45,18 +45,52 @@ set -euo pipefail
 # The supervisor loop restarts sshd if it crashes (panic, OOM, etc.);
 # ``setsid`` puts the loop in its own session so SIGHUP from the outer
 # init shell (which exits after ``exec bash`` below) can't take it down.
-if [[ "${TEROK_CONTAINER_RUNTIME:-}" == "krun" ]]; then
+if [[ "${TEROK_CONTAINER_RUNTIME:-}" == "krun" && "$(id -u)" == "0" ]]; then
+  # sshd builds a clean session env via PAM — the daemon's inherited
+  # podman ``-e`` env is intentionally NOT propagated to user sessions.
+  # ``PermitUserEnvironment=yes`` makes sshd read ``~/.ssh/environment``
+  # (NAME=VALUE, one per line, literal values) right after auth, before
+  # any /etc/profile or /etc/bashrc — works regardless of distro or L1
+  # image vintage.
   echo ">> starting sshd supervisor on TCP 22 (krun mode — root + dev login)"
   mkdir -p /run/sshd
   setsid bash -c '
     while :; do
       /usr/sbin/sshd -D -e \
         -o "AllowUsers dev root" \
-        -o "PermitRootLogin without-password"
+        -o "PermitRootLogin without-password" \
+        -o "PermitUserEnvironment yes"
       echo "[sshd-supervisor] sshd exited (code $?); restarting in 1s" >&2
       sleep 1
     done
   ' </dev/null &
+
+  # Inverse-list filter: drop shell-internal / login-set vars (the PAM
+  # session sets them) and bash's own exported namespace; everything
+  # else is podman's ``-e`` payload, propagated automatically.  Newline
+  # values would corrupt the line-oriented file and are skipped.
+  install -d -m 0700 -o dev -g dev /home/dev/.ssh
+  {
+    while IFS= read -r name; do
+      case "$name" in
+        PATH|HOME|PWD|OLDPWD|USER|LOGNAME|SHELL|SHLVL|IFS|MAIL|HOSTNAME|TERM|LANG|LC_*|LS_COLORS) ;;
+        _|BASH*|FUNCNAME|EUID|UID|GROUPS|PPID|RANDOM|LINENO|SECONDS|HISTFILE|HISTSIZE|HISTCONTROL) ;;
+        *)
+          val="${!name-}"
+          [[ "$val" == *$'\n'* ]] && continue
+          printf '%s=%s\n' "$name" "$val"
+          ;;
+      esac
+    done < <(compgen -e)
+  } > /home/dev/.ssh/environment
+  chown dev:dev /home/dev/.ssh/environment
+  chmod 0600 /home/dev/.ssh/environment
+
+  # Drop to dev so git operations below produce dev-owned files (the
+  # operator's ssh login can't ``git pull`` against root-owned ``.git``).
+  # managed-settings.json is written by the post-drop block — /etc/claude-code
+  # is dev-owned per agents/claude.yaml, so dev's write lands cleanly.
+  exec runuser -u dev -- bash "$0" "$@"
 fi
 
 # Per-task permission mode: write managed settings for agents that need
@@ -78,28 +112,25 @@ fi
 # shellcheck source=ensure-bridges.sh
 source ensure-bridges.sh
 
-if [[ -n "${SSH_AUTH_SOCK:-}" ]]; then
+# Export SSH_AUTH_SOCK from socket existence rather than the
+# ensure-bridges.sh internal export (which only fires on a fresh
+# bridge start, not when the bridge is already alive).
+if [[ -S /tmp/ssh-agent.sock ]]; then
+  export SSH_AUTH_SOCK=/tmp/ssh-agent.sock
   echo ">> bridges established (SSH_AUTH_SOCK=${SSH_AUTH_SOCK})"
+fi
 
-  # Generate minimal ~/.ssh/config — the SSH signer handles keys, so no
-  # IdentityFile is needed.  StrictHostKeyChecking=accept-new prevents
-  # interactive prompts on first connect while still pinning known hosts.
-  mkdir -p "$HOME/.ssh"
-  chmod 700 "$HOME/.ssh"
-  cat > "$HOME/.ssh/config" << 'SSHEOF'
+# ~/.ssh/config: ``StrictHostKeyChecking accept-new`` lets the first
+# real fetch accept-and-pin the host key without an interactive prompt.
+# Independent of SSH_AUTH_SOCK — even with no agent the operator still
+# needs the host-key autoaccept for git over ssh.
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+cat > "$HOME/.ssh/config" << 'SSHEOF'
 Host *
   StrictHostKeyChecking accept-new
 SSHEOF
-  chmod 644 "$HOME/.ssh/config"
-
-  # Warm GitHub known_hosts (uses the SSH signer for authentication)
-  if command -v ssh >/dev/null 2>&1; then
-    if [[ -n "${CODE_REPO:-}" && "${CODE_REPO}" == *"github.com"* ]]; then
-      echo '>> warm github known_hosts (best-effort)'
-      timeout 5 ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o LogLevel=ERROR git@github.com || true
-    fi
-  fi
-fi
+chmod 644 "$HOME/.ssh/config"
 
 # Reset current branch to its remote tracking counterpart.
 # Used when no specific branch is configured or the configured branch is missing.

--- a/src/terok_executor/resources/scripts/terok-env.sh
+++ b/src/terok_executor/resources/scripts/terok-env.sh
@@ -72,8 +72,14 @@ glab() {
 # ── Proxy bridges ────────────────────────────────────────────────────────────
 
 # Ensure socat bridges are alive (idempotent; self-heals after container restart).
+# Skip under root: under krun the launch goes through ``bash -lc`` which sources
+# /etc/profile (and us) BEFORE init-ssh-and-repo.sh drops privileges, so
+# starting bridges here would leave them root-owned and unreachable from the
+# later dev session (UID-mismatched kill -0 / unowned ``/tmp/*.sock``).
+# init-ssh-and-repo.sh explicitly sources ensure-bridges.sh post-drop.
 # shellcheck source=ensure-bridges.sh
-command -v socat >/dev/null 2>&1 && . ensure-bridges.sh 2>/dev/null
+[[ "$(id -u)" -ne 0 ]] && command -v socat >/dev/null 2>&1 && \
+    . ensure-bridges.sh 2>/dev/null
 
 # Export SSH_AUTH_SOCK when the bridge socket exists; unset if it's gone.
 if [[ -S /tmp/ssh-agent.sock ]]; then

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -443,6 +443,46 @@ class TestLaunchPrepared:
         spec = sandbox.run.call_args[0][0]
         assert dict(spec.annotations) == {}
 
+    def test_runtime_propagates_to_runspec(self, tmp_path: Path) -> None:
+        """``runtime="krun"`` lands on ``RunSpec.runtime`` — the typed channel
+        sandbox turns into both podman's ``--runtime`` flag and shield's
+        dnsmasq-bind selection.  Without this the orchestrator would still
+        have to smuggle ``--runtime krun`` through ``extra_args`` and shield
+        would silently fall back to the default-runtime dnsmasq bind."""
+        sandbox = _mock_sandbox()
+        runner = AgentRunner(sandbox=sandbox)
+
+        runner.launch_prepared(
+            env={},
+            volumes=[],
+            image="img",
+            command=[],
+            name="c",
+            task_dir=tmp_path,
+            runtime="krun",
+        )
+
+        spec = sandbox.run.call_args[0][0]
+        assert spec.runtime == "krun"
+
+    def test_runtime_defaults_to_none(self, tmp_path: Path) -> None:
+        """Omitting ``runtime`` leaves ``RunSpec.runtime`` ``None`` so podman
+        falls through to its built-in default."""
+        sandbox = _mock_sandbox()
+        runner = AgentRunner(sandbox=sandbox)
+
+        runner.launch_prepared(
+            env={},
+            volumes=[],
+            image="img",
+            command=[],
+            name="c",
+            task_dir=tmp_path,
+        )
+
+        spec = sandbox.run.call_args[0][0]
+        assert spec.runtime is None
+
     def test_sealed_defaults_false(self, tmp_path: Path) -> None:
         """Sealed isolation is opt-in — the default must be shared-mode."""
         sandbox = _mock_sandbox()


### PR DESCRIPTION
## Summary

- `AgentRunner.launch_prepared` gains a `runtime: str | None = None` kwarg that threads into `RunSpec.runtime`.  Sandbox already turns the field into both podman's `--runtime` flag and the shield runtime mapping, so orchestrators no longer need to smuggle `--runtime krun` through `extra_args` for shield to see it.
- `krun_launch_args` docstring rewrite: `--dns 169.254.1.1` is now the shield-bypass fallback only.  Under shield-up, shield's bind-mounted resolv.conf points at the link-local dnsmasq listener (terok-shield#327 / terok-sandbox#347) so clearance prompts fire on hostnames.

## Test plan

- [x] `make check` clean (949 unit tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to select the OCI runtime (e.g., krun) when launching containers; runtime choice is propagated.
  * Per-task environment exports for SSH/login sessions and guarded krun-mode SSH supervisor start (UID 0 only).

* **Documentation**
  * Clarified DNS and shield-mode behavior and override order.

* **Chores**
  * Updated sandbox dependency to a Git-based release.

* **Tests**
  * Added unit tests validating runtime propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->