### PR TITLE
feat(auth): thread credential_set through authenticate, runtime, and preflight

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.0.149a26"
+version = "0.0.149a27"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -111,6 +111,15 @@ class ContainerEnvSpec:
     credential_scope: str = "standalone"
     """Scope for vault token creation.  terok passes ``project.id``."""
 
+    credential_set: str = "default"
+    """Vault storage namespace to read credentials from.  Pairs with
+    [`Authenticator.run`][terok_executor.Authenticator.run]'s
+    ``credential_set`` — if the auth flow stored a token under set
+    ``foo``, the runtime must read from set ``foo`` too or the container
+    will see empty env.  Default ``"default"`` matches the shared
+    host-wide bucket every standalone caller uses; terok overrides for
+    per-project credentials."""
+
     vault_transport: Literal["direct", "socket"] = "direct"
     """Vault transport mode: ``"direct"`` (HTTP base URL) or ``"socket"``
     (Unix socket path via [`socket_env`][terok_executor.roster.VaultRoute.socket_env])."""
@@ -315,6 +324,7 @@ def assemble_container_env(
                 spec.task_id,
                 vault_transport=spec.vault_transport,
                 vault_required=spec.vault_required,
+                credential_set=spec.credential_set,
             )
         )
 
@@ -430,6 +440,7 @@ def _inject_vault_tokens(
     *,
     vault_transport: Literal["direct", "socket"] = "direct",
     vault_required: bool = False,
+    credential_set: str = "default",
 ) -> dict[str, str]:
     """Inject vault phantom tokens if the vault is running.
 
@@ -445,6 +456,10 @@ def _inject_vault_tokens(
     When *vault_required* is ``False`` (standalone default), soft-fails to
     empty dict.  When ``True`` (terok project mode), raises ``SystemExit``
     if the vault is unreachable.
+
+    *credential_set* selects which vault DB namespace to query — the auth
+    flow stores credentials keyed by ``(credential_set, provider)``, and
+    the runtime must use the same value to look them back up.
     """
     from terok_executor.integrations.sandbox import SandboxConfig, VaultManager
 
@@ -475,7 +490,6 @@ def _inject_vault_tokens(
         return {}
 
     try:
-        credential_set = "default"
         stored = set(db.list_credentials(credential_set))
         routed = stored & vault_routes.keys()
 

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -161,6 +161,7 @@ class Authenticator:
         image: str | Callable[[], str] | None = None,
         expose_token: bool = False,
         oauth_enabled: bool = True,
+        credential_set: str = "default",
     ) -> None:
         """Run the auth flow for ``self.provider``; see module-level docs.
 
@@ -175,6 +176,7 @@ class Authenticator:
             image=image,
             expose_token=expose_token,
             oauth_enabled=oauth_enabled,
+            credential_set=credential_set,
         )
 
     def prepare_oauth(
@@ -221,6 +223,7 @@ def authenticate(
     image: str | Callable[[], str] | None = None,
     expose_token: bool = False,
     oauth_enabled: bool = True,
+    credential_set: str = "default",
 ) -> None:
     """Run the auth flow for *provider*, optionally scoped to a project.
 
@@ -259,6 +262,13 @@ def authenticate(
             (e.g. ``agent.codex.allow_oauth=true`` plus ``experimental:
             true``).  When the provider declares only OAuth and the
             gate is closed, raises ``SystemExit`` with a clear hint.
+        credential_set: Storage namespace in the vault DB.  Defaults to
+            ``"default"`` — the shared host-wide bucket every standalone
+            and pre-existing terok caller uses.  Per-project callers
+            pass a project-specific value (e.g. ``project.id``) to
+            keep each project's tokens isolated.  The DB schema keys on
+            ``(credential_set, provider)``, so two projects can hold
+            independent logins for the same provider side-by-side.
 
     Raises ``SystemExit`` if the provider name is unknown or no usable
     auth mode remains after gating.
@@ -283,7 +293,7 @@ def authenticate(
         choice = input("Choose [1/2]: ").strip()
         if choice == "2":
             key = _prompt_api_key(info)
-            store_api_key(provider, key)
+            store_api_key(provider, key, credential_set=credential_set)
             return
         _run_auth_container(
             project_id,
@@ -291,6 +301,7 @@ def authenticate(
             mounts_dir=mounts_dir,
             image=_resolve_image(image, provider),
             expose_token=expose_token,
+            credential_set=credential_set,
         )
 
     elif has_api_key:
@@ -298,7 +309,7 @@ def authenticate(
         # Reaches here either because the provider declares only api_key,
         # or because the OAuth gate is closed.
         key = _prompt_api_key(info)
-        store_api_key(provider, key)
+        store_api_key(provider, key, credential_set=credential_set)
 
     elif has_oauth:
         # OAuth only — image is required.
@@ -308,6 +319,7 @@ def authenticate(
             mounts_dir=mounts_dir,
             image=_resolve_image(image, provider),
             expose_token=expose_token,
+            credential_set=credential_set,
         )
 
     else:

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -23,6 +23,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 
 
 @dataclass(frozen=True)
@@ -51,6 +52,20 @@ class Preflight:
     family: str | None = None
     interactive: bool = True
     assume_yes: bool = field(default=False)
+    credential_set: str = "default"
+    """Vault DB namespace to check for stored credentials.  Pairs with
+    [`Authenticator.run`][terok_executor.Authenticator.run]'s
+    ``credential_set`` — a project running with per-project credentials
+    passes its own value so the preflight verdict reflects what the
+    runtime will actually load, not the shared host-wide bucket."""
+
+    mounts_dir: Path | None = None
+    """Override for the agent-config mount tree.  ``None`` means use the
+    global [`paths.mounts_dir`][terok_executor.paths.mounts_dir].  Callers
+    that pair a non-``"default"`` ``credential_set`` with a per-project
+    mount tree (terok in scope=project mode) must override this too —
+    otherwise the captured OAuth credential's post-capture writer drops
+    the phantom marker into the wrong tree and the runtime never sees it."""
 
     # ── Orchestrator ───────────────────────────────────────────────
 
@@ -162,7 +177,11 @@ class Preflight:
         if not r.ok and self.interactive:
             print(f"  {r.name}... {r.message}")
             if self._confirm(f"Authenticate {self.provider} now?") and _fix_credentials(
-                self.provider, base_image=self.base_image, family=self.family
+                self.provider,
+                base_image=self.base_image,
+                family=self.family,
+                credential_set=self.credential_set,
+                mounts_dir=self.mounts_dir,
             ):
                 r = self.check_credentials()
         _print_step(r)
@@ -296,7 +315,7 @@ class Preflight:
                 f"{self.provider} credentials", False, "credential database unavailable"
             )
         try:
-            cred = db.load_credential("default", self.provider)
+            cred = db.load_credential(self.credential_set, self.provider)
         finally:
             db.close()
         if cred:
@@ -402,25 +421,37 @@ def _fix_ssh_key(scope: str = "standalone") -> bool:
     return True
 
 
-def _fix_credentials(provider: str, *, base_image: str, family: str | None = None) -> bool:
+def _fix_credentials(
+    provider: str,
+    *,
+    base_image: str,
+    family: str | None = None,
+    credential_set: str = "default",
+    mounts_dir: Path | None = None,
+) -> bool:
     """Run the interactive authentication flow for *provider*.
 
     *family* threads through to the lazy image resolver so the auth-time
     build matches the family the rest of preflight builds against (an
-    unknown base requires the explicit override).
+    unknown base requires the explicit override).  *credential_set*
+    selects the vault DB namespace the captured token is stored under;
+    *mounts_dir* must override the host-wide default whenever
+    *credential_set* is non-default, otherwise the OAuth post-capture
+    writer drops phantom markers into the wrong tree.
     """
     from terok_executor.container.build import ImageBuilder
     from terok_executor.credentials.auth import Authenticator
     from terok_executor.credentials.vault_config import write_vault_config
-    from terok_executor.paths import mounts_dir
+    from terok_executor.paths import mounts_dir as _default_mounts_dir
 
     # Lazy image resolution — picking API key from the OAuth-or-API-key prompt
     # short-circuits before we ever invoke ensure_default_l1.
     try:
         Authenticator(provider).run(
             None,
-            mounts_dir=mounts_dir(),
+            mounts_dir=mounts_dir if mounts_dir is not None else _default_mounts_dir(),
             image=lambda: ImageBuilder(base_image, family=family).ensure_default_l1(),
+            credential_set=credential_set,
         )
     except SystemExit:
         return False

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -821,7 +821,7 @@ class TestAuthenticateImageLaziness:
             authenticate(None, "claude", mounts_dir=tmp_path, image=resolver)
 
         resolver.assert_not_called()
-        mock_store.assert_called_once_with("claude", "sk-ant-test")
+        mock_store.assert_called_once_with("claude", "sk-ant-test", credential_set="default")
 
     def test_oauth_choice_resolves_image(self, tmp_path: Path) -> None:
         """User picks ``1`` (OAuth) → resolver is called exactly once."""
@@ -1016,7 +1016,7 @@ class TestAuthenticateOauthGate:
                 oauth_enabled=False,
             )
 
-        mock_store.assert_called_once_with("claude", "sk-ant-test")
+        mock_store.assert_called_once_with("claude", "sk-ant-test", credential_set="default")
         mock_run.assert_not_called()
 
     def test_oauth_enabled_default_keeps_dual_prompt(self, tmp_path: Path) -> None:
@@ -1187,3 +1187,162 @@ class TestPrepareOauthSession:
         ):
             with pytest.raises(SystemExit, match="does not support OAuth"):
                 Authenticator("blablador").prepare_oauth(None, mounts_dir=tmp_path, image="img")
+
+
+class TestAuthenticateCredentialSet:
+    """``credential_set`` must flow from ``authenticate`` to every leaf storage call.
+
+    Both the API-key fast path and the OAuth container path need it, in both
+    the dual-prompt mode and the single-mode shortcuts — otherwise opting
+    in to per-project credentials would silently write to the shared
+    ``"default"`` set and the runtime would read back nothing.
+    """
+
+    def test_dual_mode_api_key_choice_threads_set(self, tmp_path: Path) -> None:
+        """Dual-prompt + ``2`` (API key) → ``store_api_key`` sees the set."""
+        from unittest.mock import patch
+
+        from terok_executor.credentials.auth import AuthProvider, authenticate
+
+        provider = AuthProvider(
+            name="claude",
+            label="Claude",
+            host_dir_name="_claude-config",
+            container_mount="/home/dev/.claude",
+            command=["claude"],
+            banner_hint="",
+            modes=("oauth", "api_key"),
+            api_key_hint="hint",
+        )
+        with (
+            patch.dict(
+                "terok_executor.credentials.auth.AUTH_PROVIDERS",
+                {"claude": provider},
+                clear=True,
+            ),
+            patch("builtins.input", return_value="2"),
+            patch(
+                "terok_executor.credentials.auth._prompt_api_key",
+                return_value="sk-ant",
+            ),
+            patch("terok_executor.credentials.auth.store_api_key") as mock_store,
+        ):
+            authenticate(None, "claude", mounts_dir=tmp_path, credential_set="my-proj")
+        mock_store.assert_called_once_with("claude", "sk-ant", credential_set="my-proj")
+
+    def test_dual_mode_oauth_choice_threads_set(self, tmp_path: Path) -> None:
+        """Dual-prompt + ``1`` (OAuth) → ``_run_auth_container`` sees the set."""
+        from unittest.mock import patch
+
+        from terok_executor.credentials.auth import AuthProvider, authenticate
+
+        provider = AuthProvider(
+            name="claude",
+            label="Claude",
+            host_dir_name="_claude-config",
+            container_mount="/home/dev/.claude",
+            command=["claude"],
+            banner_hint="",
+            modes=("oauth", "api_key"),
+        )
+        with (
+            patch.dict(
+                "terok_executor.credentials.auth.AUTH_PROVIDERS",
+                {"claude": provider},
+                clear=True,
+            ),
+            patch("builtins.input", return_value="1"),
+            patch("terok_executor.credentials.auth._run_auth_container") as mock_run,
+        ):
+            authenticate(
+                None, "claude", mounts_dir=tmp_path, image="img:tag", credential_set="my-proj"
+            )
+        assert mock_run.call_args.kwargs["credential_set"] == "my-proj"
+
+    def test_api_key_only_threads_set(self, tmp_path: Path) -> None:
+        """API-key-only provider → ``store_api_key`` sees the set, no prompt."""
+        from unittest.mock import patch
+
+        from terok_executor.credentials.auth import AuthProvider, authenticate
+
+        provider = AuthProvider(
+            name="vibe",
+            label="Vibe",
+            host_dir_name="_vibe-config",
+            container_mount="/home/dev/.vibe",
+            command=["vibe"],
+            banner_hint="",
+            modes=("api_key",),
+        )
+        with (
+            patch.dict(
+                "terok_executor.credentials.auth.AUTH_PROVIDERS",
+                {"vibe": provider},
+                clear=True,
+            ),
+            patch(
+                "terok_executor.credentials.auth._prompt_api_key",
+                return_value="sk-vibe",
+            ),
+            patch("terok_executor.credentials.auth.store_api_key") as mock_store,
+        ):
+            authenticate(None, "vibe", mounts_dir=tmp_path, credential_set="my-proj")
+        mock_store.assert_called_once_with("vibe", "sk-vibe", credential_set="my-proj")
+
+    def test_oauth_only_threads_set(self, tmp_path: Path) -> None:
+        """OAuth-only provider → ``_run_auth_container`` sees the set."""
+        from unittest.mock import patch
+
+        from terok_executor.credentials.auth import AuthProvider, authenticate
+
+        provider = AuthProvider(
+            name="codex",
+            label="Codex",
+            host_dir_name="_codex-config",
+            container_mount="/home/dev/.codex",
+            command=["setup-codex-auth.sh"],
+            banner_hint="",
+            modes=("oauth",),
+        )
+        with (
+            patch.dict(
+                "terok_executor.credentials.auth.AUTH_PROVIDERS",
+                {"codex": provider},
+                clear=True,
+            ),
+            patch("terok_executor.credentials.auth._run_auth_container") as mock_run,
+        ):
+            authenticate(
+                None, "codex", mounts_dir=tmp_path, image="img:tag", credential_set="my-proj"
+            )
+        assert mock_run.call_args.kwargs["credential_set"] == "my-proj"
+
+    def test_default_keeps_backcompat(self, tmp_path: Path) -> None:
+        """Callers that don't pass ``credential_set`` still hit the ``"default"`` bucket."""
+        from unittest.mock import patch
+
+        from terok_executor.credentials.auth import AuthProvider, authenticate
+
+        provider = AuthProvider(
+            name="vibe",
+            label="Vibe",
+            host_dir_name="_vibe-config",
+            container_mount="/home/dev/.vibe",
+            command=["vibe"],
+            banner_hint="",
+            modes=("api_key",),
+        )
+        with (
+            patch.dict(
+                "terok_executor.credentials.auth.AUTH_PROVIDERS",
+                {"vibe": provider},
+                clear=True,
+            ),
+            patch(
+                "terok_executor.credentials.auth._prompt_api_key",
+                return_value="sk",
+            ),
+            patch("terok_executor.credentials.auth.store_api_key") as mock_store,
+        ):
+            authenticate(None, "vibe", mounts_dir=tmp_path)
+        mock_store.assert_called_once_with("vibe", "sk", credential_set="default")

--- a/tests/unit/test_authenticator.py
+++ b/tests/unit/test_authenticator.py
@@ -26,6 +26,7 @@ def test_run_delegates_with_bound_provider() -> None:
             image="some:tag",
             expose_token=True,
             oauth_enabled=False,
+            credential_set="proj-123",
         )
     auth.assert_called_once_with(
         "proj-123",
@@ -34,6 +35,7 @@ def test_run_delegates_with_bound_provider() -> None:
         image="some:tag",
         expose_token=True,
         oauth_enabled=False,
+        credential_set="proj-123",
     )
 
 
@@ -48,6 +50,7 @@ def test_run_defaults_match_underlying_fn() -> None:
         image=None,
         expose_token=False,
         oauth_enabled=True,
+        credential_set="default",
     )
 
 

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -27,7 +27,13 @@ def _find_vol(volumes: tuple[VolumeSpec, ...], container_path: str) -> VolumeSpe
     return next((v for v in volumes if container_path in v.container_path), None)
 
 
-def _make_vault_db(tmp_path: Path, cred_name: str = "claude", cred_data: dict | None = None):
+def _make_vault_db(
+    tmp_path: Path,
+    cred_name: str = "claude",
+    cred_data: dict | None = None,
+    *,
+    credential_set: str = "default",
+):
     """Return a ``SandboxConfig`` with one credential pre-stored in its ``CredentialDB``.
 
     The DB is created, populated, and closed internally.
@@ -38,7 +44,7 @@ def _make_vault_db(tmp_path: Path, cred_name: str = "claude", cred_data: dict | 
     cfg.db_path.parent.mkdir(parents=True, exist_ok=True)
     db = CredentialDB(cfg.db_path, passphrase=TEST_VAULT_PASSPHRASE)
     db.store_credential(
-        "default",
+        credential_set,
         cred_name,
         {"type": "api_key", "key": "sk-test"} if cred_data is None else cred_data,
     )
@@ -730,6 +736,36 @@ class TestVaultTokenInjection:
 
         assert "TEROK_SSH_SIGNER_TOKEN" not in result.env
         assert "TEROK_SSH_SIGNER_PORT" not in result.env
+
+    def test_vault_credential_set_isolates_lookups(self, workspace, envs_dir, roster, tmp_path):
+        """``credential_set`` selects which vault DB namespace gets read.
+
+        A credential stored under set ``other`` must be invisible when the
+        spec asks for the default set, and vice versa — otherwise per-project
+        opt-in would silently leak shared tokens into project-scoped tasks.
+        """
+        cfg = _make_vault_db(tmp_path, credential_set="my-proj")
+        # spec without credential_set override → reads from "default" → no creds visible
+        default_spec = _spec(workspace, envs_dir, credential_scope="my-proj")
+        # spec with matching credential_set → reads from "my-proj" → token issued
+        scoped_spec = _spec(
+            workspace, envs_dir, credential_scope="my-proj", credential_set="my-proj"
+        )
+        with (
+            patch(
+                "terok_executor.integrations.sandbox.VaultManager.is_socket_active",
+                return_value=True,
+            ),
+            patch("terok_executor.integrations.sandbox.SandboxConfig", return_value=cfg),
+        ):
+            default_result = assemble_container_env(
+                default_spec, roster, caller_manages_vault=False
+            )
+            scoped_result = assemble_container_env(scoped_spec, roster, caller_manages_vault=False)
+
+        assert "ANTHROPIC_API_KEY" not in default_result.env
+        assert "ANTHROPIC_API_KEY" in scoped_result.env
+        assert scoped_result.env["ANTHROPIC_API_KEY"].startswith("terok-p-")
 
     def test_vault_ssh_only_no_provider_creds(self, workspace, envs_dir, roster, tmp_path):
         """SSH signer token injected even when no provider credentials are stored."""

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -203,6 +203,69 @@ def test_credentials_db_unavailable(_cls: MagicMock) -> None:
     assert "unavailable" in r.message
 
 
+@patch("terok_executor.integrations.sandbox.SandboxConfig.open_credential_db")
+def test_credentials_default_set(mock_db_cls: MagicMock) -> None:
+    """No ``credential_set`` override → DB is queried with ``"default"``."""
+    db = mock_db_cls.return_value
+    db.load_credential.return_value = {"type": "api_key"}
+    _pf().check_credentials()
+    db.load_credential.assert_called_once_with("default", "claude")
+
+
+@patch("terok_executor.integrations.sandbox.SandboxConfig.open_credential_db")
+def test_credentials_custom_set(mock_db_cls: MagicMock) -> None:
+    """``credential_set=<id>`` → DB is queried with that set, not ``"default"``."""
+    db = mock_db_cls.return_value
+    db.load_credential.return_value = {"type": "api_key"}
+    _pf(credential_set="my-proj").check_credentials()
+    db.load_credential.assert_called_once_with("my-proj", "claude")
+
+
+def test_fix_credentials_threads_mounts_dir_to_authenticator() -> None:
+    """When ``mounts_dir`` is supplied, ``_fix_credentials`` routes it to ``Authenticator``.
+
+    Pairs with the new ``credential_set`` parameter — both must be honoured
+    so the captured token's vault row and the post-capture phantom marker
+    land in the same per-project tree.
+    """
+    from pathlib import Path
+
+    from terok_executor.preflight import _fix_credentials
+
+    with (
+        patch("terok_executor.credentials.auth.Authenticator") as auth_cls,
+        patch("terok_executor.credentials.vault_config.write_vault_config"),
+    ):
+        ok = _fix_credentials(
+            "claude",
+            base_image="ubuntu:24.04",
+            credential_set="my-proj",
+            mounts_dir=Path("/proj/root/mounts"),
+        )
+    assert ok is True
+    auth_cls.return_value.run.assert_called_once()
+    kwargs = auth_cls.return_value.run.call_args.kwargs
+    assert kwargs["mounts_dir"] == Path("/proj/root/mounts")
+    assert kwargs["credential_set"] == "my-proj"
+
+
+def test_fix_credentials_default_mounts_dir_falls_back_to_global() -> None:
+    """No ``mounts_dir`` override → ``Authenticator`` sees the host-wide default."""
+    from pathlib import Path
+
+    from terok_executor.preflight import _fix_credentials
+
+    with (
+        patch("terok_executor.credentials.auth.Authenticator") as auth_cls,
+        patch("terok_executor.credentials.vault_config.write_vault_config"),
+        patch("terok_executor.paths.mounts_dir", return_value=Path("/global/mounts")),
+    ):
+        _fix_credentials("claude", base_image="ubuntu:24.04")
+    kwargs = auth_cls.return_value.run.call_args.kwargs
+    assert kwargs["mounts_dir"] == Path("/global/mounts")
+    assert kwargs["credential_set"] == "default"
+
+
 # ── check_ssh_key ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a `credential_set` parameter to `authenticate()`, `ContainerEnvSpec`, and `Preflight`. Default `"default"` keeps every existing caller on the shared host-wide bucket; per-project callers can now pass a project-specific value (e.g. `project.id`) so the vault DB rows, runtime token lookups, and preflight verdicts agree on a single namespace.

No behavior change for standalone or for terok callers that don't opt in. The DB schema already keyed on `(credential_set, provider)` — this PR just routes the parameter end-to-end instead of hardcoding `"default"` at the leaves.

Threaded through:
- `authenticate()` → `_run_auth_container` → `_capture_credentials` → `db.store_credential`
- `authenticate()` → API-key fast path → `store_api_key` → `db.store_credential`
- `ContainerEnvSpec.credential_set` → `_inject_vault_tokens` → `db.list_credentials` / `db.load_credential` / `db.create_token`
- `Preflight.credential_set` → `check_credentials` → `db.load_credential`
- `Preflight._offer_credentials` → `_fix_credentials` → `authenticate`

## Test plan

- [x] New tests for `authenticate(credential_set=...)` covering all four mode paths (dual + api-key picked, dual + oauth picked, api-key-only, oauth-only), plus a back-compat test for omitting the parameter.
- [x] New test for `_inject_vault_tokens` covering the read isolation between `"default"` and a custom set.
- [x] New tests for `Preflight(credential_set=...)` covering default and custom set in `check_credentials`.
- [x] `make check` green (958 tests, lint, tach, docstrings, vulture, REUSE, bandit, coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for credential namespaces. Users can now isolate credentials by specifying a `credential_set` parameter, enabling secure separation of tokens by namespace and provider.

* **Tests**
  * Added comprehensive test coverage for credential set isolation and propagation across authentication flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->