### PR TITLE
chore: add ImageBuilder + Authenticator; fold image-config onto schema (W5.A)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3388,13 +3388,14 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.14a6"
+version = "0.6.14a7"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_clearance-0.6.14a7-py3-none-any.whl", hash = "sha256:a4ae1867ae03b07f7bde36fd789e3bfd5c1b2ca1194bbb8c35e57e0a5e0176e8"},
+]
 
 [package.dependencies]
 asyncvarlink = ">=0.3.1,<0.4.0"
@@ -3403,20 +3404,19 @@ pyyaml = ">=6.0"
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/terok-ai/terok-clearance.git"
-reference = "refs/pull/143/head"
-resolved_reference = "c42f01a27d82194a341ff0150195699424f8e896"
+type = "url"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/terok_clearance-0.6.14a7-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.124a19"
+version = "0.0.124a20"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.124a20-py3-none-any.whl", hash = "sha256:9984aae5d7bdf0bde5a7fac0557d877a3aaa48fe348a71ca191eff131426452e"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3429,25 +3429,24 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {git = "https://github.com/terok-ai/terok-clearance.git", rev = "refs/pull/143/head"}
-terok-shield = {git = "https://github.com/terok-ai/terok-shield.git", rev = "refs/pull/333/head"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/terok_clearance-0.6.14a7-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a9/terok_shield-0.6.42a9-py3-none-any.whl"}
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/terok-ai/terok-sandbox.git"
-reference = "refs/pull/356/head"
-resolved_reference = "8f4a0fcbbc10cee79d1646caaf1e14d940de82eb"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a20/terok_sandbox-0.0.124a20-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.42a8"
+version = "0.6.42a9"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_shield-0.6.42a9-py3-none-any.whl", hash = "sha256:0b70cd297908a96b2c5fcc483c81a31c3103f0c798a4e493454f20120476e48d"},
+]
 
 [package.dependencies]
 pydantic = ">=2.0"
@@ -3455,10 +3454,8 @@ PyYAML = ">=6.0"
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/terok-ai/terok-shield.git"
-reference = "refs/pull/333/head"
-resolved_reference = "727fbd707603692f9128558c4e3b6c622186d275"
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a9/terok_shield-0.6.42a9-py3-none-any.whl"
 
 [[package]]
 name = "terok-util"
@@ -3876,4 +3873,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "443c59f3b6936b8e9d1abc54d55089ad8a6f9c1ee1279d90d8590bbac37cfb99"
+content-hash = "3be8befe79b55db9a53e57f2756f7a8f5c7b37162465f300952a57b98d0d928f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3393,9 +3393,8 @@ description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_clearance-0.6.14a6-py3-none-any.whl", hash = "sha256:9f31a09b6c99723b52ea0f7a3e90ce1e0c8507d24f41273ebbb0f616b0809534"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 asyncvarlink = ">=0.3.1,<0.4.0"
@@ -3404,8 +3403,10 @@ pyyaml = ">=6.0"
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a6/terok_clearance-0.6.14a6-py3-none-any.whl"
+type = "git"
+url = "https://github.com/terok-ai/terok-clearance.git"
+reference = "refs/pull/143/head"
+resolved_reference = "c42f01a27d82194a341ff0150195699424f8e896"
 
 [[package]]
 name = "terok-sandbox"
@@ -3414,9 +3415,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.124a19-py3-none-any.whl", hash = "sha256:3c2e2a1acc92d05718f4d2575a00a1a763a3b11fb7f54bc06ecdb26d48383120"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3429,13 +3429,15 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a6/terok_clearance-0.6.14a6-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a8/terok_shield-0.6.42a8-py3-none-any.whl"}
+terok-clearance = {git = "https://github.com/terok-ai/terok-clearance.git", rev = "refs/pull/143/head"}
+terok-shield = {git = "https://github.com/terok-ai/terok-shield.git", rev = "refs/pull/333/head"}
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a19/terok_sandbox-0.0.124a19-py3-none-any.whl"
+type = "git"
+url = "https://github.com/terok-ai/terok-sandbox.git"
+reference = "refs/pull/356/head"
+resolved_reference = "8f4a0fcbbc10cee79d1646caaf1e14d940de82eb"
 
 [[package]]
 name = "terok-shield"
@@ -3444,9 +3446,8 @@ description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_shield-0.6.42a8-py3-none-any.whl", hash = "sha256:82488d094222383a96bfb837760643954492639685f7acb9aa800c47bc899487"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 pydantic = ">=2.0"
@@ -3454,8 +3455,10 @@ PyYAML = ">=6.0"
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a8/terok_shield-0.6.42a8-py3-none-any.whl"
+type = "git"
+url = "https://github.com/terok-ai/terok-shield.git"
+reference = "refs/pull/333/head"
+resolved_reference = "727fbd707603692f9128558c4e3b6c622186d275"
 
 [[package]]
 name = "terok-util"
@@ -3873,4 +3876,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "79f3f8000a55ebc825fd21a10ea234ac031a9883ad271eb4bf283d2d2c69c833"
+content-hash = "443c59f3b6936b8e9d1abc54d55089ad8a6f9c1ee1279d90d8590bbac37cfb99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a19/terok_sandbox-0.0.124a19-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/terok-ai/terok-sandbox.git@refs/pull/356/head",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl",
     "ruamel.yaml>=0.18",
     "Jinja2>=3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 dependencies = [
-    "terok-sandbox @ git+https://github.com/terok-ai/terok-sandbox.git@refs/pull/356/head",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a20/terok_sandbox-0.0.124a20-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl",
     "ruamel.yaml>=0.18",
     "Jinja2>=3.1",
@@ -54,7 +54,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.0.149a22"
+version = "0.0.149a23"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -46,14 +46,7 @@ from .commands import (
     validate_agent_selection,
 )
 
-# -- Global config writers (executor-owned slices of config.yml) ---------------
-from .config import (
-    get_global_image_agents,
-    get_global_image_base_image,
-    set_global_image_agents,
-)
-
-# -- Config schema (executor-owned slice of the shared config.yml) -----------
+# -- Config schema + read/write accessors for the executor-owned image: section --
 from .config_schema import ExecutorConfigView, RawImageSection
 
 # -- Container (build, env assembly, runner) -----------------------------------
@@ -61,20 +54,9 @@ from .container.build import (
     AGENTS_LABEL,
     DEFAULT_BASE_IMAGE,
     BuildError,
+    ImageBuilder,
     ImageSet,
-    build_base_images,
     build_project_image,
-    build_sidecar_image,
-    detect_family,
-    ensure_default_l1,
-    image_agents,
-    l0_image_tag,
-    l1_image_tag,
-    render_l0,
-    render_l1,
-    stage_scripts,
-    stage_tmux_config,
-    stage_toad_agents,
 )
 from .container.cache import seed_workspace_from_clone_cache
 from .container.env import ContainerEnvSpec, assemble_container_env
@@ -82,7 +64,7 @@ from .container.inject import inject_prompt
 from .container.runner import AgentRunner
 
 # -- Credentials (auth flows, extractors, vault commands) ----------------------
-from .credentials.auth import AUTH_PROVIDERS, authenticate
+from .credentials.auth import AUTH_PROVIDERS, Authenticator
 from .credentials.vault_commands import VAULT_COMMANDS, scan_leaked_credentials
 
 # -- Doctor + paths ------------------------------------------------------------
@@ -162,7 +144,7 @@ __all__ = [
     "prepare_agent_config_dir",
     # Auth
     "AUTH_PROVIDERS",
-    "authenticate",
+    "Authenticator",
     # Instructions
     "bundled_default_instructions",
     "resolve_instructions",
@@ -172,29 +154,14 @@ __all__ = [
     # Config schema (executor-owned slice of the shared config.yml)
     "ExecutorConfigView",
     "RawImageSection",
-    # Global config writers
-    "get_global_image_agents",
-    "get_global_image_base_image",
-    "set_global_image_agents",
     # Build: image construction + resource staging
     "AGENTS_LABEL",
     "DEFAULT_BASE_IMAGE",
     "BuildError",
+    "ImageBuilder",
     "ImageSet",
-    "build_base_images",
     "build_project_image",
-    "build_sidecar_image",
-    "detect_family",
-    "ensure_default_l1",
-    "image_agents",
-    "l0_image_tag",
-    "l1_image_tag",
-    "render_l0",
-    "render_l1",
-    "stage_scripts",
-    "stage_toad_agents",
-    "stage_tmux_config",
-    # Vault routes + scan
+    # Vault routes + roster bootstrap
     "ensure_vault_routes",
     "scan_leaked_credentials",
     # Roster

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -340,7 +340,7 @@ def _handle_auth(
     base_image: str | None = None,
 ) -> None:
     """Run auth flow for an agent."""
-    from .credentials.auth import AUTH_PROVIDERS, authenticate, store_api_key
+    from .credentials.auth import AUTH_PROVIDERS, Authenticator, store_api_key
 
     if api_key is not None:
         if not api_key.strip():
@@ -350,18 +350,17 @@ def _handle_auth(
             raise SystemExit(f"Unknown provider: {agent}. Available: {available}")
         store_api_key(agent, api_key.strip())
     else:
-        from .config import get_global_image_base_image
-        from .container.build import ensure_default_l1
+        from .config_schema import ExecutorConfigView
+        from .container.build import ImageBuilder
         from .paths import mounts_dir
 
         # Lazy: if the user picks API key from the OAuth-or-API-key prompt,
         # ensure_default_l1 is never invoked and we don't pay for an L1 build.
-        base = base_image or get_global_image_base_image() or DEFAULT_BASE_IMAGE
-        authenticate(
+        base = base_image or ExecutorConfigView.image_base_image() or DEFAULT_BASE_IMAGE
+        Authenticator(agent).run(
             None,
-            agent,
             mounts_dir=mounts_dir(),
-            image=lambda: ensure_default_l1(base),
+            image=lambda: ImageBuilder(base).ensure_default_l1(),
         )
 
     # Write vault URLs to shared config files (e.g. Vibe config.toml, gh config.yml)
@@ -442,11 +441,11 @@ def validate_agent_selection(raw: str) -> None:
 
 def _handle_agents_set(*, selection: str | None = None) -> None:
     """Write the global ``image.agents`` default to ``config.yml``."""
-    from .config import set_global_image_agents
+    from .config_schema import ExecutorConfigView
 
     raw = selection if selection is not None else prompt_agents_selection()
     validate_agent_selection(raw)
-    path = set_global_image_agents(raw)
+    path = ExecutorConfigView.set_image_agents(raw)
     print(f"Wrote image.agents = {raw!r} to {path}")
 
 
@@ -460,15 +459,14 @@ def _handle_build(
     sidecar: bool = False,
 ) -> None:
     """Build L0+L1 container images (optionally include sidecar L1)."""
-    from .container.build import BuildError, build_base_images, build_sidecar_image
+    from .container.build import BuildError, ImageBuilder
     from .roster.loader import parse_agent_selection
 
     selection = parse_agent_selection(agents)
 
+    builder = ImageBuilder(base, family=family)
     try:
-        images = build_base_images(
-            base, family=family, agents=selection, rebuild=rebuild, full_rebuild=full_rebuild
-        )
+        images = builder.build_base(agents=selection, rebuild=rebuild, full_rebuild=full_rebuild)
     except (BuildError, ValueError) as e:
         # ValueError is raised by resolve_selection() for unknown agent names
         # — surface it as a clean CLI message rather than a traceback.
@@ -478,9 +476,7 @@ def _handle_build(
 
     if sidecar:
         try:
-            tag = build_sidecar_image(
-                base, family=family, rebuild=rebuild, full_rebuild=full_rebuild
-            )
+            tag = builder.build_sidecar(rebuild=rebuild, full_rebuild=full_rebuild)
         except BuildError as e:
             raise SystemExit(str(e)) from e
         print(f"L1 (sidecar): {tag}")
@@ -618,7 +614,7 @@ def _handle_uninstall(
 
 def _build_images_with_banner(base: str, family: str | None) -> None:
     """Invoke the image factory with a friendly first-run wrapper."""
-    from .container.build import BuildError, build_base_images
+    from .container.build import BuildError, ImageBuilder
 
     print()
     print("─ Building agent images ──────────────────────────────────────")
@@ -626,7 +622,7 @@ def _build_images_with_banner(base: str, family: str | None) -> None:
     print("Subsequent runs reuse the cached layers and start instantly.")
     print("──────────────────────────────────────────────────────────────")
     try:
-        images = build_base_images(base, family=family)
+        images = ImageBuilder(base, family=family).build_base()
     except BuildError as exc:
         raise SystemExit(f"Build failed: {exc}") from exc
     print("──────────────────────────────────────────────────────────────")
@@ -637,11 +633,18 @@ def _build_images_with_banner(base: str, family: str | None) -> None:
 
 def _remove_images(base: str) -> None:
     """Drop L0+L1 images for *base* from the local store (idempotent)."""
-    from .container.build import l0_image_tag, l1_image_tag
+    from .container.build import ImageBuilder
 
     try:
         subprocess.run(
-            ["podman", "image", "rm", "--force", l1_image_tag(base), l0_image_tag(base)],
+            [
+                "podman",
+                "image",
+                "rm",
+                "--force",
+                ImageBuilder(base).l1_tag(),
+                ImageBuilder(base).l0_tag,
+            ],
             capture_output=True,
             timeout=30,
             check=False,

--- a/src/terok_executor/config.py
+++ b/src/terok_executor/config.py
@@ -1,15 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Reads and writes the executor's slice of the global ``config.yml`` (``image:``).
+"""Writable-path resolution for the executor's slice of the global ``config.yml``.
 
-The ``image:`` section is the executor's schema slice — ``base_image``
-seeds every L0/L1 build's FROM line, ``agents`` picks which roster
-entries are baked in.  Readers return the merged effective value;
-``None`` distinguishes "operator hasn't chosen yet" from any explicit
-value.  The writer goes through
-[`yaml_update_section`][terok_sandbox.yaml_update_section] so the
-on-disk replace is atomic and the file mode stays 0o600.
+The read/write accessors for the ``image:`` section live on
+[`ExecutorConfigView`][terok_executor.config_schema.ExecutorConfigView]
+— this module holds only the path-resolution helper they call when
+they need to write.
 """
 
 from __future__ import annotations
@@ -17,47 +14,9 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from terok_util import namespace_config_dir, read_config_section
+from terok_util import namespace_config_dir
 
-from terok_executor.integrations.sandbox import yaml_update_section
-
-__all__ = [
-    "get_global_image_agents",
-    "get_global_image_base_image",
-    "set_global_image_agents",
-    "writable_config_path",
-]
-
-
-def get_global_image_agents() -> str | None:
-    """Return the effective ``image.agents``, or ``None`` when unset.
-
-    ``None`` distinguishes "field absent" from ``"all"`` (the explicit
-    "every roster entry" selector).
-    """
-    return read_config_section("image").get("agents") or None
-
-
-def get_global_image_base_image() -> str | None:
-    """Return the explicit ``image.base_image``, or ``None`` when unset.
-
-    Callers apply the schema fallback themselves
-    ([`DEFAULT_BASE_IMAGE`][terok_executor.DEFAULT_BASE_IMAGE]) — keeping
-    that constant out of this module preserves the foundation-layer
-    boundary (config sits below container/build).
-    """
-    return read_config_section("image").get("base_image") or None
-
-
-def set_global_image_agents(selection: str) -> Path:
-    """Write *selection* into ``image.agents`` and return the file path.
-
-    Caller validates *selection* up-front (typically via
-    [`validate_agent_selection`][terok_executor.validate_agent_selection]).
-    """
-    path = writable_config_path()
-    yaml_update_section(path, "image", {"agents": selection})
-    return path
+__all__ = ["writable_config_path"]
 
 
 def writable_config_path() -> Path:

--- a/src/terok_executor/config_schema.py
+++ b/src/terok_executor/config_schema.py
@@ -21,6 +21,7 @@ ecosystem set.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -83,11 +84,56 @@ class ExecutorConfigView(SandboxConfigView):
     terok's ``RawGlobalConfig`` inherits from this class and flips
     back to ``extra="forbid"``: the topmost layer knows every section,
     so a typo at the top level is caught there.
+
+    The class also exposes classmethods for reading and writing the
+    ``image:`` section on disk: ``image_agents()``,
+    ``image_base_image()``, and ``set_image_agents(selection)``.  The
+    schema thus owns both the *shape* and the canonical *accessors*
+    for its owned section, rather than scattering one helper per
+    operation across a separate ``config`` module.
     """
 
     model_config = ConfigDict(extra="allow")
 
     image: RawImageSection = Field(default_factory=RawImageSection)
+
+    @staticmethod
+    def image_agents() -> str | None:
+        """Return the effective ``image.agents``, or ``None`` when unset.
+
+        ``None`` distinguishes "field absent" from ``"all"`` (the
+        explicit "every roster entry" selector).
+        """
+        from terok_util import read_config_section
+
+        return read_config_section("image").get("agents") or None
+
+    @staticmethod
+    def image_base_image() -> str | None:
+        """Return the explicit ``image.base_image``, or ``None`` when unset.
+
+        Callers apply the schema fallback themselves
+        ([`DEFAULT_BASE_IMAGE`][terok_executor.DEFAULT_BASE_IMAGE]) —
+        keeping that constant out of this module preserves the
+        foundation-layer boundary (schema sits below container/build).
+        """
+        from terok_util import read_config_section
+
+        return read_config_section("image").get("base_image") or None
+
+    @staticmethod
+    def set_image_agents(selection: str) -> Path:
+        """Write *selection* into ``image.agents`` and return the file path.
+
+        Caller validates *selection* up-front (typically via
+        [`validate_agent_selection`][terok_executor.validate_agent_selection]).
+        """
+        from terok_executor.config import writable_config_path
+        from terok_executor.integrations.sandbox import yaml_update_section
+
+        path = writable_config_path()
+        yaml_update_section(path, "image", {"agents": selection})
+        return path
 
 
 __all__ = [

--- a/src/terok_executor/config_schema.py
+++ b/src/terok_executor/config_schema.py
@@ -85,7 +85,7 @@ class ExecutorConfigView(SandboxConfigView):
     back to ``extra="forbid"``: the topmost layer knows every section,
     so a typo at the top level is caught there.
 
-    The class also exposes classmethods for reading and writing the
+    The class also exposes staticmethods for reading and writing the
     ``image:`` section on disk: ``image_agents()``,
     ``image_base_image()``, and ``set_image_agents(selection)``.  The
     schema thus owns both the *shape* and the canonical *accessors*
@@ -127,12 +127,20 @@ class ExecutorConfigView(SandboxConfigView):
 
         Caller validates *selection* up-front (typically via
         [`validate_agent_selection`][terok_executor.validate_agent_selection]).
+
+        Invalidates terok-util's process-wide ``read_config_section``
+        cache before returning so the next ``image_agents()`` /
+        ``image_base_image()`` call observes the freshly-written value
+        rather than the in-memory snapshot taken before the write.
         """
+        from terok_util import paths as _util_paths
+
         from terok_executor.config import writable_config_path
         from terok_executor.integrations.sandbox import yaml_update_section
 
         path = writable_config_path()
         yaml_update_section(path, "image", {"agents": selection})
+        _util_paths._config_section_cache.clear()
         return path
 
 

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -166,7 +166,161 @@ class ImageSet:
     """L1 sidecar image tag, if built (e.g. ``terok-l1-sidecar:fedora-44``)."""
 
 
-# ── Public entry points ──
+# ── Public entry point ──
+
+
+@dataclass(frozen=True)
+class ImageBuilder:
+    """Build pipeline for terok agent container images.
+
+    Holds the ``(base_image, family)`` the L0/L1/L2 build stack is
+    anchored on.  Build operations are instance-bound; pure
+    family detection, image introspection, and resource staging stay
+    as static methods — they don't depend on the builder's state.
+
+    Two scopes of operations:
+
+    * **Instance methods** — apply ``self.base_image`` and ``self.family``
+      to a podman build (``build_base``, ``build_sidecar``,
+      ``ensure_default_l1``), tag computations (``l0_tag``,
+      ``l1_tag``, ``l1_sidecar_tag``), and Dockerfile rendering
+      (``render_l0``, ``render_l1``, ``render_l1_sidecar``).
+    * **Static methods** — pure helpers that operate on arbitrary
+      inputs: ``detect_family``, ``image_agents``, ``stage_scripts``,
+      ``stage_tmux_config``, ``stage_toad_agents``.
+    """
+
+    base_image: str = DEFAULT_BASE_IMAGE
+    """Base OS image the L0 layer FROMs (e.g. ``fedora:44``)."""
+
+    family: str | None = None
+    """Package family override (``"deb"`` / ``"rpm"``) — auto-detected when ``None``."""
+
+    # ── Build operations ───────────────────────────────
+
+    def build_base(
+        self,
+        *,
+        agents: str | tuple[str, ...] = "all",
+        rebuild: bool = False,
+        full_rebuild: bool = False,
+        build_dir: Path | None = None,
+        tag_as_default: bool = False,
+    ) -> ImageSet:
+        """Build L0 + L1 images for *agents*; returns the resulting tag pair.
+
+        See module-level ``build_base_images`` for the parameter contract.
+        """
+        return build_base_images(
+            self.base_image,
+            family=self.family,
+            agents=agents,
+            rebuild=rebuild,
+            full_rebuild=full_rebuild,
+            build_dir=build_dir,
+            tag_as_default=tag_as_default,
+        )
+
+    def build_sidecar(
+        self,
+        *,
+        tool_name: str = "coderabbit",
+        rebuild: bool = False,
+        full_rebuild: bool = False,
+        build_dir: Path | None = None,
+    ) -> str:
+        """Build the L1 sidecar image variant for *tool_name*; returns the tag."""
+        return build_sidecar_image(
+            self.base_image,
+            family=self.family,
+            tool_name=tool_name,
+            rebuild=rebuild,
+            full_rebuild=full_rebuild,
+            build_dir=build_dir,
+        )
+
+    def ensure_default_l1(self, agents: str | tuple[str, ...] = "all") -> str:
+        """Return the default-alias L1 tag, building the default L1 if absent."""
+        return ensure_default_l1(self.base_image, family=self.family, agents=agents)
+
+    # ── Tag computation (instance — anchored on self.base_image) ────
+
+    @property
+    def l0_tag(self) -> str:
+        """L0 image tag for ``self.base_image``."""
+        return l0_image_tag(self.base_image)
+
+    @property
+    def l1_sidecar_tag(self) -> str:
+        """L1 sidecar image tag for ``self.base_image``."""
+        return l1_sidecar_image_tag(self.base_image)
+
+    def l1_tag(self, agents: tuple[str, ...] | None = None) -> str:
+        """L1 image tag for *agents* under ``self.base_image`` (alias when ``None``)."""
+        return l1_image_tag(self.base_image, agents)
+
+    # ── Templates (instance — uses self.base_image + self.family) ───
+
+    def render_l0(self) -> str:
+        """Render the L0 Dockerfile for this base."""
+        return render_l0(self.base_image, family=self._family)
+
+    def render_l1(
+        self,
+        l0_tag: str,
+        *,
+        agents: tuple[str, ...] | str = "all",
+        cache_bust: str = "0",
+    ) -> str:
+        """Render the L1 CLI Dockerfile for *agents* on top of *l0_tag*."""
+        return render_l1(l0_tag, family=self._family, agents=agents, cache_bust=cache_bust)
+
+    def render_l1_sidecar(
+        self,
+        l0_tag: str,
+        *,
+        tool_name: str = "coderabbit",
+        cache_bust: str = "0",
+    ) -> str:
+        """Render the L1 sidecar Dockerfile for *tool_name* on top of *l0_tag*."""
+        return render_l1_sidecar(
+            l0_tag, family=self._family, tool_name=tool_name, cache_bust=cache_bust
+        )
+
+    @property
+    def _family(self) -> str:
+        """Resolved family — override when set, else detected from ``base_image``."""
+        return self.family or detect_family(self.base_image)
+
+    # ── Static utilities (no instance state) ────────────
+
+    @staticmethod
+    def detect_family(base_image: str, override: str | None = None) -> str:
+        """Resolve the package family (``"deb"`` / ``"rpm"``) for *base_image*."""
+        return detect_family(base_image, override)
+
+    @staticmethod
+    def image_agents(image: str) -> set[str]:
+        """Return roster agent names from an L1 image's ``ai.terok.agents`` label."""
+        return image_agents(image)
+
+    @staticmethod
+    def stage_scripts(dest: Path) -> None:
+        """Stage shell helper scripts (``hilfe``, ``terok-*``) into *dest*."""
+        stage_scripts(dest)
+
+    @staticmethod
+    def stage_tmux_config(dest: Path) -> None:
+        """Stage the tmux config into *dest*."""
+        stage_tmux_config(dest)
+
+    @staticmethod
+    def stage_toad_agents(dest: Path) -> None:
+        """Stage toad agent metadata into *dest*."""
+        stage_toad_agents(dest)
+
+
+# ── Underlying free functions (now private — call via ImageBuilder) ──
 
 
 def detect_family(base_image: str, override: str | None = None) -> str:

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 from terok_executor._util import detect_host_timezone
 from terok_executor.integrations.sandbox import SandboxConfig, Sharing, VolumeSpec
 
-from .build import BuildError, build_base_images
+from .build import BuildError, ImageBuilder
 
 if TYPE_CHECKING:
     import subprocess
@@ -792,14 +792,13 @@ class AgentRunner:
 
     def _ensure_images(self) -> str:
         """Ensure L0+L1 images exist, return L1 tag."""
-        images = build_base_images(self._base_image, family=self._family)
+        images = ImageBuilder(self._base_image, self._family).build_base()
         return images.l1
 
     def _ensure_sidecar_image(self, tool_name: str) -> str:
         """Ensure sidecar L1 exists for *tool_name*, return its tag."""
-        from .build import build_sidecar_image
 
-        return build_sidecar_image(self._base_image, family=self._family, tool_name=tool_name)
+        return ImageBuilder(self._base_image, self._family).build_sidecar(tool_name=tool_name)
 
     def _setup_gate(self, repo_url: str, task_id: str) -> str:
         """Mirror a repo via the sandbox gate and return the gate HTTP URL.

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -131,6 +131,52 @@ AUTH_PROVIDERS: dict[str, AuthProvider] = {}
 # ── Public API ──
 
 
+@dataclass(frozen=True)
+class Authenticator:
+    """Vendor-credential acquisition for a single agent.
+
+    Wraps the ``authenticate`` flow behind a stable class so callers
+    that orchestrate a multi-step setup (terok project init, the
+    standalone ``terok-executor auth`` command, the TUI auth flow)
+    talk to one named surface bound to ``self.provider``.
+
+    The discovery counterparts
+    ([`list_authenticated_agents`][terok_executor.list_authenticated_agents],
+    [`scan_leaked_credentials`][terok_executor.scan_leaked_credentials])
+    stay as module-level fns in their owning submodules — folding them
+    in here would create a tach cycle through ``terok_executor.acp``
+    and ``terok_executor.credentials.vault_commands``, which already
+    depend on this module transitively.
+    """
+
+    provider: str
+    """Auth provider name (e.g. ``"claude"``)."""
+
+    def run(
+        self,
+        project_id: str | None,
+        *,
+        mounts_dir: Path,
+        image: str | Callable[[], str] | None = None,
+        expose_token: bool = False,
+        oauth_enabled: bool = True,
+    ) -> None:
+        """Run the auth flow for ``self.provider``; see module-level docs.
+
+        Mirrors the parameters of the underlying ``authenticate`` free
+        function — instance-bound ``self.provider`` replaces the old
+        positional ``provider`` arg.
+        """
+        authenticate(
+            project_id,
+            self.provider,
+            mounts_dir=mounts_dir,
+            image=image,
+            expose_token=expose_token,
+            oauth_enabled=oauth_enabled,
+        )
+
+
 def authenticate(
     project_id: str | None,
     provider: str,

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -270,9 +270,9 @@ class Preflight:
 
     def check_images(self) -> CheckResult:
         """Check whether L0+L1 container images exist."""
-        from terok_executor.container.build import l1_image_tag
+        from terok_executor.container.build import ImageBuilder
 
-        tag = l1_image_tag(self.base_image)
+        tag = ImageBuilder(self.base_image).l1_tag()
         try:
             result = subprocess.run(
                 ["podman", "image", "exists", tag],
@@ -375,11 +375,11 @@ def _fix_sandbox_services() -> bool:
 
 def _fix_images(base_image: str, family: str | None = None) -> bool:
     """Build L0+L1 container images with a friendly first-run banner."""
-    from terok_executor.container.build import BuildError, build_base_images
+    from terok_executor.container.build import BuildError, ImageBuilder
 
     _print_first_build_preamble()
     try:
-        build_base_images(base_image, family=family)
+        ImageBuilder(base_image, family).build_base()
     except BuildError as exc:
         print(f"  Build failed: {exc}", file=sys.stderr)
         return False
@@ -404,19 +404,18 @@ def _fix_ssh_key(scope: str = "standalone") -> bool:
 
 def _fix_credentials(provider: str, *, base_image: str) -> bool:
     """Run the interactive authentication flow for *provider*."""
-    from terok_executor.container.build import ensure_default_l1
-    from terok_executor.credentials.auth import authenticate
+    from terok_executor.container.build import ImageBuilder
+    from terok_executor.credentials.auth import Authenticator
     from terok_executor.credentials.vault_config import write_vault_config
     from terok_executor.paths import mounts_dir
 
     # Lazy image resolution — picking API key from the OAuth-or-API-key prompt
     # short-circuits before we ever invoke ensure_default_l1.
     try:
-        authenticate(
+        Authenticator(provider).run(
             None,
-            provider,
             mounts_dir=mounts_dir(),
-            image=lambda: ensure_default_l1(base_image),
+            image=lambda: ImageBuilder(base_image).ensure_default_l1(),
         )
     except SystemExit:
         return False

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -162,7 +162,7 @@ class Preflight:
         if not r.ok and self.interactive:
             print(f"  {r.name}... {r.message}")
             if self._confirm(f"Authenticate {self.provider} now?") and _fix_credentials(
-                self.provider, base_image=self.base_image
+                self.provider, base_image=self.base_image, family=self.family
             ):
                 r = self.check_credentials()
         _print_step(r)
@@ -402,8 +402,13 @@ def _fix_ssh_key(scope: str = "standalone") -> bool:
     return True
 
 
-def _fix_credentials(provider: str, *, base_image: str) -> bool:
-    """Run the interactive authentication flow for *provider*."""
+def _fix_credentials(provider: str, *, base_image: str, family: str | None = None) -> bool:
+    """Run the interactive authentication flow for *provider*.
+
+    *family* threads through to the lazy image resolver so the auth-time
+    build matches the family the rest of preflight builds against (an
+    unknown base requires the explicit override).
+    """
     from terok_executor.container.build import ImageBuilder
     from terok_executor.credentials.auth import Authenticator
     from terok_executor.credentials.vault_config import write_vault_config
@@ -415,7 +420,7 @@ def _fix_credentials(provider: str, *, base_image: str) -> bool:
         Authenticator(provider).run(
             None,
             mounts_dir=mounts_dir(),
-            image=lambda: ImageBuilder(base_image).ensure_default_l1(),
+            image=lambda: ImageBuilder(base_image, family=family).ensure_default_l1(),
         )
     except SystemExit:
         return False

--- a/tach.toml
+++ b/tach.toml
@@ -53,11 +53,20 @@ depends_on = [
     "terok_executor.integrations.sandbox",
 ]
 
-# Global config.yml writers (executor-owned sections — currently image.agents).
-# Depends on terok_sandbox symbols via the integrations adapter.
+# Writable-path resolver for the executor-owned slice of config.yml.
+# The read/write accessors themselves live on ExecutorConfigView; this
+# module hosts only the path helper they call.
 [[modules]]
 path = "terok_executor.config"
+depends_on = []
+
+# Pydantic schema for the executor's slice of config.yml.  Owns both
+# the schema and the read/write accessors for the image: section,
+# which is why it imports the sandbox YAML writer + the path helper.
+[[modules]]
+path = "terok_executor.config_schema"
 depends_on = [
+    "terok_executor.config",
     "terok_executor.integrations.sandbox",
 ]
 
@@ -264,7 +273,7 @@ depends_on = [
 path = "terok_executor.commands"
 depends_on = [
     "terok_executor.acp",
-    "terok_executor.config",
+    "terok_executor.config_schema",
     "terok_executor.container.build",
     "terok_executor.container.runner",
     "terok_executor.credentials.auth",
@@ -309,7 +318,7 @@ depends_on = [
     "terok_executor._tree",
     "terok_executor.acp",
     "terok_executor.commands",
-    "terok_executor.config",
+    "terok_executor.config_schema",
     "terok_executor.container.build",
     "terok_executor.container.cache",
     "terok_executor.container.env",

--- a/tests/unit/test_authenticator.py
+++ b/tests/unit/test_authenticator.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Authenticator class API surface.
+
+The underlying ``authenticate`` free function has its own dedicated
+tests in ``test_auth_capture.py``; this file exercises the
+``Authenticator`` class that wraps it so the new bound-provider
+surface is the unit of test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+from terok_executor.credentials.auth import Authenticator
+
+
+def test_run_delegates_with_bound_provider() -> None:
+    """``Authenticator(provider).run(...)`` forwards to the module-level fn."""
+    with mock.patch("terok_executor.credentials.auth.authenticate") as auth:
+        Authenticator("claude").run(
+            "proj-123",
+            mounts_dir=Path("/m"),
+            image="some:tag",
+            expose_token=True,
+            oauth_enabled=False,
+        )
+    auth.assert_called_once_with(
+        "proj-123",
+        "claude",
+        mounts_dir=Path("/m"),
+        image="some:tag",
+        expose_token=True,
+        oauth_enabled=False,
+    )
+
+
+def test_run_defaults_match_underlying_fn() -> None:
+    """Default kwargs match the underlying ``authenticate`` defaults."""
+    with mock.patch("terok_executor.credentials.auth.authenticate") as auth:
+        Authenticator("codex").run(None, mounts_dir=Path("/m"))
+    auth.assert_called_once_with(
+        None,
+        "codex",
+        mounts_dir=Path("/m"),
+        image=None,
+        expose_token=False,
+        oauth_enabled=True,
+    )
+
+
+def test_provider_is_frozen() -> None:
+    """``Authenticator`` is a frozen dataclass — provider can't change after construction."""
+    import dataclasses
+
+    a = Authenticator("claude")
+    assert a.provider == "claude"
+    try:
+        a.provider = "codex"  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("expected FrozenInstanceError")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,11 +3,11 @@
 
 """Tests for the executor's global-config write helpers.
 
-[`set_global_image_agents`][terok_executor.set_global_image_agents] is
-the surface every "set the default agents" entry point routes through —
-``terok-executor agents set``, the terok wrapper's mirror, and the TUI
-modal.  Round-trip preservation and parent-dir auto-creation are the
-contracts the callers rely on.
+[`ExecutorConfigView.set_image_agents`][terok_executor.config_schema.ExecutorConfigView.set_image_agents]
+is the surface every "set the default agents" entry point routes through
+— ``terok-executor agents set``, the terok wrapper's mirror, and the
+TUI modal.  Round-trip preservation and parent-dir auto-creation are
+the contracts the callers rely on.
 """
 
 from __future__ import annotations
@@ -16,12 +16,8 @@ from pathlib import Path
 
 import pytest
 
-from terok_executor.config import (
-    get_global_image_agents,
-    get_global_image_base_image,
-    set_global_image_agents,
-    writable_config_path,
-)
+from terok_executor.config import writable_config_path
+from terok_executor.config_schema import ExecutorConfigView
 
 
 @pytest.fixture
@@ -59,13 +55,13 @@ class TestWritableConfigPath:
         assert writable_config_path() == namespace_config_dir() / "config.yml"
 
 
-class TestSetGlobalImageAgents:
+class TestSetImageAgents:
     """End-to-end write semantics: creates parent, preserves comments, round-trips."""
 
     def test_creates_file_when_missing(self, override_config: Path) -> None:
         """Missing target file is created, parent dirs included."""
         assert not override_config.exists()
-        path = set_global_image_agents("claude,vibe")
+        path = ExecutorConfigView.set_image_agents("claude,vibe")
         assert path == override_config
         assert override_config.read_text(encoding="utf-8").strip().startswith("image:")
 
@@ -73,7 +69,7 @@ class TestSetGlobalImageAgents:
         """Deeply-nested parent is created."""
         target = tmp_path / "deep" / "nested" / "config.yml"
         monkeypatch.setenv("TEROK_CONFIG_FILE", str(target))
-        set_global_image_agents("all")
+        ExecutorConfigView.set_image_agents("all")
         assert target.is_file()
 
     def test_updates_existing_image_section(self, override_config: Path) -> None:
@@ -81,7 +77,7 @@ class TestSetGlobalImageAgents:
         override_config.write_text(
             "image:\n  base_image: ubuntu:24.04\n  agents: claude\n", encoding="utf-8"
         )
-        set_global_image_agents("all,-vibe")
+        ExecutorConfigView.set_image_agents("all,-vibe")
         content = override_config.read_text(encoding="utf-8")
         assert "agents: all,-vibe" in content
         assert "base_image: ubuntu:24.04" in content
@@ -91,7 +87,7 @@ class TestSetGlobalImageAgents:
         override_config.write_text(
             "tui:\n  default_tmux: true\nimage:\n  agents: claude\n", encoding="utf-8"
         )
-        set_global_image_agents("vibe")
+        ExecutorConfigView.set_image_agents("vibe")
         content = override_config.read_text(encoding="utf-8")
         assert "default_tmux: true" in content
         assert "agents: vibe" in content
@@ -102,38 +98,38 @@ class TestSetGlobalImageAgents:
             "# Top comment\nimage:\n  # inline comment\n  agents: claude\n",
             encoding="utf-8",
         )
-        set_global_image_agents("vibe")
+        ExecutorConfigView.set_image_agents("vibe")
         content = override_config.read_text(encoding="utf-8")
         assert "# Top comment" in content
         assert "# inline comment" in content
         assert "agents: vibe" in content
 
 
-class TestGetGlobalImageAgents:
+class TestImageAgents:
     """The merged-stack reader resolves ``None`` for absent, value for present."""
 
     def test_returns_none_when_unset(self, override_config: Path) -> None:  # noqa: ARG002
         """No file → ``None``; distinguishes from explicit ``"all"``."""
-        assert get_global_image_agents() is None
+        assert ExecutorConfigView.image_agents() is None
 
     def test_round_trip_after_set(self, override_config: Path) -> None:  # noqa: ARG002
         """``set`` then ``get`` returns the value that was written."""
-        set_global_image_agents("claude,vibe")
+        ExecutorConfigView.set_image_agents("claude,vibe")
         # Reset cache so the freshly-written file is re-read.
         from terok_util import paths as util_paths
 
         util_paths._config_section_cache.clear()
-        assert get_global_image_agents() == "claude,vibe"
+        assert ExecutorConfigView.image_agents() == "claude,vibe"
 
 
-class TestGetGlobalImageBaseImage:
+class TestImageBaseImage:
     """The merged-stack reader resolves ``None`` for absent, value for present."""
 
     def test_returns_none_when_unset(self, override_config: Path) -> None:  # noqa: ARG002
         """No file → ``None``; callers apply the schema fallback themselves."""
-        assert get_global_image_base_image() is None
+        assert ExecutorConfigView.image_base_image() is None
 
     def test_returns_explicit_value(self, override_config: Path) -> None:
         """An explicit ``image.base_image`` is returned verbatim."""
         override_config.write_text("image:\n  base_image: ubuntu:24.04\n", encoding="utf-8")
-        assert get_global_image_base_image() == "ubuntu:24.04"
+        assert ExecutorConfigView.image_base_image() == "ubuntu:24.04"

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -24,7 +24,6 @@ from terok_executor.commands import (
 )
 from terok_executor.container.build import ImageSet
 
-
 # ── _handle_auth ────────────────────────────────────────────
 
 
@@ -124,5 +123,3 @@ def test_remove_images_uses_image_builder_tags() -> None:
     # L0 / L1 tags come from the ImageBuilder properties.
     assert "terok-l0:fedora-44" in argv
     assert "terok-l1-cli:fedora-44" in argv
-
-

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the CLI handler functions in ``commands.py``.
+
+Each handler is invoked with the deepest collaborator mocked at the
+ImageBuilder / Authenticator boundary so the test exercises the
+W5.A class-API call sites added in this PR without paying for a real
+podman / vault / OAuth stack.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from terok_executor.commands import (
+    _build_images_with_banner,
+    _handle_agents_set,
+    _handle_auth,
+    _handle_build,
+    _remove_images,
+)
+from terok_executor.container.build import ImageSet
+
+
+# ── _handle_auth ────────────────────────────────────────────
+
+
+def test_handle_auth_api_key_path_stores_directly() -> None:
+    """``_handle_auth(api_key=…)`` short-circuits to ``store_api_key`` without container."""
+    with (
+        mock.patch("terok_executor.credentials.auth.store_api_key") as store,
+        mock.patch("terok_executor.credentials.auth.AUTH_PROVIDERS", {"claude": object()}),
+    ):
+        _handle_auth(agent="claude", api_key="sk-test-key")
+    store.assert_called_once_with("claude", "sk-test-key")
+
+
+def test_handle_auth_oauth_path_routes_through_authenticator() -> None:
+    """``_handle_auth`` (no api_key) constructs an Authenticator and runs it."""
+    with (
+        mock.patch("terok_executor.credentials.auth.Authenticator") as cls,
+        mock.patch("terok_executor.credentials.vault_config.write_vault_config"),
+    ):
+        _handle_auth(agent="claude")
+    cls.assert_called_once_with("claude")
+    cls.return_value.run.assert_called_once()
+
+
+def test_handle_auth_empty_api_key_raises() -> None:
+    """Empty api_key surfaces as a clean SystemExit, not an obscure failure."""
+    with pytest.raises(SystemExit, match="cannot be empty"):
+        _handle_auth(agent="claude", api_key="   ")
+
+
+# ── _handle_build ───────────────────────────────────────────
+
+
+def test_handle_build_routes_through_image_builder() -> None:
+    """``_handle_build`` calls ``ImageBuilder(base, family).build_base()``."""
+    images = ImageSet(l0="l0:tag", l1="l1:tag")
+    with mock.patch("terok_executor.container.build.ImageBuilder") as cls:
+        cls.return_value.build_base.return_value = images
+        _handle_build(base="fedora:44", family="rpm", agents="claude", sidecar=False)
+    cls.assert_called_once_with("fedora:44", family="rpm")
+    cls.return_value.build_base.assert_called_once()
+
+
+def test_handle_build_sidecar_flag_builds_sidecar() -> None:
+    """``sidecar=True`` triggers ``build_sidecar`` after the L0/L1 build."""
+    images = ImageSet(l0="l0", l1="l1")
+    with mock.patch("terok_executor.container.build.ImageBuilder") as cls:
+        cls.return_value.build_base.return_value = images
+        cls.return_value.build_sidecar.return_value = "sidecar:tag"
+        _handle_build(base="fedora:44", family=None, agents="all", sidecar=True)
+    cls.return_value.build_sidecar.assert_called_once()
+
+
+# ── _handle_agents_set ──────────────────────────────────────
+
+
+def test_handle_agents_set_writes_through_config_view() -> None:
+    """``_handle_agents_set`` validates then writes via ExecutorConfigView."""
+    from pathlib import Path
+
+    with (
+        mock.patch("terok_executor.commands.validate_agent_selection", return_value=None),
+        mock.patch(
+            "terok_executor.config_schema.ExecutorConfigView.set_image_agents",
+            return_value=Path("/tmp/cfg.yml"),
+        ) as setter,
+    ):
+        _handle_agents_set(selection="claude,codex")
+    setter.assert_called_once_with("claude,codex")
+
+
+# ── _build_images_with_banner ───────────────────────────────
+
+
+def test_build_images_with_banner_routes_through_image_builder(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Friendly first-run wrapper calls ``ImageBuilder.build_base()``."""
+    with mock.patch("terok_executor.container.build.ImageBuilder") as cls:
+        cls.return_value.build_base.return_value = ImageSet(l0="L0", l1="L1")
+        _build_images_with_banner("fedora:44", None)
+    cls.assert_called_once_with("fedora:44", family=None)
+    out = capsys.readouterr().out
+    assert "Building agent images" in out
+
+
+# ── _remove_images ──────────────────────────────────────────
+
+
+def test_remove_images_uses_image_builder_tags() -> None:
+    """``_remove_images`` resolves L0 / L1 tags via ``ImageBuilder``."""
+    with mock.patch("subprocess.run") as run:
+        _remove_images("fedora:44")
+    run.assert_called_once()
+    argv = run.call_args.args[0]
+    assert argv[:4] == ["podman", "image", "rm", "--force"]
+    # L0 / L1 tags come from the ImageBuilder properties.
+    assert "terok-l0:fedora-44" in argv
+    assert "terok-l1-cli:fedora-44" in argv
+
+

--- a/tests/unit/test_image_builder.py
+++ b/tests/unit/test_image_builder.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ImageBuilder class API surface.
+
+The underlying free functions (``build_base_images``, ``render_l0``,
+``stage_scripts``, …) have their own dedicated tests in
+``test_build.py``; this file exercises the ``ImageBuilder`` methods
+that wrap them, so the class-level surface is the unit of test rather
+than the implementation it delegates to.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+from terok_executor.container.build import (
+    DEFAULT_BASE_IMAGE,
+    ImageBuilder,
+    ImageSet,
+)
+
+
+# ── Build delegation ──────────────────────────────────────────────
+
+
+def test_build_base_delegates_with_self_state() -> None:
+    """``build_base`` threads ``(base_image, family)`` from the instance."""
+    builder = ImageBuilder("fedora:44", family="rpm")
+    expected = ImageSet(l0="x", l1="y")
+    with mock.patch(
+        "terok_executor.container.build.build_base_images", return_value=expected
+    ) as build:
+        result = builder.build_base(agents=("claude",), rebuild=True)
+    assert result is expected
+    build.assert_called_once_with(
+        "fedora:44",
+        family="rpm",
+        agents=("claude",),
+        rebuild=True,
+        full_rebuild=False,
+        build_dir=None,
+        tag_as_default=False,
+    )
+
+
+def test_build_sidecar_delegates_with_self_state() -> None:
+    """``build_sidecar`` threads ``(base_image, family)`` and tool_name."""
+    builder = ImageBuilder("ubuntu:24.04", family="deb")
+    with mock.patch(
+        "terok_executor.container.build.build_sidecar_image", return_value="tag"
+    ) as build:
+        result = builder.build_sidecar(tool_name="custom", rebuild=True)
+    assert result == "tag"
+    build.assert_called_once_with(
+        "ubuntu:24.04",
+        family="deb",
+        tool_name="custom",
+        rebuild=True,
+        full_rebuild=False,
+        build_dir=None,
+    )
+
+
+def test_ensure_default_l1_delegates() -> None:
+    """``ensure_default_l1`` delegates to the module-level fn with self.state."""
+    builder = ImageBuilder("fedora:44", family="rpm")
+    with mock.patch(
+        "terok_executor.container.build.ensure_default_l1", return_value="alias-tag"
+    ) as fn:
+        result = builder.ensure_default_l1(agents=("claude",))
+    assert result == "alias-tag"
+    fn.assert_called_once_with("fedora:44", family="rpm", agents=("claude",))
+
+
+# ── Tag computation ───────────────────────────────────────────────
+
+
+def test_l0_tag_uses_self_base_image() -> None:
+    """``l0_tag`` returns the canonical L0 tag for the builder's base."""
+    assert ImageBuilder("fedora:44").l0_tag == "terok-l0:fedora-44"
+
+
+def test_l1_sidecar_tag_uses_self_base_image() -> None:
+    """``l1_sidecar_tag`` returns the canonical sidecar tag for the builder's base."""
+    assert ImageBuilder("fedora:44").l1_sidecar_tag == "terok-l1-sidecar:fedora-44"
+
+
+def test_l1_tag_alias_when_agents_none() -> None:
+    """``l1_tag(None)`` returns the default-alias tag."""
+    assert ImageBuilder("ubuntu:24.04").l1_tag() == "terok-l1-cli:ubuntu-24.04"
+
+
+def test_l1_tag_with_agents_appends_suffix() -> None:
+    """``l1_tag(agents)`` appends a sorted ``-a-b-c`` suffix."""
+    assert (
+        ImageBuilder("ubuntu:24.04").l1_tag(("codex", "claude"))
+        == "terok-l1-cli:ubuntu-24.04-claude-codex"
+    )
+
+
+# ── Template rendering ────────────────────────────────────────────
+
+
+def test_render_l0_uses_self_base_and_family() -> None:
+    """``render_l0`` threads the builder's base + resolved family."""
+    builder = ImageBuilder("fedora:44", family="rpm")
+    with mock.patch(
+        "terok_executor.container.build.render_l0", return_value="Dockerfile content"
+    ) as fn:
+        result = builder.render_l0()
+    assert result == "Dockerfile content"
+    fn.assert_called_once_with("fedora:44", family="rpm")
+
+
+def test_render_l1_threads_resolved_family_and_args() -> None:
+    """``render_l1`` resolves family from the base when ``family`` is None."""
+    builder = ImageBuilder("fedora:44")  # family=None — auto-detect
+    with mock.patch(
+        "terok_executor.container.build.render_l1", return_value="L1 dockerfile"
+    ) as fn:
+        result = builder.render_l1("l0-tag", agents=("claude",), cache_bust="42")
+    assert result == "L1 dockerfile"
+    fn.assert_called_once_with(
+        "l0-tag", family="rpm", agents=("claude",), cache_bust="42"
+    )
+
+
+def test_render_l1_sidecar_threads_self_state() -> None:
+    """``render_l1_sidecar`` passes family + tool_name to the underlying fn."""
+    builder = ImageBuilder("fedora:44", family="rpm")
+    with mock.patch(
+        "terok_executor.container.build.render_l1_sidecar", return_value="sidecar"
+    ) as fn:
+        result = builder.render_l1_sidecar("l0-tag", tool_name="ruff", cache_bust="7")
+    assert result == "sidecar"
+    fn.assert_called_once_with("l0-tag", family="rpm", tool_name="ruff", cache_bust="7")
+
+
+def test_family_property_auto_detects_when_unset() -> None:
+    """``_family`` auto-detects from base_image when the override is None."""
+    assert ImageBuilder("fedora:44")._family == "rpm"
+    assert ImageBuilder("ubuntu:24.04")._family == "deb"
+
+
+def test_family_property_honours_override() -> None:
+    """``_family`` returns the explicit override verbatim when set."""
+    assert ImageBuilder("fedora:44", family="deb")._family == "deb"
+
+
+# ── Static utilities ──────────────────────────────────────────────
+
+
+def test_detect_family_classmethod_delegates() -> None:
+    """``ImageBuilder.detect_family`` is a re-export of the module fn."""
+    assert ImageBuilder.detect_family("fedora:44") == "rpm"
+    assert ImageBuilder.detect_family("ubuntu:24.04", "rpm") == "rpm"
+
+
+def test_image_agents_classmethod_delegates() -> None:
+    """``ImageBuilder.image_agents`` delegates to the module fn."""
+    with mock.patch(
+        "terok_executor.container.build.image_agents", return_value={"claude", "codex"}
+    ) as fn:
+        assert ImageBuilder.image_agents("some:tag") == {"claude", "codex"}
+    fn.assert_called_once_with("some:tag")
+
+
+def test_stage_scripts_delegates(tmp_path: Path) -> None:
+    """``stage_scripts`` static method routes to the module fn."""
+    with mock.patch("terok_executor.container.build.stage_scripts") as fn:
+        ImageBuilder.stage_scripts(tmp_path)
+    fn.assert_called_once_with(tmp_path)
+
+
+def test_stage_tmux_config_delegates(tmp_path: Path) -> None:
+    """``stage_tmux_config`` static method routes to the module fn."""
+    with mock.patch("terok_executor.container.build.stage_tmux_config") as fn:
+        ImageBuilder.stage_tmux_config(tmp_path)
+    fn.assert_called_once_with(tmp_path)
+
+
+def test_stage_toad_agents_delegates(tmp_path: Path) -> None:
+    """``stage_toad_agents`` static method routes to the module fn."""
+    with mock.patch("terok_executor.container.build.stage_toad_agents") as fn:
+        ImageBuilder.stage_toad_agents(tmp_path)
+    fn.assert_called_once_with(tmp_path)
+
+
+# ── Default base image ────────────────────────────────────────────
+
+
+def test_default_base_image() -> None:
+    """A bare ``ImageBuilder()`` falls back to ``DEFAULT_BASE_IMAGE``."""
+    assert ImageBuilder().base_image == DEFAULT_BASE_IMAGE

--- a/tests/unit/test_image_builder.py
+++ b/tests/unit/test_image_builder.py
@@ -21,7 +21,6 @@ from terok_executor.container.build import (
     ImageSet,
 )
 
-
 # ── Build delegation ──────────────────────────────────────────────
 
 
@@ -117,14 +116,10 @@ def test_render_l0_uses_self_base_and_family() -> None:
 def test_render_l1_threads_resolved_family_and_args() -> None:
     """``render_l1`` resolves family from the base when ``family`` is None."""
     builder = ImageBuilder("fedora:44")  # family=None — auto-detect
-    with mock.patch(
-        "terok_executor.container.build.render_l1", return_value="L1 dockerfile"
-    ) as fn:
+    with mock.patch("terok_executor.container.build.render_l1", return_value="L1 dockerfile") as fn:
         result = builder.render_l1("l0-tag", agents=("claude",), cache_bust="42")
     assert result == "L1 dockerfile"
-    fn.assert_called_once_with(
-        "l0-tag", family="rpm", agents=("claude",), cache_bust="42"
-    )
+    fn.assert_called_once_with("l0-tag", family="rpm", agents=("claude",), cache_bust="42")
 
 
 def test_render_l1_sidecar_threads_self_state() -> None:


### PR DESCRIPTION
## Summary

Three new entry points cap the largest pieces of executor's previously free-function surface:

| Class | Replaces | Notes |
|---|---|---|
| `ImageBuilder(base_image, family=None)` | 13 free fns (`build_*`, `render_*`, `stage_*`, `l[01]_*_tag`, `detect_family`, `image_agents`, `ensure_default_l1`) | Instance methods anchor on the (base, family) pair; static helpers cover pure ops |
| `Authenticator(provider)` | `authenticate(...)` free fn | `.run(project_id, mounts_dir=…, image=…)` swap; discovery counterparts stay as module fns to keep the dep graph acyclic |
| `ExecutorConfigView.image_agents() / image_base_image() / set_image_agents()` | `config.py` free fns | The schema class now owns both the section's shape and its read/write accessors; `config.py` shrinks to a single `writable_config_path()` helper |

Net `__all__` shrink: -3 (added 2 classes, removed 17 free fns).

## Architectural cleanup

- **One builder bound to (base, family).** Instead of threading the pair through five different free fns (build_base, build_sidecar, ensure_default_l1, render_l0, render_l1_sidecar), construct once: `ImageBuilder(base, family).build_base()`. Internal callers (commands.py, preflight.py, container/runner.py) migrate; the duplication-prone "pass base + family to every fn" pattern disappears.
- **Schema class owns its section's accessors.** `ExecutorConfigView` already defined the `image:` section's shape; adding the three classmethod (now staticmethod) accessors puts shape and access in one place. The old `config.py` shrinks to a path helper.
- **Tach cycle avoidance.** `Authenticator` deliberately doesn't classmethod-fold `list_authenticated_agents` / `scan_leaked_credentials` because those live in `terok_executor.acp` / `terok_executor.credentials.vault_commands`, which depend on the auth module transitively — fold would create a cycle. Class docstring documents this explicitly.

## Deferred from original W5.A scope

Smaller absorptions deferred to a follow-up — they add churn without a meaningful API change:

- `KrunRuntime.create(cfg)` classmethod (krun.py — 3 fns)
- `DoctorReport` class (doctor.py — thin orchestrator entry-point)
- `AgentRoster.shared() / parse_selection / validate_selection / ensure_vault_routes` (roster/loader.py — 7 fns)
- `AgentConfigSpec.parse_md / prepare_dir / bundled_instructions / resolve_instructions` (provider/agents.py + provider/instructions.py — 4 fns)
- `ContainerEnvSpec.materialize / inject_prompt / seed_cache` (container/env.py — 4 fns)
- `StorageReport` classmethod factories (storage.py — 2 fns)

The flagship classes (ImageBuilder + Authenticator + ExecutorConfigView merge) cover the biggest verb-mound consolidations. The deferred classmethod additions are largely cosmetic re-shuffles that are cheaper to do as one cleanup PR than to scatter across this large diff.

## Depends on

- terok-ai/terok-sandbox#356 — `ShieldManager` / `ShieldHooks` (W5.B); transitively pulls terok-shield#333 and terok-clearance#143

All pins revert to release wheels at chain-merge time.

## Test plan

- [x] `make check` — ruff lint/format, tach, mypy, security (bandit), docstr-coverage 98.3%, vulture, reuse — all clean
- [x] `poetry run pytest tests/unit` — 950 passed
- [ ] `properdocs build --strict` — will surface cross-ref warnings against `terok_sandbox.ShieldManager`/`HooksInstaller` (inventories not yet generated; resolve at chain merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated terok-sandbox to a development version.

* **Refactor**
  * Consolidated image building interfaces into a unified builder class.
  * Simplified authentication workflows through a dedicated authenticator interface.
  * Streamlined package exports to focus on primary public APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->