### PR TITLE
chore(schema): drop redundant _reject_legacy_socket_path validator

### DIFF
--- a/src/terok_executor/roster/schema.py
+++ b/src/terok_executor/roster/schema.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 
 from terok_executor.credentials.auth import AuthKeyConfig, AuthProvider, api_key_command
 from terok_executor.provider.providers import AgentProvider, OpenCodeProviderConfig
@@ -255,16 +255,6 @@ class RawVault(StrictModel):
             "layer skips host-level denies for these providers."
         ),
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def _reject_legacy_socket_path(_cls, data: object) -> object:
-        if isinstance(data, dict) and "socket_path" in data:
-            raise ValueError(
-                "'socket_path' is no longer configurable — "
-                "remove it; the env builder resolves the vault socket path centrally"
-            )
-        return data
 
     def to_dataclass(self, *, provider: str) -> VaultRoute:
         """Project to a runtime [`VaultRoute`][terok_executor.roster.types.VaultRoute]."""

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -787,17 +787,6 @@ class TestStrictValidation:
         with pytest.raises(ValidationError, match="section"):
             RawAgentYaml.model_validate({"help": {"section": "elsewhere"}})
 
-    def test_legacy_socket_path_rejected_with_helpful_message(self) -> None:
-        data = {
-            "vault": {
-                "route_prefix": "x",
-                "upstream": "https://x",
-                "socket_path": "/tmp/legacy.sock",
-            }
-        }
-        with pytest.raises(ValidationError, match="socket_path.*no longer"):
-            RawAgentYaml.model_validate(data)
-
     def test_install_depends_on_accepts_string_shorthand(self) -> None:
         spec = RawAgentYaml.model_validate({"install": {"depends_on": "claude"}})
         assert spec.install is not None

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -75,13 +75,6 @@ class TestVaultRoutesParsed:
             assert route.oauth_phantom_env == {}, f"{name} should have no oauth_phantom_env"
             assert route.socket_env == "", f"{name} should have no socket_env"
 
-    def test_rejects_legacy_socket_path_field(self) -> None:
-        """socket_path was removed — declaring it must fail loudly so stale
-        agent manifests don't silently drift out of sync."""
-        base = {"route_prefix": "test", "upstream": "https://example.com"}
-        with pytest.raises(ValidationError, match="socket_path.*no longer"):
-            _vault_route("test", {"vault": {**base, "socket_path": "/tmp/s.sock"}})
-
     def test_opencode_agents_have_routes(self) -> None:
         """Blablador and KISSKI have vault routes."""
         reg = get_roster()


### PR DESCRIPTION
## Summary

- Drops `RawAuthVault._reject_legacy_socket_path` at `src/terok_executor/roster/schema.py:259-267` — a `model_validator(mode="before")` whose only job was to dress pydantic's existing `extra="forbid"` rejection with a `socket_path is no longer configurable` hint. The hint outlived the migration window; stale roster files still fail loudly, just with the generic `Extra inputs are not permitted` message that every other unknown field already produces.
- Removes the two pinned tests (`test_legacy_socket_path_rejected_with_helpful_message` in `test_roster.py`, `test_rejects_legacy_socket_path_field` in `test_vault_routes.py`) that only asserted the custom message. The generic strict-keys behaviour is already covered by `test_config_schema.py:27`.
- Drops the now-unused `model_validator` import.

Net: 29 LoC out, 1 in.

## Test plan

- [x] `make lint` clean
- [x] `make test-unit` — 945 passed; 4 pre-existing `test_preflight.py` failures also fail on clean `upstream/master` (env-related, no shield/sandbox on PATH), unrelated to this change.
- [x] `make tach` / `make reuse` / docstring coverage all green
- Stale roster carrying `socket_path` still fails validation (now via `Extra inputs are not permitted` rather than the custom hint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed overly restrictive validation that blocked socket_path field usage
  * Enhanced configuration validation to properly enforce help.section value constraints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->