### PR TITLE
refactor: fold roster/storage/krun free fns onto their classes (W5.A.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.0.149a23"
+version = "0.0.149a24"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -10,8 +10,8 @@ lifecycle of one AI coding agent at a time.  Designed for standalone use
 The public surface is ``__all__`` below.  Key entry points:
 
 - [`AgentRunner`][terok_executor.AgentRunner] — launch agents in containers
-- [`authenticate`][terok_executor.authenticate] — credential flow
-- [`build_base_images`][terok_executor.build_base_images] — image construction
+- [`Authenticator`][terok_executor.Authenticator] — credential flow
+- [`ImageBuilder`][terok_executor.ImageBuilder] — image construction
 - [`AgentRoster.shared`][terok_executor.AgentRoster.shared] — YAML agent registry (process-wide cache)
 
 Implementation-detail types (raw config schema fragments, ACP error

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -12,7 +12,7 @@ The public surface is ``__all__`` below.  Key entry points:
 - [`AgentRunner`][terok_executor.AgentRunner] — launch agents in containers
 - [`authenticate`][terok_executor.authenticate] — credential flow
 - [`build_base_images`][terok_executor.build_base_images] — image construction
-- [`get_roster`][terok_executor.get_roster] — YAML agent registry
+- [`AgentRoster.shared`][terok_executor.AgentRoster.shared] — YAML agent registry (process-wide cache)
 
 Implementation-detail types (raw config schema fragments, ACP error
 classes, internal result types, sidecar image / inject helpers) stay
@@ -40,11 +40,7 @@ from ._tree import COMMANDS
 
 # -- ACP host-proxy (per-task multi-agent aggregator) -------------------------
 from .acp import ACPEndpointStatus, acp_socket_is_live, list_authenticated_agents
-from .commands import (
-    COMMANDS as AGENT_COMMANDS,
-    prompt_agents_selection,
-    validate_agent_selection,
-)
+from .commands import COMMANDS as AGENT_COMMANDS
 
 # -- Config schema + read/write accessors for the executor-owned image: section --
 from .config_schema import ExecutorConfigView, RawImageSection
@@ -67,14 +63,8 @@ from .container.runner import AgentRunner
 from .credentials.auth import AUTH_PROVIDERS, Authenticator
 from .credentials.vault_commands import VAULT_COMMANDS, scan_leaked_credentials
 
-# -- Doctor + paths ------------------------------------------------------------
-from .doctor import agent_doctor_checks
-from .krun import (
-    KrunHostKeypair,
-    ensure_krun_host_keypair,
-    krun_launch_args,
-    make_krun_runtime,
-)
+# -- Krun (KVM-microVM) provisioning + runtime factory -----------------------
+from .krun import KrunHost, KrunHostKeypair, ensure_krun_host_keypair
 
 # -- Provider (descriptor + headless behaviour, instructions, agent config) ----
 from .provider.agents import AgentConfigSpec, parse_md_agent, prepare_agent_config_dir
@@ -84,24 +74,18 @@ from .provider.providers import (
     PROVIDER_NAMES,
     AgentProvider,
     CLIOverrides,
-    collect_all_auto_approve_env,
     get_provider,
     resolve_provider_value,
 )
 
 # -- Roster (agent catalog + config resolution) --------------------------------
-from .roster import AgentRoster, ensure_vault_routes, get_roster, parse_agent_selection
+from .roster import AgentRoster
 
 # -- Sandbox bootstrap composition ---------------------------------------------
 from .sandbox import ensure_sandbox_ready
 
 # -- Storage queries (filesystem footprint measurement) -------------------------
-from .storage import (
-    SharedMountStorageInfo,
-    TaskStorageInfo,
-    get_shared_mounts_storage,
-    get_tasks_storage,
-)
+from .storage import SharedMountStorageInfo, TaskStorageInfo
 
 # -- Bootstrap YAML roster into module-level dicts ---------------------------
 # AGENT_PROVIDERS and AUTH_PROVIDERS are empty dicts populated here to avoid
@@ -114,9 +98,7 @@ def _bootstrap_roster() -> None:
 
     import terok_executor.provider.providers as _reg
 
-    from .roster import get_roster
-
-    roster = get_roster()
+    roster = AgentRoster.shared()
     AGENT_PROVIDERS.update(roster.providers)
     AUTH_PROVIDERS.update(roster.auth_providers)
     PROVIDER_NAMES = _reg.PROVIDER_NAMES = roster.agent_names
@@ -135,7 +117,6 @@ __all__ = [
     "AgentProvider",
     "CLIOverrides",
     "PROVIDER_NAMES",
-    "collect_all_auto_approve_env",
     "get_provider",
     "resolve_provider_value",
     # Agent config preparation
@@ -161,26 +142,17 @@ __all__ = [
     "ImageBuilder",
     "ImageSet",
     "build_project_image",
-    # Vault routes + roster bootstrap
-    "ensure_vault_routes",
+    # Vault credential scanning
     "scan_leaked_credentials",
     # Roster
     "AgentRoster",
-    "get_roster",
-    "parse_agent_selection",
     # Command registry
     "AGENT_COMMANDS",
     "COMMANDS",
     "VAULT_COMMANDS",
-    "prompt_agents_selection",
-    "validate_agent_selection",
-    # Doctor (container health checks)
-    "agent_doctor_checks",
     # Storage queries
     "SharedMountStorageInfo",
     "TaskStorageInfo",
-    "get_shared_mounts_storage",
-    "get_tasks_storage",
     # Runner facade
     "AgentRunner",
     # Container environment assembly
@@ -192,8 +164,7 @@ __all__ = [
     # Sandbox bootstrap composition
     "ensure_sandbox_ready",
     # Krun (KVM-microVM) provisioning + runtime factory
+    "KrunHost",
     "KrunHostKeypair",
     "ensure_krun_host_keypair",
-    "krun_launch_args",
-    "make_krun_runtime",
 ]

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -373,9 +373,10 @@ def _handle_agents_list(*, show_all: bool = False) -> None:
     """List registered agents."""
     import sys
 
-    from .roster.loader import _load_bundled_agents, _load_user_agents, get_roster
+    from .roster import AgentRoster
+    from .roster.loader import _load_bundled_agents, _load_user_agents
 
-    roster = get_roster()
+    roster = AgentRoster.shared()
     names = roster.all_names if show_all else roster.agent_names
 
     if not names:
@@ -401,50 +402,14 @@ def _handle_agents_list(*, show_all: bool = False) -> None:
         print(f"{name:<{w_name}}  {label:<{w_label}}  {kind}")
 
 
-def prompt_agents_selection() -> str:
-    """Print the installed roster and read one line of executor grammar.
-
-    Empty input → ``"all"``.  Non-interactive stdin (closed pipe) exits
-    with a hint to pass the selection positionally instead.
-    """
-    from .roster.loader import get_roster
-
-    roster = get_roster()
-    providers = roster.providers
-    print("\nAvailable agents:")
-    for name in sorted(roster.agent_names):
-        provider = providers.get(name)
-        label = provider.label if provider is not None else name
-        print(f"  · {name}  — {label}")
-    try:
-        raw = input("\nType a comma list, or '-name' to exclude [all]: ").strip()
-    except EOFError as exc:
-        raise SystemExit(
-            "No interactive stdin available.  Pass the selection positionally "
-            "instead, e.g. `terok agents set all`."
-        ) from exc
-    return raw or "all"
-
-
-def validate_agent_selection(raw: str) -> None:
-    """Reject *raw* with ``SystemExit(2)`` if it names roster entries we don't have."""
-    import sys
-
-    from .roster.loader import get_roster, parse_agent_selection
-
-    try:
-        get_roster().resolve_selection(parse_agent_selection(raw))
-    except ValueError as exc:
-        print(f"Invalid agent selection: {exc}", file=sys.stderr)
-        raise SystemExit(2) from exc
-
-
 def _handle_agents_set(*, selection: str | None = None) -> None:
     """Write the global ``image.agents`` default to ``config.yml``."""
     from .config_schema import ExecutorConfigView
+    from .roster import AgentRoster
 
-    raw = selection if selection is not None else prompt_agents_selection()
-    validate_agent_selection(raw)
+    roster = AgentRoster.shared()
+    raw = selection if selection is not None else roster.prompt_selection()
+    roster.validate_selection(raw)
     path = ExecutorConfigView.set_image_agents(raw)
     print(f"Wrote image.agents = {raw!r} to {path}")
 
@@ -460,9 +425,9 @@ def _handle_build(
 ) -> None:
     """Build L0+L1 container images (optionally include sidecar L1)."""
     from .container.build import BuildError, ImageBuilder
-    from .roster.loader import parse_agent_selection
+    from .roster import AgentRoster
 
-    selection = parse_agent_selection(agents)
+    selection = AgentRoster.parse_selection(agents)
 
     builder = ImageBuilder(base, family=family)
     try:

--- a/src/terok_executor/config_schema.py
+++ b/src/terok_executor/config_schema.py
@@ -126,7 +126,7 @@ class ExecutorConfigView(SandboxConfigView):
         """Write *selection* into ``image.agents`` and return the file path.
 
         Caller validates *selection* up-front (typically via
-        [`validate_agent_selection`][terok_executor.validate_agent_selection]).
+        [`AgentRoster.validate_selection`][terok_executor.AgentRoster.validate_selection]).
 
         Invalidates terok-util's process-wide ``read_config_section``
         cache before returning so the next ``image_agents()`` /

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -259,33 +259,45 @@ class ImageBuilder:
         """L1 image tag for *agents* under ``self.base_image`` (alias when ``None``)."""
         return l1_image_tag(self.base_image, agents)
 
-    # ── Templates (instance — uses self.base_image + self.family) ───
+    # ── Templates ────────────────────────────────────────
 
     def render_l0(self) -> str:
-        """Render the L0 Dockerfile for this base."""
+        """Render the L0 Dockerfile for this base.
+
+        Instance-bound because L0 is anchored on ``self.base_image``.
+        """
         return render_l0(self.base_image, family=self._family)
 
+    @staticmethod
     def render_l1(
-        self,
         l0_tag: str,
         *,
+        family: str,
         agents: tuple[str, ...] | str = "all",
         cache_bust: str = "0",
     ) -> str:
-        """Render the L1 CLI Dockerfile for *agents* on top of *l0_tag*."""
-        return render_l1(l0_tag, family=self._family, agents=agents, cache_bust=cache_bust)
+        """Render the L1 CLI Dockerfile for *agents* on top of *l0_tag*.
 
+        Static because the L1 stage depends only on the L0 tag and the
+        package family — it never touches ``self.base_image``.  Callers
+        that already have an [`ImageBuilder`][terok_executor.container.build.ImageBuilder]
+        can pass ``builder._family`` to thread the resolved family through.
+        """
+        return render_l1(l0_tag, family=family, agents=agents, cache_bust=cache_bust)
+
+    @staticmethod
     def render_l1_sidecar(
-        self,
         l0_tag: str,
         *,
+        family: str,
         tool_name: str = "coderabbit",
         cache_bust: str = "0",
     ) -> str:
-        """Render the L1 sidecar Dockerfile for *tool_name* on top of *l0_tag*."""
-        return render_l1_sidecar(
-            l0_tag, family=self._family, tool_name=tool_name, cache_bust=cache_bust
-        )
+        """Render the L1 sidecar Dockerfile for *tool_name* on top of *l0_tag*.
+
+        Static for the same reason as [`render_l1`][terok_executor.container.build.ImageBuilder.render_l1].
+        """
+        return render_l1_sidecar(l0_tag, family=family, tool_name=tool_name, cache_bust=cache_bust)
 
     @property
     def _family(self) -> str:
@@ -453,13 +465,13 @@ def build_base_images(
         ValueError: If *build_dir* is a file or a non-empty directory,
             or if *agents* contains unknown roster entries.
     """
-    from terok_executor.roster.loader import get_roster
+    from terok_executor.roster import AgentRoster
 
     _validate_build_dir(build_dir)
     _check_podman()
 
     base_image = _normalize_base_image(base_image)
-    selected = get_roster().resolve_selection(agents)
+    selected = AgentRoster.shared().resolve_selection(agents)
 
     l0_tag = l0_image_tag(base_image)
     l1_tag = l1_image_tag(base_image, selected)
@@ -690,9 +702,9 @@ def render_l1(
     *cache_bust* invalidates the per-agent install layers when changed
     (typically set to a Unix timestamp).
     """
-    from terok_executor.roster.loader import get_roster
+    from terok_executor.roster import AgentRoster
 
-    roster = get_roster()
+    roster = AgentRoster.shared()
     selected = roster.resolve_selection(agents)
     installs = roster.installs
 
@@ -799,9 +811,9 @@ def stage_help_fragments(dest: Path, agents: tuple[str, ...]) -> None:
     real ANSI sequences so that ``hilfe`` only needs to ``cat`` them.
     Empty sections are omitted entirely; ``hilfe`` skips missing files.
     """
-    from terok_executor.roster.loader import get_roster
+    from terok_executor.roster import AgentRoster
 
-    roster = get_roster()
+    roster = AgentRoster.shared()
     helps = roster.helps
 
     by_section: dict[str, list[str]] = {}

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -11,11 +11,11 @@ the canonical assembly function so that logic lives in one place.
 Usage::
 
     from terok_executor.container.env import ContainerEnvSpec, assemble_container_env
-    from terok_executor import get_roster
+    from terok_executor import AgentRoster
 
     result = assemble_container_env(
         ContainerEnvSpec(task_id="abc", provider_name="claude", workspace_host_path=ws),
-        get_roster(),
+        AgentRoster.shared(),
     )
     # result.env, result.volumes, result.task_dir
 """

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -114,9 +114,9 @@ class AgentRunner:
     def roster(self) -> AgentRoster:
         """Lazy-init agent roster."""
         if self._roster is None:
-            from terok_executor.roster.loader import get_roster
+            from terok_executor.roster import AgentRoster as _Roster
 
-            self._roster = get_roster()
+            self._roster = _Roster.shared()
         return self._roster
 
     # ------------------------------------------------------------------

--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -24,9 +24,9 @@ if TYPE_CHECKING:
 
 def _ensure_routes(cfg: SandboxConfig | None = None) -> Path:
     """Generate routes.json from the YAML agent roster."""
-    from terok_executor.roster.loader import ensure_vault_routes
+    from terok_executor.roster import AgentRoster
 
-    return ensure_vault_routes(cfg=cfg)
+    return AgentRoster.shared().ensure_vault_routes(cfg=cfg)
 
 
 def _handle_start(*, cfg: SandboxConfig | None = None) -> None:
@@ -114,9 +114,9 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     """
     import stat
 
-    from terok_executor.roster.loader import get_roster
+    from terok_executor.roster import AgentRoster
 
-    roster = get_roster()
+    roster = AgentRoster.shared()
     base_resolved = mounts_base.resolve(strict=False)
     leaked: list[tuple[str, Path]] = []
     for name, route in roster.vault_routes.items():

--- a/src/terok_executor/credentials/vault_config.py
+++ b/src/terok_executor/credentials/vault_config.py
@@ -72,9 +72,9 @@ def write_vault_config(provider_name: str) -> None:
     to redirect API traffic through the vault.  The patch spec is declared
     in the agent YAML — no provider-specific code needed.
     """
-    from terok_executor.roster.loader import get_roster
+    from terok_executor.roster import AgentRoster
 
-    roster = get_roster()
+    roster = AgentRoster.shared()
     route = roster.vault_routes.get(provider_name)
     if not route or not route.shared_config_patch:
         return

--- a/src/terok_executor/doctor.py
+++ b/src/terok_executor/doctor.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Agent-level container health checks.
+"""Agent-level container health checks (implementation).
 
 Contributes domain-specific checks to the layered doctor protocol
 (``terok_sandbox.doctor``): socat bridge liveness, credential file
@@ -11,6 +11,10 @@ for the vault.
 The checks are returned as `DoctorCheck` specs — probe commands
 + evaluate callables — that the top-level orchestrator (``terok sickbay``)
 executes inside containers via ``podman exec``.
+
+Public entry point: [`AgentRoster.doctor_checks`][terok_executor.roster.loader.AgentRoster.doctor_checks].
+This module is the implementation home; consumers call it through the
+roster method so the dependency direction stays roster → checks.
 """
 
 from __future__ import annotations
@@ -51,12 +55,15 @@ _REAL_KEY_PREFIXES = ("sk-ant-", "sk-", "gho_", "ghp_", "ghs_", "glpat-")
 # ── Public API ───────────────────────────────────────────────────────────
 
 
-def agent_doctor_checks(
+def _build_agent_doctor_checks(
     roster: AgentRoster,
     *,
     token_broker_port: int | None = None,
 ) -> list[DoctorCheck]:
-    """Return agent-level health checks for in-container diagnostics.
+    """Assemble agent-level health checks for in-container diagnostics.
+
+    Private to the doctor module — call through
+    [`AgentRoster.doctor_checks`][terok_executor.roster.loader.AgentRoster.doctor_checks].
 
     Args:
         roster: The loaded agent roster.
@@ -64,9 +71,6 @@ def agent_doctor_checks(
             selects socket mode; any integer selects TCP mode.  Base URL
             checks use the port (or the in-container loopback port) to
             derive the expected host.
-
-    Returns:
-        List of `DoctorCheck` instances ready for orchestration.
     """
     socket_mode = token_broker_port is None
     checks: list[DoctorCheck] = [

--- a/src/terok_executor/krun.py
+++ b/src/terok_executor/krun.py
@@ -3,27 +3,23 @@
 
 """Krun (KVM-microVM) host-side provisioning: identity + runtime factory.
 
-Two responsibilities, both intentionally outside terok:
+[`KrunHost`][terok_executor.krun.KrunHost] is the host-side companion to
+sandbox's [`KrunRuntime`][terok_sandbox.KrunRuntime].  One instance per
+launch bundles the three things the orchestrator needs:
 
-- [`ensure_krun_host_keypair`][terok_executor.krun.ensure_krun_host_keypair]
-  — mint or load the SSH keypair the L0 guest's ``sshd`` trusts, and
-  materialise both halves onto tmpfs files: the private half so
-  ``ssh -i`` can read it, and the public half so the orchestrator can
-  bind-mount it into the running guest at
-  ``/etc/ssh/authorized_keys.d/terok``.  The vault is the system of
-  record; the tmpfs cache is a derived view rebuilt per process.
-
-- [`make_krun_runtime`][terok_executor.krun.make_krun_runtime] — one-shot
-  constructor for a production
-  [`KrunRuntime`][terok_sandbox.KrunRuntime] backed by the TCP-over-passt
-  SSH transport, with the keypair already wired in.  terok flips its
-  runtime selector to ``krun`` and calls this; everything else is
-  invisible.
+- the vault-backed ``%host`` keypair materialised to tmpfs (cached, so
+  the vault DB is opened once even when ``runtime`` and ``launch_args``
+  are both called);
+- a production [`KrunRuntime`][terok_sandbox.KrunRuntime] with the
+  TCP-over-passt SSH transport wired in;
+- the extra ``podman run`` arguments terok must splice in (pubkey
+  bind-mount, runtime-signal env var, ``--user root`` override, and the
+  pasta DNS forwarder).
 
 Living in executor (rather than terok) keeps the rule honest: anything
-that owns the L0 build path also owns the trust material that makes
-the resulting guest reachable.  Selecting krun without provisioning
-the key is a contradiction, so the two operations belong together.
+that owns the L0 build path also owns the trust material that makes the
+resulting guest reachable.  Selecting krun without provisioning the key
+is a contradiction, so the two operations belong together.
 """
 
 from __future__ import annotations
@@ -90,6 +86,106 @@ class KrunHostKeypair:
     """``True`` when this call minted the key; ``False`` when it was loaded."""
 
 
+class KrunHost:
+    """Host-side krun launch context — vault keypair + runtime + launch args.
+
+    One instance per launch.  The first access to
+    [`keypair`][terok_executor.krun.KrunHost.keypair] opens the vault DB
+    and materialises the ``%host`` private/public keypair to tmpfs;
+    every subsequent access on the same instance reuses the cached
+    result, so calling both [`runtime`][terok_executor.krun.KrunHost.runtime]
+    and [`launch_args`][terok_executor.krun.KrunHost.launch_args] pays
+    that cost only once.
+
+    Requires the vault to be unlocked — the krun runtime is gated on
+    ``experimental: true`` upstream and assumes the operator has the
+    vault open for the session.  A ``NoPassphraseError`` from the
+    underlying vault open propagates unchanged so the orchestrator can
+    render its own remediation hint.
+
+    Args:
+        cfg: Sandbox config used to open the credential DB.  ``None``
+            means use the zero-arg default — appropriate for standalone
+            executor flows; terok injects its own enriched config when
+            calling.
+    """
+
+    __slots__ = ("_cfg", "_keypair")
+
+    def __init__(self, *, cfg: SandboxConfig | None = None):
+        """Bind a krun launch to *cfg*; the keypair is loaded on first access."""
+        self._cfg = cfg
+        self._keypair: KrunHostKeypair | None = None
+
+    @property
+    def keypair(self) -> KrunHostKeypair:
+        """Vault-backed ``%host`` keypair materialised to tmpfs (cached).
+
+        First access opens the vault DB and writes the OpenSSH-PEM
+        private + public-key line to a tmpfs cache directory; subsequent
+        accesses on the same instance return the same object without
+        reopening the vault.
+        """
+        if self._keypair is None:
+            self._keypair = ensure_krun_host_keypair(cfg=self._cfg)
+        return self._keypair
+
+    def runtime(self) -> KrunRuntime:
+        """Construct a production [`KrunRuntime`][terok_sandbox.KrunRuntime] in one call.
+
+        Wires together the three production pieces — the cached host
+        keypair, the TCP-over-passt SSH transport, and a fresh
+        [`PodmanRuntime`][terok_sandbox.PodmanRuntime] for lifecycle.
+        The experimental-flag gate stays on the orchestrator side (this
+        factory is reachable only when the gate is open).
+        """
+        kp = self.keypair
+        transport = TcpSSHTransport(
+            identity_file=kp.private_path,
+            endpoint_resolver=podman_port_resolver(),
+        )
+        return KrunRuntime(transport=transport, podman=PodmanRuntime())
+
+    def launch_args(self) -> list[str]:
+        """Extra ``podman run`` args terok must splice in for a krun launch.
+
+        Four things that all reach across the orchestrator/runtime
+        boundary into executor's domain — the L0 image, the host
+        keypair, the in-guest ``init-ssh-and-repo.sh``, and the DNS
+        forwarder address — so they live here together rather than
+        being open-coded in terok's ``_project_runtime_flags``:
+
+        - Bind-mount the live host pubkey over the L0's empty
+          placeholder at ``/etc/ssh/authorized_keys.d/terok``.  ``z`` is
+          the shared SELinux relabel (never ``Z`` — the host pubkey is
+          host-wide and concurrent containers share the source).
+        - Set ``TEROK_CONTAINER_RUNTIME=krun`` so the init script's krun
+          gate fires.
+        - Override the L0's ``USER dev`` directive with ``--user root``
+          so the in-guest sshd can start, listen on TCP 22, and drop to
+          the authenticated user on connection.  ``USER dev`` is the
+          right default under crun (AI agents that refuse uid 0); under
+          krun the session uid comes from which ``ssh user@…`` the
+          operator picks.
+        - ``--dns 169.254.1.1`` — kept for shield-bypass; under
+          shield-up the bind-mounted resolv.conf overrides this anyway.
+
+        Doesn't include ``--runtime krun`` itself or krun's microVM-sizing
+        annotations — those are orchestrator-level decisions terok keeps.
+        """
+        kp = self.keypair
+        return [
+            "-v",
+            f"{kp.public_path}:/etc/ssh/authorized_keys.d/terok:ro,z",
+            "-e",
+            "TEROK_CONTAINER_RUNTIME=krun",
+            "--user",
+            "root",
+            "--dns",
+            _PASTA_DNS_FORWARDER,
+        ]
+
+
 def ensure_krun_host_keypair(
     *,
     cfg: SandboxConfig | None = None,
@@ -149,64 +245,6 @@ def ensure_krun_host_keypair(
         fingerprint=infra.fingerprint,
         created=infra.created,
     )
-
-
-def make_krun_runtime(*, cfg: SandboxConfig | None = None) -> KrunRuntime:
-    """Construct a production [`KrunRuntime`][terok_sandbox.KrunRuntime] in one call.
-
-    Wires together the three production pieces — the vault-backed host
-    keypair, the TCP-over-passt SSH transport, and a fresh
-    [`PodmanRuntime`][terok_sandbox.PodmanRuntime] for lifecycle —
-    so the orchestrator's runtime selector reduces to a single call:
-    ``_runtime = make_krun_runtime(cfg=...)``.  The experimental-flag
-    gate stays on the orchestrator side (this factory is reachable
-    only when the gate is open).
-    """
-    kp = ensure_krun_host_keypair(cfg=cfg)
-    transport = TcpSSHTransport(
-        identity_file=kp.private_path,
-        endpoint_resolver=podman_port_resolver(),
-    )
-    return KrunRuntime(transport=transport, podman=PodmanRuntime())
-
-
-def krun_launch_args(*, cfg: SandboxConfig | None = None) -> list[str]:
-    """Extra ``podman run`` args terok must splice in for a krun launch.
-
-    Four things that all reach across the orchestrator/runtime boundary
-    into executor's domain — the L0 image, the host keypair, the
-    in-guest ``init-ssh-and-repo.sh``, and the DNS forwarder address —
-    so they live here together rather than being open-coded in terok's
-    ``_project_runtime_flags``:
-
-    - Bind-mount the live host pubkey over the L0's empty placeholder
-      at ``/etc/ssh/authorized_keys.d/terok``.  ``z`` is the shared
-      SELinux relabel (never ``Z`` — the host pubkey is host-wide and
-      concurrent containers share the source).
-    - Set ``TEROK_CONTAINER_RUNTIME=krun`` so the init script's krun
-      gate fires.
-    - Override the L0's ``USER dev`` directive with ``--user root`` so
-      the in-guest sshd can start, listen on TCP 22, and drop to the
-      authenticated user on connection.  ``USER dev`` is the right
-      default under crun (AI agents that refuse uid 0); under krun the
-      session uid comes from which ``ssh user@…`` the operator picks.
-    - ``--dns 169.254.1.1`` — kept for shield-bypass; under shield-up
-      the bind-mounted resolv.conf overrides this anyway.
-
-    Doesn't include ``--runtime krun`` itself or krun's microVM-sizing
-    annotations — those are orchestrator-level decisions terok keeps.
-    """
-    kp = ensure_krun_host_keypair(cfg=cfg)
-    return [
-        "-v",
-        f"{kp.public_path}:/etc/ssh/authorized_keys.d/terok:ro,z",
-        "-e",
-        "TEROK_CONTAINER_RUNTIME=krun",
-        "--user",
-        "root",
-        "--dns",
-        _PASTA_DNS_FORWARDER,
-    ]
 
 
 # ── Private helpers ─────────────────────────────────────────────────────────

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -344,9 +344,9 @@ class Preflight:
 
     def _provider_hints(self) -> None:
         """Print a hint about authenticating additional tools."""
-        from terok_executor.roster.loader import get_roster
+        from terok_executor.roster import AgentRoster
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         others = sorted(name for name in roster.all_names if name != self.provider)
         if others:
             print("\n  Hint: authenticate additional tools with: terok-executor auth <name>")

--- a/src/terok_executor/provider/providers.py
+++ b/src/terok_executor/provider/providers.py
@@ -482,25 +482,6 @@ def get_provider(name: str | None, *, default_agent: str | None = None) -> Agent
     return resolve_provider(AGENT_PROVIDERS, name, default_agent=default_agent)
 
 
-def collect_all_auto_approve_env() -> dict[str, str]:
-    """Collect ``auto_approve_env`` from all providers into one dict.
-
-    Used by task runners to inject these env vars at the container level
-    (not just inside shell wrappers) so that ACP-spawned agents also
-    inherit unrestricted permissions.
-    """
-    merged: dict[str, str] = {}
-    for p in AGENT_PROVIDERS.values():
-        for key, value in p.auto_approve_env.items():
-            if key in merged and merged[key] != value:
-                raise ValueError(
-                    f"Conflicting auto_approve_env for {key!r}: "
-                    f"{merged[key]!r} vs {value!r} (provider {p.name!r})"
-                )
-            merged[key] = value
-    return merged
-
-
 def collect_opencode_provider_env() -> dict[str, str]:
     """Collect environment variables for all OpenCode-based providers.
 

--- a/src/terok_executor/roster/__init__.py
+++ b/src/terok_executor/roster/__init__.py
@@ -7,24 +7,12 @@ Delegates to `.loader` for YAML deserialization and roster construction,
 and to `.config_stack` for generic layered config resolution.
 """
 
-from .loader import (
-    AgentRoster,
-    MountDef,
-    SidecarSpec,
-    VaultRoute,
-    ensure_vault_routes,
-    get_roster,
-    load_roster,
-    parse_agent_selection,
-)
+from .loader import AgentRoster, MountDef, SidecarSpec, VaultRoute, load_roster
 
 __all__ = [
     "AgentRoster",
     "MountDef",
     "SidecarSpec",
     "VaultRoute",
-    "ensure_vault_routes",
-    "get_roster",
     "load_roster",
-    "parse_agent_selection",
 ]

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -32,7 +32,7 @@ from terok_util import deep_merge, namespace_config_dir
 
 from terok_executor._util import yaml_load
 from terok_executor.credentials.auth import AuthProvider
-from terok_executor.integrations.sandbox import SandboxConfig
+from terok_executor.integrations.sandbox import DoctorCheck, SandboxConfig
 from terok_executor.provider.providers import AgentProvider
 
 from .schema import RawAgentYaml, VaultRouteEntry
@@ -293,38 +293,141 @@ class AgentRoster:
                 env.update(p.opencode_config.to_env(p.name))
         return env
 
+    # ── Process-singleton + selection parsing ──
 
-# ── Public API ────────────────────────────────────────────────────────────
+    @staticmethod
+    def shared() -> AgentRoster:
+        """Return the process-wide cached roster.
+
+        Loaded on first access; every subsequent call returns the same
+        instance.  Use this from anywhere that just needs the global
+        view; tests that mutate or replace the roster should call
+        [`load_roster`][terok_executor.roster.loader.load_roster] and
+        keep the result local.
+        """
+        return _shared_roster()
+
+    @staticmethod
+    def parse_selection(raw: str) -> str | tuple[str, ...]:
+        """Normalise a user-supplied agent selection string.
+
+        Accepts a comma-list of selection tokens or the literal ``"all"``.
+        Each token is either an agent name (``"claude"``) or a name
+        prefixed with ``-`` to exclude it from the selection
+        (``"-vibe"``).  The pseudo-name ``"all"`` is also valid as a
+        token, so ``"all,-vibe"`` means "everything except vibe".  When
+        the input contains only excludes (``"-vibe"``), the selection
+        seeds from every installable entry — same effect as
+        ``"all,-vibe"``.
+
+        Whitespace is stripped, empty / whitespace-only entries dropped,
+        and case folded.  Empty or all-whitespace input collapses to
+        ``"all"`` — the same shape
+        [`AgentRoster.resolve_selection`][terok_executor.roster.loader.AgentRoster.resolve_selection]
+        expects.  Unknown names are not checked here;
+        ``resolve_selection`` does that.
+        """
+        folded = raw.strip().lower()
+        if folded == "all" or not folded:
+            return "all"
+        tokens = tuple(n.strip() for n in folded.split(",") if n.strip())
+        return tokens or "all"
+
+    def validate_selection(self, raw: str) -> None:
+        """Reject *raw* with ``SystemExit(2)`` if it names roster entries we don't have.
+
+        CLI-flavoured: prints a ``Invalid agent selection: …`` line on
+        stderr and exits.  Domain callers that just want the parsed
+        tuple should use
+        [`parse_selection`][terok_executor.roster.loader.AgentRoster.parse_selection]
+        + [`resolve_selection`][terok_executor.roster.loader.AgentRoster.resolve_selection]
+        and handle ``ValueError`` themselves.
+        """
+        try:
+            self.resolve_selection(self.parse_selection(raw))
+        except ValueError as exc:
+            print(f"Invalid agent selection: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
+
+    def prompt_selection(self) -> str:
+        """Print the installed roster and read one line of executor grammar.
+
+        Empty input → ``"all"``.  Non-interactive stdin (closed pipe)
+        exits with a hint to pass the selection positionally instead.
+        """
+        providers = self.providers
+        print("\nAvailable agents:")
+        for name in sorted(self.agent_names):
+            provider = providers.get(name)
+            label = provider.label if provider is not None else name
+            print(f"  · {name}  — {label}")
+        try:
+            raw = input("\nType a comma list, or '-name' to exclude [all]: ").strip()
+        except EOFError as exc:
+            raise SystemExit(
+                "No interactive stdin available.  Pass the selection positionally "
+                "instead, e.g. `terok agents set all`."
+            ) from exc
+        return raw or "all"
+
+    # ── Vault routes + doctor checks ──
+
+    def ensure_vault_routes(self, cfg: SandboxConfig | None = None) -> Path:
+        """Generate ``routes.json`` from this roster and write it to disk.
+
+        The routes file is written to the path configured in
+        [`SandboxConfig`][terok_sandbox.SandboxConfig] (typically
+        ``~/.local/share/terok/vault/routes.json``).
+
+        When *cfg* is ``None``, falls back to standalone defaults.
+
+        Returns the path to the written file.
+        """
+        if cfg is None:
+            cfg = SandboxConfig()
+        path = cfg.routes_path
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        content = self.generate_routes_json() + "\n"
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        tmp = Path(tmp_name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            tmp.replace(path)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
+        return path
+
+    def doctor_checks(self, *, token_broker_port: int | None = None) -> list[DoctorCheck]:
+        """Return agent-level health checks for in-container diagnostics.
+
+        Delegates to
+        [`terok_executor.doctor`][terok_executor.doctor] for the actual
+        check factories; this method is the canonical entry point so
+        consumers can discover the checks through the roster.
+
+        Args:
+            token_broker_port: Host-side vault broker TCP port.  ``None``
+                selects socket mode; any integer selects TCP mode.  Base
+                URL checks use the port (or the in-container loopback
+                port) to derive the expected host.
+        """
+        from terok_executor.doctor import _build_agent_doctor_checks
+
+        return _build_agent_doctor_checks(self, token_broker_port=token_broker_port)
 
 
 @lru_cache(maxsize=1)
-def get_roster() -> AgentRoster:
-    """Return the singleton roster instance (loaded once, cached)."""
+def _shared_roster() -> AgentRoster:
+    """Process-wide cached roster — backing for ``AgentRoster.shared``."""
     return load_roster()
 
 
-def parse_agent_selection(raw: str) -> str | tuple[str, ...]:
-    """Normalise a user-supplied agent selection string.
-
-    Accepts a comma-list of selection tokens or the literal ``"all"``.  Each
-    token is either an agent name (``"claude"``) or a name prefixed with
-    ``-`` to exclude it from the selection (``"-vibe"``).  The pseudo-name
-    ``"all"`` is also valid as a token, so ``"all,-vibe"`` means "everything
-    except vibe".  When the input contains only excludes (``"-vibe"``), the
-    selection seeds from every installable entry — same effect as
-    ``"all,-vibe"``.
-
-    Whitespace is stripped, empty / whitespace-only entries dropped, and
-    case folded.  Empty or all-whitespace input collapses to ``"all"`` —
-    the same shape [`AgentRoster.resolve_selection`][terok_executor.roster.loader.AgentRoster.resolve_selection]
-    expects.  Unknown names are not checked here; ``resolve_selection``
-    does that.
-    """
-    folded = raw.strip().lower()
-    if folded == "all" or not folded:
-        return "all"
-    tokens = tuple(n.strip() for n in folded.split(",") if n.strip())
-    return tokens or "all"
+# ── Public API ────────────────────────────────────────────────────────────
 
 
 def load_roster() -> AgentRoster:
@@ -430,37 +533,6 @@ def load_roster() -> AgentRoster:
         _all_names=tuple(all_names),
         _web_ingress=frozenset(web_ingress_names),
     )
-
-
-def ensure_vault_routes(cfg: SandboxConfig | None = None) -> Path:
-    """Generate ``routes.json`` from the YAML roster and write it to disk.
-
-    The routes file is written to the path configured in
-    [`SandboxConfig`][terok_sandbox.SandboxConfig] (typically
-    ``~/.local/share/terok/vault/routes.json``).
-
-    When *cfg* is ``None``, falls back to standalone defaults.
-
-    Returns the path to the written file.
-    """
-    if cfg is None:
-        cfg = SandboxConfig()
-    path = cfg.routes_path
-
-    path.parent.mkdir(parents=True, exist_ok=True)
-    content = get_roster().generate_routes_json() + "\n"
-    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-    tmp = Path(tmp_name)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(content)
-            f.flush()
-            os.fsync(f.fileno())
-        tmp.replace(path)
-    except BaseException:
-        tmp.unlink(missing_ok=True)
-        raise
-    return path
 
 
 # ── YAML loading ──────────────────────────────────────────────────────────

--- a/src/terok_executor/sandbox.py
+++ b/src/terok_executor/sandbox.py
@@ -43,10 +43,10 @@ def ensure_sandbox_ready(
     traceback.
     """
     from terok_executor.integrations.sandbox import _handle_sandbox_setup, stage_line
-    from terok_executor.roster.loader import ensure_vault_routes
+    from terok_executor.roster import AgentRoster
 
     if not no_vault:
         with stage_line("Vault routes") as s:
-            ensure_vault_routes(cfg=cfg)
+            AgentRoster.shared().ensure_vault_routes(cfg=cfg)
             s.ok("regenerated")
     _handle_sandbox_setup(cfg=cfg, no_vault=no_vault, **aggregator_kwargs)

--- a/src/terok_executor/storage.py
+++ b/src/terok_executor/storage.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .paths import mounts_dir
-from .roster import MountDef, get_roster
+from .roster import AgentRoster, MountDef
 
 
 @dataclass(frozen=True)
@@ -30,6 +30,30 @@ class TaskStorageInfo:
         """Combined footprint of workspace and agent config."""
         return self.workspace_bytes + self.agent_config_bytes
 
+    @classmethod
+    def measure(cls, task_dir: Path) -> TaskStorageInfo:
+        """Measure a single task's disk footprint.
+
+        Expects the standard layout: ``<task_dir>/workspace-dangerous/``
+        for the agent-writable code, ``<task_dir>/agent-config/`` for
+        per-task configuration.
+        """
+        return cls(
+            task_id=task_dir.name,
+            workspace_bytes=_dir_bytes(task_dir / "workspace-dangerous"),
+            agent_config_bytes=_dir_bytes(task_dir / "agent-config"),
+        )
+
+    @classmethod
+    def measure_all(cls, tasks_root: Path) -> list[TaskStorageInfo]:
+        """Measure every task under *tasks_root*, sorted by task ID."""
+        if not tasks_root.is_dir():
+            return []
+        return sorted(
+            (cls.measure(d) for d in tasks_root.iterdir() if d.is_dir()),
+            key=lambda t: t.task_id,
+        )
+
 
 @dataclass(frozen=True)
 class SharedMountStorageInfo:
@@ -38,6 +62,31 @@ class SharedMountStorageInfo:
     name: str
     label: str
     bytes: int
+
+    @classmethod
+    def measure_all(cls, mounts_base: Path | None = None) -> list[SharedMountStorageInfo]:
+        """Measure each shared config mount directory.
+
+        Labels come from the agent roster when available, falling back to
+        a title-cased version of the directory name.
+        """
+        base = mounts_base or mounts_dir()
+        if not base.is_dir():
+            return []
+
+        roster_mounts = AgentRoster.shared().mounts
+        return sorted(
+            (
+                cls(
+                    name=d.name,
+                    label=_mount_label(d.name, roster_mounts),
+                    bytes=_dir_bytes(d),
+                )
+                for d in base.iterdir()
+                if d.is_dir()
+            ),
+            key=lambda m: m.name,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -59,59 +108,3 @@ def _mount_label(name: str, roster_mounts: tuple[MountDef, ...]) -> str:
             return m.label
     # Fallback: "_claude-config" → "Claude config"
     return name.lstrip("_").replace("-", " ").capitalize()
-
-
-# ---------------------------------------------------------------------------
-# Public queries
-# ---------------------------------------------------------------------------
-
-
-def get_task_storage(task_dir: Path) -> TaskStorageInfo:
-    """Measure a single task's disk footprint.
-
-    Expects the standard layout: ``<task_dir>/workspace-dangerous/`` for
-    the agent-writable code, ``<task_dir>/agent-config/`` for per-task
-    configuration.
-    """
-    return TaskStorageInfo(
-        task_id=task_dir.name,
-        workspace_bytes=_dir_bytes(task_dir / "workspace-dangerous"),
-        agent_config_bytes=_dir_bytes(task_dir / "agent-config"),
-    )
-
-
-def get_tasks_storage(tasks_root: Path) -> list[TaskStorageInfo]:
-    """Measure all tasks under *tasks_root*, sorted by task ID."""
-    if not tasks_root.is_dir():
-        return []
-    return sorted(
-        (get_task_storage(d) for d in tasks_root.iterdir() if d.is_dir()),
-        key=lambda t: t.task_id,
-    )
-
-
-def get_shared_mounts_storage(
-    mounts_base: Path | None = None,
-) -> list[SharedMountStorageInfo]:
-    """Measure each shared config mount directory.
-
-    Labels come from the agent roster when available, falling back to
-    a title-cased version of the directory name.
-    """
-    base = mounts_base or mounts_dir()
-    if not base.is_dir():
-        return []
-
-    roster_mounts = get_roster().mounts
-    return sorted(
-        (
-            SharedMountStorageInfo(
-                name=d.name,
-                label=_mount_label(d.name, roster_mounts),
-                bytes=_dir_bytes(d),
-            )
-            for d in base.iterdir()
-            if d.is_dir()
-        ),
-        key=lambda m: m.name,
-    )

--- a/tach.toml
+++ b/tach.toml
@@ -95,7 +95,7 @@ depends_on = [
     "terok_executor.integrations.sandbox",
     "terok_executor.provider.providers",
     "terok_executor.roster.schema",
-    "terok_executor.roster.types",
+    "terok_executor.roster.types", "terok_executor.doctor",
 ]
 
 # Roster package waypoint (re-exports from loader)
@@ -144,8 +144,7 @@ depends_on = [
 # Build resource staging — standalone
 [[modules]]
 path = "terok_executor.container.build"
-depends_on = [
-    "terok_executor.roster.loader",
+depends_on = ["terok_executor.roster",
 ]
 
 # Clone-cache workspace seeding — copies cached clone into task workspace
@@ -178,8 +177,7 @@ depends_on = [
     "terok_executor.integrations.sandbox",
     "terok_executor.paths",
     "terok_executor.provider.agents",
-    "terok_executor.provider.instructions",
-    "terok_executor.roster.loader",
+    "terok_executor.provider.instructions", "terok_executor.roster",
 ]
 
 # ── credentials/ — authentication + vault ────────────────
@@ -213,8 +211,7 @@ path = "terok_executor.credentials.vault_config"
 depends_on = [
     "terok_executor.integrations.sandbox",
     "terok_executor.paths",
-    "terok_executor.roster.loader",
-    "terok_executor.vault_addr",
+    "terok_executor.vault_addr", "terok_executor.roster",
 ]
 
 # Credential proxy CLI commands — wraps sandbox lifecycle + route generation
@@ -223,8 +220,7 @@ path = "terok_executor.credentials.vault_commands"
 depends_on = [
     "terok_executor.credentials.vendor_files",
     "terok_executor.integrations.sandbox",
-    "terok_executor.paths",
-    "terok_executor.roster.loader",
+    "terok_executor.paths", "terok_executor.roster",
 ]
 
 # ── Sandbox bootstrap composition ──────────────────────────────────
@@ -234,8 +230,7 @@ depends_on = [
 [[modules]]
 path = "terok_executor.sandbox"
 depends_on = [
-    "terok_executor.integrations.sandbox",
-    "terok_executor.roster.loader",
+    "terok_executor.integrations.sandbox", "terok_executor.roster",
 ]
 
 # ── ACP host-proxy (per-task aggregator) ──────────────────────────
@@ -262,8 +257,7 @@ depends_on = [
     "terok_executor.credentials.vault_config",
     "terok_executor.integrations.sandbox",
     "terok_executor.paths",
-    "terok_executor.roster.loader",
-    "terok_executor.sandbox",
+    "terok_executor.sandbox", "terok_executor.roster",
 ]
 
 # ── CLI surface ────────────────────────────────────────────────────
@@ -282,7 +276,7 @@ depends_on = [
     "terok_executor.paths",
     "terok_executor.preflight",
     "terok_executor.roster.loader",
-    "terok_executor.sandbox",
+    "terok_executor.sandbox", "terok_executor.roster",
 ]
 
 # Composes the full executor CommandTree (own verbs + sandbox deep
@@ -325,7 +319,6 @@ depends_on = [
     "terok_executor.container.runner",
     "terok_executor.credentials.auth",
     "terok_executor.credentials.vault_commands",
-    "terok_executor.doctor",
     "terok_executor.integrations.sandbox",
     "terok_executor.paths",
     "terok_executor.provider.agents",

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -14,9 +14,8 @@ from terok_executor.doctor import (
     _make_phantom_token_checks,
     _make_ssh_bridge_check,
     _make_vault_bridge_check,
-    agent_doctor_checks,
 )
-from terok_executor.roster import get_roster
+from terok_executor.roster import AgentRoster
 
 TOKEN_BROKER_PORT = 18731
 
@@ -95,7 +94,7 @@ class TestCredentialFileChecks:
     """Known credential file leak detection."""
 
     def test_generates_checks_for_routed_providers(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_credential_file_checks(roster)
         # Should have at least one check for providers with credential_file
         providers_with_cred = [
@@ -106,7 +105,7 @@ class TestCredentialFileChecks:
         assert len(checks) == len(providers_with_cred)
 
     def test_clean_when_file_missing(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_credential_file_checks(roster)
         if checks:
             # rc != 0 with "No such file" stderr means file doesn't exist
@@ -114,7 +113,7 @@ class TestCredentialFileChecks:
             assert verdict.severity == "ok"
 
     def test_warn_on_permission_denied(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_credential_file_checks(roster)
         if checks:
             verdict = checks[0].evaluate(1, "", "cat: /path: Permission denied\n")
@@ -122,7 +121,7 @@ class TestCredentialFileChecks:
             assert "Permission denied" in verdict.detail
 
     def test_error_on_real_key(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_credential_file_checks(roster)
         if checks:
             verdict = checks[0].evaluate(0, '{"api_key": "sk-ant-real-key"}', "")
@@ -130,7 +129,7 @@ class TestCredentialFileChecks:
             assert verdict.fixable is True
 
     def test_clean_on_empty_file(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_credential_file_checks(roster)
         if checks:
             verdict = checks[0].evaluate(0, "", "")
@@ -147,20 +146,20 @@ class TestPhantomTokenChecks:
         assert not _PHANTOM_TOKEN_RE.match("too-short")
 
     def test_generates_checks_for_env_vars(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_phantom_token_checks(roster)
         # Should have at least some checks
         assert len(checks) > 0
 
     def test_ok_for_phantom_token(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_phantom_token_checks(roster)
         if checks:
             verdict = checks[0].evaluate(0, "terok-p-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4\n", "")
             assert verdict.severity == "ok"
 
     def test_warn_for_unrecognised_format(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_phantom_token_checks(roster)
         if checks:
             verdict = checks[0].evaluate(0, "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4\n", "")
@@ -168,14 +167,14 @@ class TestPhantomTokenChecks:
             assert "unrecognised" in verdict.detail
 
     def test_error_for_real_key(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_phantom_token_checks(roster)
         if checks:
             verdict = checks[0].evaluate(0, "sk-ant-api03-real-key-here\n", "")
             assert verdict.severity == "error"
 
     def test_warn_when_unset(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_phantom_token_checks(roster)
         if checks:
             # rc=1 from printenv means var is unset
@@ -183,7 +182,7 @@ class TestPhantomTokenChecks:
             assert verdict.severity == "warn"
 
     def test_no_duplicate_env_vars(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_phantom_token_checks(roster)
         env_vars = [" ".join(c.probe_cmd) for c in checks]
         assert len(env_vars) == len(set(env_vars)), "duplicate env var checks"
@@ -193,17 +192,17 @@ class TestBaseUrlChecks:
     """Base URL override verification."""
 
     def test_generates_checks_tcp(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_base_url_checks(roster, TOKEN_BROKER_PORT)
         assert len(checks) > 0
 
     def test_generates_checks_socket(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_base_url_checks(roster, None)
         assert len(checks) > 0
 
     def test_tcp_ok_when_routed(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_base_url_checks(roster, TOKEN_BROKER_PORT)
         if checks:
             verdict = checks[0].evaluate(
@@ -214,66 +213,66 @@ class TestBaseUrlChecks:
     def test_socket_ok_when_routed(self) -> None:
         from terok_executor.vault_addr import LOOPBACK_VAULT_PORT
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_base_url_checks(roster, None)
         if checks:
             verdict = checks[0].evaluate(0, f"http://localhost:{LOOPBACK_VAULT_PORT}\n", "")
             assert verdict.severity == "ok"
 
     def test_error_when_bypassed(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_base_url_checks(roster, TOKEN_BROKER_PORT)
         if checks:
             verdict = checks[0].evaluate(0, "https://api.anthropic.com\n", "")
             assert verdict.severity == "error"
 
     def test_warn_when_unset(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_base_url_checks(roster, TOKEN_BROKER_PORT)
         if checks:
             verdict = checks[0].evaluate(0, "", "")
             assert verdict.severity == "warn"
 
     def test_no_duplicate_vars(self) -> None:
-        roster = get_roster()
+        roster = AgentRoster.shared()
         checks = _make_base_url_checks(roster, TOKEN_BROKER_PORT)
         vars_checked = [" ".join(c.probe_cmd) for c in checks]
         assert len(vars_checked) == len(set(vars_checked))
 
 
 class TestAgentDoctorChecks:
-    """Integration: agent_doctor_checks() assembly."""
+    """Integration: AgentRoster.doctor_checks() assembly."""
 
     def test_includes_bridge_checks(self) -> None:
-        roster = get_roster()
-        checks = agent_doctor_checks(roster, token_broker_port=TOKEN_BROKER_PORT)
+        roster = AgentRoster.shared()
+        checks = roster.doctor_checks(token_broker_port=TOKEN_BROKER_PORT)
         categories = {c.category for c in checks}
         assert "bridge" in categories
 
     def test_includes_mount_checks(self) -> None:
-        roster = get_roster()
-        checks = agent_doctor_checks(roster, token_broker_port=TOKEN_BROKER_PORT)
+        roster = AgentRoster.shared()
+        checks = roster.doctor_checks(token_broker_port=TOKEN_BROKER_PORT)
         categories = {c.category for c in checks}
         assert "mount" in categories
 
     def test_includes_env_checks(self) -> None:
-        roster = get_roster()
-        checks = agent_doctor_checks(roster, token_broker_port=TOKEN_BROKER_PORT)
+        roster = AgentRoster.shared()
+        checks = roster.doctor_checks(token_broker_port=TOKEN_BROKER_PORT)
         categories = {c.category for c in checks}
         assert "env" in categories
 
     def test_base_url_checks_emitted_in_both_modes(self) -> None:
         """Socket and TCP mode both need base-URL checks — the probe host differs."""
-        roster = get_roster()
-        checks_tcp = agent_doctor_checks(roster, token_broker_port=TOKEN_BROKER_PORT)
-        checks_socket = agent_doctor_checks(roster, token_broker_port=None)
+        roster = AgentRoster.shared()
+        checks_tcp = roster.doctor_checks(token_broker_port=TOKEN_BROKER_PORT)
+        checks_socket = roster.doctor_checks(token_broker_port=None)
         base_url_tcp = [c for c in checks_tcp if "Base URL" in c.label]
         base_url_socket = [c for c in checks_socket if "Base URL" in c.label]
         assert len(base_url_tcp) > 0
         assert len(base_url_socket) > 0
 
     def test_all_are_doctor_check_instances(self) -> None:
-        roster = get_roster()
-        checks = agent_doctor_checks(roster, token_broker_port=TOKEN_BROKER_PORT)
+        roster = AgentRoster.shared()
+        checks = roster.doctor_checks(token_broker_port=TOKEN_BROKER_PORT)
         for check in checks:
             assert isinstance(check, DoctorCheck)

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -18,7 +18,7 @@ from terok_executor.container.env import (
     _shared_config_mounts,
     assemble_container_env,
 )
-from terok_executor.roster import get_roster
+from terok_executor.roster import AgentRoster
 from tests.unit.conftest import TEST_VAULT_PASSPHRASE
 
 
@@ -72,7 +72,7 @@ def _make_vault_db_with_ssh_keys(tmp_path: Path, scope: str = "myproj"):
 @pytest.fixture
 def roster():
     """Return the live agent roster (loaded from bundled YAML)."""
-    return get_roster()
+    return AgentRoster.shared()
 
 
 @pytest.fixture

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -85,7 +85,9 @@ def test_handle_agents_set_writes_through_config_view() -> None:
     from pathlib import Path
 
     with (
-        mock.patch("terok_executor.commands.validate_agent_selection", return_value=None),
+        mock.patch(
+            "terok_executor.roster.loader.AgentRoster.validate_selection", return_value=None
+        ),
         mock.patch(
             "terok_executor.config_schema.ExecutorConfigView.set_image_agents",
             return_value=Path("/tmp/cfg.yml"),

--- a/tests/unit/test_headless_providers.py
+++ b/tests/unit/test_headless_providers.py
@@ -11,7 +11,6 @@ from terok_executor.provider.agents import _generate_claude_wrapper
 from terok_executor.provider.providers import (
     AGENT_PROVIDERS,
     PROVIDER_NAMES,
-    collect_all_auto_approve_env,
     get_provider,
     resolve_provider_value,
 )
@@ -21,6 +20,7 @@ from terok_executor.provider.wrappers import (
     generate_agent_wrapper,
     generate_all_wrappers,
 )
+from terok_executor.roster import AgentRoster
 from tests.constants import CONTAINER_INSTRUCTIONS_PATH, CONTAINER_TEROK_DIR
 
 
@@ -350,7 +350,7 @@ class TestGenerateAllWrappers:
 
     def test_collect_all_auto_approve_env(self) -> None:
         """The merged auto-approve env map contains all provider env vars."""
-        merged = collect_all_auto_approve_env()
+        merged = AgentRoster.shared().collect_all_auto_approve_env()
         assert merged["OPENCODE_PERMISSION"] == '{"*":"allow"}'
         # VIBE_BYPASS_TOOL_PERMISSIONS is the real Vibe field
         # (vibe.core.config._settings.VibeConfig.bypass_tool_permissions;

--- a/tests/unit/test_image_builder.py
+++ b/tests/unit/test_image_builder.py
@@ -113,22 +113,22 @@ def test_render_l0_uses_self_base_and_family() -> None:
     fn.assert_called_once_with("fedora:44", family="rpm")
 
 
-def test_render_l1_threads_resolved_family_and_args() -> None:
-    """``render_l1`` resolves family from the base when ``family`` is None."""
-    builder = ImageBuilder("fedora:44")  # family=None — auto-detect
+def test_render_l1_takes_explicit_family() -> None:
+    """``render_l1`` is a staticmethod — family must be passed explicitly."""
     with mock.patch("terok_executor.container.build.render_l1", return_value="L1 dockerfile") as fn:
-        result = builder.render_l1("l0-tag", agents=("claude",), cache_bust="42")
+        result = ImageBuilder.render_l1("l0-tag", family="rpm", agents=("claude",), cache_bust="42")
     assert result == "L1 dockerfile"
     fn.assert_called_once_with("l0-tag", family="rpm", agents=("claude",), cache_bust="42")
 
 
-def test_render_l1_sidecar_threads_self_state() -> None:
-    """``render_l1_sidecar`` passes family + tool_name to the underlying fn."""
-    builder = ImageBuilder("fedora:44", family="rpm")
+def test_render_l1_sidecar_takes_explicit_family() -> None:
+    """``render_l1_sidecar`` is a staticmethod — family must be passed explicitly."""
     with mock.patch(
         "terok_executor.container.build.render_l1_sidecar", return_value="sidecar"
     ) as fn:
-        result = builder.render_l1_sidecar("l0-tag", tool_name="ruff", cache_bust="7")
+        result = ImageBuilder.render_l1_sidecar(
+            "l0-tag", family="rpm", tool_name="ruff", cache_bust="7"
+        )
     assert result == "sidecar"
     fn.assert_called_once_with("l0-tag", family="rpm", tool_name="ruff", cache_bust="7")
 

--- a/tests/unit/test_krun.py
+++ b/tests/unit/test_krun.py
@@ -19,9 +19,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from terok_executor.krun import (
+    KrunHost,
     KrunHostKeypair,
     ensure_krun_host_keypair,
-    make_krun_runtime,
 )
 
 
@@ -299,8 +299,8 @@ class TestWriteAtomic:
         assert leftovers == [], f"stranded tmp files: {leftovers}"
 
 
-class TestMakeKrunRuntime:
-    """`make_krun_runtime` wires the vault key into a TcpSSHTransport-backed runtime."""
+class TestKrunHostRuntime:
+    """`KrunHost.runtime()` wires the vault key into a TcpSSHTransport-backed runtime."""
 
     def test_returns_krun_runtime_with_tcp_transport(self, tmp_path: Path, _vault_backed) -> None:
         """Production factory: KrunRuntime + TcpSSHTransport, identity from %host."""
@@ -312,7 +312,7 @@ class TestMakeKrunRuntime:
         runtime_dir = tmp_path / "runtime"
         with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=runtime_dir):
             runtime_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
-            rt = make_krun_runtime(cfg=_vault_backed)
+            rt = KrunHost(cfg=_vault_backed).runtime()
 
         assert isinstance(rt, KrunRuntime)
         assert isinstance(rt.transport, TcpSSHTransport)
@@ -320,8 +320,8 @@ class TestMakeKrunRuntime:
         assert isinstance(rt._podman, PodmanRuntime)
 
 
-class TestKrunLaunchArgs:
-    """`krun_launch_args` collects the four things that reach across the
+class TestKrunHostLaunchArgs:
+    """`KrunHost.launch_args()` collects the four things that reach across the
     orchestrator/runtime boundary into executor's domain — the host-pubkey
     bind-mount, the init-script gate env var, the USER-directive override,
     and the pasta DNS forwarder — so terok doesn't have to know the
@@ -330,12 +330,10 @@ class TestKrunLaunchArgs:
     def test_emits_pubkey_bind_mount_with_shared_selinux_relabel(
         self, tmp_path: Path, _vault_backed
     ) -> None:
-        from terok_executor.krun import krun_launch_args
-
         runtime_dir = tmp_path / "runtime"
         with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=runtime_dir):
             runtime_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
-            args = krun_launch_args(cfg=_vault_backed)
+            args = KrunHost(cfg=_vault_backed).launch_args()
 
         v_idx = args.index("-v")
         spec = args[v_idx + 1]
@@ -348,21 +346,17 @@ class TestKrunLaunchArgs:
         assert ",Z" not in spec and ":Z" not in spec
 
     def test_emits_runtime_signal_env_var(self, tmp_path: Path, _vault_backed) -> None:
-        from terok_executor.krun import krun_launch_args
-
         with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
             tmp_path.chmod(0o700)
-            args = krun_launch_args(cfg=_vault_backed)
+            args = KrunHost(cfg=_vault_backed).launch_args()
 
         env_assignments = [args[i + 1] for i, t in enumerate(args) if t == "-e"]
         assert "TEROK_CONTAINER_RUNTIME=krun" in env_assignments
 
     def test_overrides_image_user_to_root(self, tmp_path: Path, _vault_backed) -> None:
-        from terok_executor.krun import krun_launch_args
-
         with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
             tmp_path.chmod(0o700)
-            args = krun_launch_args(cfg=_vault_backed)
+            args = KrunHost(cfg=_vault_backed).launch_args()
 
         user_idx = args.index("--user")
         assert args[user_idx + 1] == "root"
@@ -375,11 +369,23 @@ class TestKrunLaunchArgs:
         ``terok_shield.nft.constants``).  Hardcoded by design — anything
         else either gets dropped by shield or isn't routable from the guest.
         """
-        from terok_executor.krun import krun_launch_args
-
         with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
             tmp_path.chmod(0o700)
-            args = krun_launch_args(cfg=_vault_backed)
+            args = KrunHost(cfg=_vault_backed).launch_args()
 
         dns_idx = args.index("--dns")
         assert args[dns_idx + 1] == "169.254.1.1"
+
+    def test_keypair_loaded_once_across_runtime_and_launch_args(
+        self, tmp_path: Path, _vault_backed
+    ) -> None:
+        """``runtime()`` + ``launch_args()`` on the same host open the vault once."""
+        with patch("terok_executor.krun._ensure_safe_runtime_dir", return_value=tmp_path):
+            tmp_path.chmod(0o700)
+            host = KrunHost(cfg=_vault_backed)
+            with patch(
+                "terok_executor.krun.ensure_krun_host_keypair", wraps=ensure_krun_host_keypair
+            ) as spy:
+                host.runtime()
+                host.launch_args()
+        assert spy.call_count == 1

--- a/tests/unit/test_roster.py
+++ b/tests/unit/test_roster.py
@@ -14,10 +14,11 @@ from pydantic import ValidationError
 from terok_executor.credentials.auth import AuthProvider
 from terok_executor.provider.providers import AgentProvider
 from terok_executor.roster import (
+    AgentRoster,
     SidecarSpec,
     load_roster,
 )
-from terok_executor.roster.loader import _load_bundled_agents, parse_agent_selection
+from terok_executor.roster.loader import _load_bundled_agents
 from terok_executor.roster.schema import RawAgentYaml
 
 
@@ -565,31 +566,31 @@ class TestParseAgentSelection:
     ``resolve_selection`` consumes."""
 
     def test_all_passes_through(self) -> None:
-        assert parse_agent_selection("all") == "all"
+        assert AgentRoster.parse_selection("all") == "all"
 
     def test_empty_string_collapses_to_all(self) -> None:
-        assert parse_agent_selection("") == "all"
-        assert parse_agent_selection("   ") == "all"
+        assert AgentRoster.parse_selection("") == "all"
+        assert AgentRoster.parse_selection("   ") == "all"
 
     def test_comma_list_becomes_tuple(self) -> None:
-        assert parse_agent_selection("claude,codex") == ("claude", "codex")
+        assert AgentRoster.parse_selection("claude,codex") == ("claude", "codex")
 
     def test_preserves_exclude_prefix(self) -> None:
-        assert parse_agent_selection("claude,-vibe") == ("claude", "-vibe")
+        assert AgentRoster.parse_selection("claude,-vibe") == ("claude", "-vibe")
 
     def test_bare_exclude_kept_as_single_token(self) -> None:
-        assert parse_agent_selection("-vibe") == ("-vibe",)
+        assert AgentRoster.parse_selection("-vibe") == ("-vibe",)
 
     def test_all_and_exclude_combine(self) -> None:
-        assert parse_agent_selection("all,-vibe") == ("all", "-vibe")
+        assert AgentRoster.parse_selection("all,-vibe") == ("all", "-vibe")
 
     def test_case_folded_and_whitespace_stripped(self) -> None:
-        assert parse_agent_selection(" Claude , -VIBE ") == ("claude", "-vibe")
+        assert AgentRoster.parse_selection(" Claude , -VIBE ") == ("claude", "-vibe")
 
     def test_end_to_end_roundtrip_through_resolve(self) -> None:
         """The CLI/config string ``"-vibe"`` should install everything except vibe."""
         reg = load_roster()
-        selection = parse_agent_selection("-vibe")
+        selection = AgentRoster.parse_selection("-vibe")
         full = set(reg.resolve_selection("all"))
         assert set(reg.resolve_selection(selection)) == full - {"vibe"}
 

--- a/tests/unit/test_setup_flow.py
+++ b/tests/unit/test_setup_flow.py
@@ -127,7 +127,7 @@ class TestHandleUninstall:
 def compose_spies():
     """Patch the two targets ``ensure_sandbox_ready`` composes: routes + aggregator."""
     with (
-        patch("terok_executor.roster.loader.ensure_vault_routes") as routes,
+        patch("terok_executor.roster.loader.AgentRoster.ensure_vault_routes") as routes,
         patch("terok_executor.integrations.sandbox._handle_sandbox_setup") as aggregator,
     ):
         yield routes, aggregator
@@ -144,7 +144,9 @@ class TestEnsureSandboxReady:
     def test_generates_routes_before_sandbox_setup(self, compose_spies) -> None:
         routes, aggregator = compose_spies
         order: list[str] = []
-        routes.side_effect = lambda cfg: order.append("routes")
+        # ``ensure_vault_routes`` is now a bound method, so the patched mock
+        # receives ``self`` as first positional — accept-and-discard.
+        routes.side_effect = lambda *_a, **_k: order.append("routes")
         aggregator.side_effect = lambda **_: order.append("sandbox")
         ensure_sandbox_ready()
         assert order == ["routes", "sandbox"]

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -16,11 +16,10 @@ import pytest
 
 from terok_executor.roster.loader import MountDef
 from terok_executor.storage import (
+    SharedMountStorageInfo,
+    TaskStorageInfo,
     _dir_bytes,
     _mount_label,
-    get_shared_mounts_storage,
-    get_task_storage,
-    get_tasks_storage,
 )
 
 # ---------------------------------------------------------------------------
@@ -120,17 +119,17 @@ class TestGetTaskStorage:
     """Measuring a single task directory."""
 
     def test_measures_workspace_and_config(self, task_tree: Path):
-        info = get_task_storage(task_tree)
+        info = TaskStorageInfo.measure(task_tree)
         assert info.workspace_bytes == 150
         assert info.agent_config_bytes == 30
         assert info.total_bytes == 180
 
     def test_task_id_from_dirname(self, task_tree: Path):
-        info = get_task_storage(task_tree)
+        info = TaskStorageInfo.measure(task_tree)
         assert info.task_id == task_tree.name
 
     def test_missing_subdirs_yield_zero(self, tmp_path: Path):
-        info = get_task_storage(tmp_path)
+        info = TaskStorageInfo.measure(tmp_path)
         assert info.total_bytes == 0
 
 
@@ -143,17 +142,17 @@ class TestGetTasksStorage:
     """Bulk measurement across all task directories."""
 
     def test_finds_both_tasks(self, tasks_root: Path):
-        results = get_tasks_storage(tasks_root)
+        results = TaskStorageInfo.measure_all(tasks_root)
         assert len(results) == 2
         assert results[0].task_id == "aaa111"
         assert results[1].task_id == "bbb222"
 
     def test_each_task_has_bytes(self, tasks_root: Path):
-        results = get_tasks_storage(tasks_root)
+        results = TaskStorageInfo.measure_all(tasks_root)
         assert all(t.total_bytes > 0 for t in results)
 
     def test_missing_root_returns_empty(self):
-        assert get_tasks_storage(Path("/nonexistent")) == []
+        assert TaskStorageInfo.measure_all(Path("/nonexistent")) == []
 
 
 # ---------------------------------------------------------------------------
@@ -169,9 +168,9 @@ class TestGetSharedMountsStorage:
             MountDef("_claude-config", "/home/dev/.claude", "Claude"),
             MountDef("_codex-config", "/home/dev/.codex", "Codex"),
         )
-        with patch("terok_executor.storage.get_roster") as mock_roster:
+        with patch("terok_executor.storage.AgentRoster.shared") as mock_roster:
             mock_roster.return_value.mounts = roster_mounts
-            results = get_shared_mounts_storage(mounts_tree)
+            results = SharedMountStorageInfo.measure_all(mounts_tree)
 
         assert len(results) == 2
         claude = next(m for m in results if m.name == "_claude-config")
@@ -179,12 +178,12 @@ class TestGetSharedMountsStorage:
         assert claude.bytes == 3  # "abc"
 
     def test_missing_base_returns_empty(self):
-        with patch("terok_executor.storage.get_roster"):
-            assert get_shared_mounts_storage(Path("/nonexistent")) == []
+        with patch("terok_executor.storage.AgentRoster.shared"):
+            assert SharedMountStorageInfo.measure_all(Path("/nonexistent")) == []
 
     def test_sorted_by_name(self, mounts_tree: Path):
-        with patch("terok_executor.storage.get_roster") as mock_roster:
+        with patch("terok_executor.storage.AgentRoster.shared") as mock_roster:
             mock_roster.return_value.mounts = ()
-            results = get_shared_mounts_storage(mounts_tree)
+            results = SharedMountStorageInfo.measure_all(mounts_tree)
         names = [m.name for m in results]
         assert names == sorted(names)

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
-from terok_executor.roster import VaultRoute, get_roster
+from terok_executor.roster import AgentRoster, VaultRoute
 from terok_executor.roster.schema import RawAgentYaml
 from tests.unit.conftest import TEST_VAULT_PASSPHRASE
 
@@ -72,7 +72,7 @@ class TestVaultRoutesParsed:
 
     def test_claude_route_exists(self) -> None:
         """Claude has a vault route with Anthropic upstream and OAuth support."""
-        reg = get_roster()
+        reg = AgentRoster.shared()
         route = reg.vault_routes.get("claude")
         assert route is not None
         assert route.route_prefix == "claude"
@@ -86,7 +86,7 @@ class TestVaultRoutesParsed:
 
     def test_codex_route_exists(self) -> None:
         """Codex has a vault route with OpenAI + ChatGPT upstreams."""
-        route = get_roster().vault_routes.get("codex")
+        route = AgentRoster.shared().vault_routes.get("codex")
         assert route is not None
         assert route.upstream == "https://api.openai.com"
         assert route.path_upstreams == {"/backend-api/": "https://chatgpt.com"}
@@ -96,14 +96,14 @@ class TestVaultRoutesParsed:
 
     def test_gh_route_exists(self) -> None:
         """GitHub CLI has a vault route with token-style auth."""
-        route = get_roster().vault_routes.get("gh")
+        route = AgentRoster.shared().vault_routes.get("gh")
         assert route is not None
         assert route.auth_prefix == "token "
         assert route.upstream == "https://api.github.com"
 
     def test_glab_route_exists(self) -> None:
         """GitLab CLI has a vault route with PRIVATE-TOKEN header."""
-        route = get_roster().vault_routes.get("glab")
+        route = AgentRoster.shared().vault_routes.get("glab")
         assert route is not None
         assert route.auth_header == "PRIVATE-TOKEN"
         assert route.auth_prefix == ""
@@ -112,14 +112,14 @@ class TestVaultRoutesParsed:
     def test_api_key_only_providers_have_no_oauth_phantom_env(self) -> None:
         """Providers without OAuth support have empty oauth_phantom_env."""
         for name in ("vibe", "blablador", "kisski"):
-            route = get_roster().vault_routes.get(name)
+            route = AgentRoster.shared().vault_routes.get(name)
             assert route is not None, f"{name} missing vault route"
             assert route.oauth_phantom_env == {}, f"{name} should have no oauth_phantom_env"
             assert route.socket_env == "", f"{name} should have no socket_env"
 
     def test_opencode_agents_have_routes(self) -> None:
         """Blablador and KISSKI have vault routes."""
-        reg = get_roster()
+        reg = AgentRoster.shared()
         for name in ("blablador", "kisski"):
             route = reg.vault_routes.get(name)
             assert route is not None, f"{name} missing vault route"
@@ -127,11 +127,11 @@ class TestVaultRoutesParsed:
 
     def test_copilot_has_no_route(self) -> None:
         """Copilot has no vault section (tier-3, no base URL support)."""
-        assert get_roster().vault_routes.get("copilot") is None
+        assert AgentRoster.shared().vault_routes.get("copilot") is None
 
     def test_claude_has_oauth_refresh(self) -> None:
         """Claude has oauth_refresh config for proactive token refresh."""
-        route = get_roster().vault_routes.get("claude")
+        route = AgentRoster.shared().vault_routes.get("claude")
         assert route is not None
         assert route.oauth_refresh is not None
         assert "token_url" in route.oauth_refresh
@@ -139,7 +139,7 @@ class TestVaultRoutesParsed:
 
     def test_codex_has_oauth_refresh(self) -> None:
         """Codex has an oauth_refresh block so vault can rotate tokens in the background."""
-        route = get_roster().vault_routes.get("codex")
+        route = AgentRoster.shared().vault_routes.get("codex")
         assert route is not None
         assert route.oauth_refresh is not None
         assert route.oauth_refresh["token_url"] == "https://auth.openai.com/oauth/token"
@@ -151,18 +151,18 @@ class TestSharedDomain:
 
     def test_default_is_false(self) -> None:
         """API-only upstreams (claude, codex, gh, …) leave the flag unset."""
-        roster = get_roster()
+        roster = AgentRoster.shared()
         for name in ("claude", "codex", "gh", "vibe", "blablador", "kisski", "openrouter"):
             route = roster.vault_routes[name]
             assert route.shared_domain is False, f"{name} should not be shared_domain"
 
     def test_glab_is_shared_domain(self) -> None:
         """gitlab.com hosts both API and ``git push`` traffic."""
-        assert get_roster().vault_routes["glab"].shared_domain is True
+        assert AgentRoster.shared().vault_routes["glab"].shared_domain is True
 
     def test_sonar_is_shared_domain(self) -> None:
         """sonarcloud.io hosts API + project pages + docs + badges."""
-        assert get_roster().vault_routes["sonar"].shared_domain is True
+        assert AgentRoster.shared().vault_routes["sonar"].shared_domain is True
 
     def test_unknown_provider_defaults_to_false(self) -> None:
         """Hand-rolled vault sections without the field default to False."""
@@ -194,7 +194,7 @@ class TestGenerateRoutesJson:
 
     def test_generates_valid_json(self) -> None:
         """generate_routes_json() produces parseable JSON with expected keys."""
-        routes_json = get_roster().generate_routes_json()
+        routes_json = AgentRoster.shared().generate_routes_json()
         routes = json.loads(routes_json)
         assert "claude" in routes
         assert routes["claude"]["upstream"] == "https://api.anthropic.com"
@@ -205,24 +205,24 @@ class TestGenerateRoutesJson:
 
     def test_all_routes_have_upstream(self) -> None:
         """Every route in the JSON has an upstream field."""
-        routes = json.loads(get_roster().generate_routes_json())
+        routes = json.loads(AgentRoster.shared().generate_routes_json())
         for prefix, cfg in routes.items():
             assert "upstream" in cfg, f"Route '{prefix}' missing upstream"
 
     def test_glab_keyed_by_provider_name(self) -> None:
         """GitLab route is keyed by provider name 'glab'."""
-        routes = json.loads(get_roster().generate_routes_json())
+        routes = json.loads(AgentRoster.shared().generate_routes_json())
         assert "glab" in routes
 
     def test_claude_routes_json_includes_oauth_refresh(self) -> None:
         """Claude's routes.json entry includes oauth_refresh config."""
-        routes = json.loads(get_roster().generate_routes_json())
+        routes = json.loads(AgentRoster.shared().generate_routes_json())
         assert "oauth_refresh" in routes["claude"]
         assert routes["claude"]["oauth_refresh"]["client_id"]
 
     def test_gh_routes_json_omits_oauth_refresh(self) -> None:
         """Providers without oauth_refresh omit it from routes.json."""
-        routes = json.loads(get_roster().generate_routes_json())
+        routes = json.loads(AgentRoster.shared().generate_routes_json())
         assert "oauth_refresh" not in routes["gh"]
 
 
@@ -237,10 +237,10 @@ class TestScanLeakedCredentials:
 
     def test_detects_nonempty_credential_file(self, tmp_path) -> None:
         """Returns (provider, path) when a credential file is present and non-empty."""
-        from terok_executor import get_roster
+        from terok_executor import AgentRoster
         from terok_executor.credentials.vault_commands import scan_leaked_credentials
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         auth = roster.auth_providers.get("claude")
         route = roster.vault_routes.get("claude")
         assert auth is not None and route is not None
@@ -256,10 +256,10 @@ class TestScanLeakedCredentials:
 
     def test_skips_empty_files(self, tmp_path) -> None:
         """Empty credential files are not flagged."""
-        from terok_executor import get_roster
+        from terok_executor import AgentRoster
         from terok_executor.credentials.vault_commands import scan_leaked_credentials
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         auth = roster.auth_providers["claude"]
         route = roster.vault_routes["claude"]
 
@@ -281,7 +281,7 @@ class TestScanLeakedCredentials:
         mock_route.credential_file = ""
         mock_roster.vault_routes = {"fake-provider": mock_route}
         mock_roster.auth_providers = {"fake-provider": MagicMock(host_dir_name="_fake")}
-        monkeypatch.setattr("terok_executor.roster.loader.get_roster", lambda: mock_roster)
+        monkeypatch.setattr("terok_executor.roster.loader._shared_roster", lambda: mock_roster)
 
         assert scan_leaked_credentials(tmp_path) == []
 
@@ -289,10 +289,10 @@ class TestScanLeakedCredentials:
         """The clean handler removes detected credential files."""
         from unittest.mock import patch
 
-        from terok_executor import get_roster
+        from terok_executor import AgentRoster
         from terok_executor.credentials.vault_commands import _handle_clean
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         auth = roster.auth_providers["claude"]
         route = roster.vault_routes["claude"]
 
@@ -706,11 +706,11 @@ class TestScanSkipsInjectedFile:
 
     def test_skips_injected_credentials(self, tmp_path: Path) -> None:
         """Injected phantom credentials are NOT flagged as leaked."""
-        from terok_executor import get_roster
+        from terok_executor import AgentRoster
         from terok_executor.credentials.auth import PHANTOM_CREDENTIALS_MARKER
         from terok_executor.credentials.vault_commands import scan_leaked_credentials
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         auth = roster.auth_providers["claude"]
         route = roster.vault_routes["claude"]
 
@@ -729,10 +729,10 @@ class TestScanSkipsInjectedFile:
 
     def test_still_detects_real_credentials(self, tmp_path: Path) -> None:
         """Real OAuth tokens are still flagged even when file structure matches."""
-        from terok_executor import get_roster
+        from terok_executor import AgentRoster
         from terok_executor.credentials.vault_commands import scan_leaked_credentials
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         auth = roster.auth_providers["claude"]
         route = roster.vault_routes["claude"]
 
@@ -749,10 +749,10 @@ class TestScanSkipsInjectedFile:
         """Injected shared Codex auth.json is NOT flagged as leaked."""
         from terok_sandbox import CODEX_SHARED_OAUTH_MARKER
 
-        from terok_executor import get_roster
+        from terok_executor import AgentRoster
         from terok_executor.credentials.vault_commands import scan_leaked_credentials
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         auth = roster.auth_providers["codex"]
         route = roster.vault_routes["codex"]
 
@@ -773,10 +773,10 @@ class TestScanSkipsInjectedFile:
         """Marker tokens do not hide a live top-level OPENAI_API_KEY."""
         from terok_sandbox import CODEX_SHARED_OAUTH_MARKER
 
-        from terok_executor import get_roster
+        from terok_executor import AgentRoster
         from terok_executor.credentials.vault_commands import scan_leaked_credentials
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         auth = roster.auth_providers["codex"]
         route = roster.vault_routes["codex"]
 
@@ -796,10 +796,10 @@ class TestScanSkipsInjectedFile:
 
     def test_malformed_codex_auth_json_is_suspicious_not_crashing(self, tmp_path: Path) -> None:
         """Non-object auth.json roots are treated as leaks, not parser crashes."""
-        from terok_executor import get_roster
+        from terok_executor import AgentRoster
         from terok_executor.credentials.vault_commands import scan_leaked_credentials
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         auth = roster.auth_providers["codex"]
         route = roster.vault_routes["codex"]
 
@@ -817,11 +817,11 @@ class TestCleanSkipsInjectedFile:
         """Clean removes real leaks but preserves injected phantom credentials."""
         from unittest.mock import patch
 
-        from terok_executor import get_roster
+        from terok_executor import AgentRoster
         from terok_executor.credentials.auth import PHANTOM_CREDENTIALS_MARKER
         from terok_executor.credentials.vault_commands import _handle_clean
 
-        roster = get_roster()
+        roster = AgentRoster.shared()
         auth = roster.auth_providers["claude"]
         route = roster.vault_routes["claude"]
 
@@ -978,16 +978,14 @@ class TestToVaultRoute:
 
 
 class TestEnsureVaultRoutes:
-    """Verify ensure_vault_routes writes routes.json to disk."""
+    """Verify AgentRoster.ensure_vault_routes writes routes.json to disk."""
 
     def test_writes_routes_json(self, tmp_path):
         """ensure_vault_routes() creates a valid routes.json file."""
         mock_cfg = MagicMock()
         mock_cfg.routes_path = tmp_path / "proxy" / "routes.json"
 
-        from terok_executor.roster import ensure_vault_routes
-
-        path = ensure_vault_routes(cfg=mock_cfg)
+        path = AgentRoster.shared().ensure_vault_routes(cfg=mock_cfg)
 
         assert path == mock_cfg.routes_path
         assert path.is_file()
@@ -1004,9 +1002,7 @@ class TestEnsureVaultRoutes:
         mock_cfg.routes_path = tmp_path / "proxy" / "routes.json"
         monkeypatch.setattr(terok_sandbox, "SandboxConfig", lambda: mock_cfg)
 
-        from terok_executor.roster import ensure_vault_routes
-
-        path = ensure_vault_routes()
+        path = AgentRoster.shared().ensure_vault_routes()
         assert path.is_file()
 
 

--- a/tests/unit/test_vault_scan_warning.py
+++ b/tests/unit/test_vault_scan_warning.py
@@ -52,7 +52,7 @@ class TestScanLeakedCredentialsWarnsOnSkip:
         # The codex provider's mount dir is intentionally absent → lstat raises.
 
         with (
-            patch("terok_executor.roster.loader.get_roster", return_value=roster),
+            patch("terok_executor.roster.loader._shared_roster", return_value=roster),
             patch(
                 "terok_executor.credentials.vault_commands._is_injected_credentials_file",
                 return_value=False,


### PR DESCRIPTION
## Summary

Continues W5 OO consolidation from #368. Free functions clustered around an existing data structure fold onto it as methods.

- **AgentRoster** absorbs `get_roster`, `parse_agent_selection`, `validate_agent_selection`, `prompt_agents_selection`, `ensure_vault_routes`, `agent_doctor_checks` (as `shared`, `parse_selection`, `validate_selection`, `prompt_selection`, `ensure_vault_routes`, `doctor_checks`). Duplicate `collect_all_auto_approve_env` free fn removed.
- **TaskStorageInfo / SharedMountStorageInfo** gain `measure` / `measure_all` classmethods; the three `get_*_storage` free fns are removed.
- **KrunHost** new class bundles `ensure_krun_host_keypair` + `make_krun_runtime` + `krun_launch_args`. One instance per launch caches the vault-backed keypair so `runtime()` + `launch_args()` open the vault once instead of twice.
- **ImageBuilder.render_l1 / render_l1_sidecar** become `@staticmethod` taking `family=` explicitly. Removes the `ImageBuilder("placeholder", ...)` wart from the terok shim. `render_l0` stays an instance method (it uses `self.base_image`).

## Public-API impact

Net -11 names. Removed: `get_roster`, `parse_agent_selection`, `ensure_vault_routes`, `prompt_agents_selection`, `validate_agent_selection`, `agent_doctor_checks`, `collect_all_auto_approve_env`, `get_task_storage`, `get_tasks_storage`, `get_shared_mounts_storage`, `make_krun_runtime`, `krun_launch_args`. Added: `KrunHost`.

The terok shim layer (`terok.lib.integrations.executor`) absorbs the rename so existing terok callers keep working without immediate churn. The shim layer is scheduled for removal in a follow-up.

## Test plan

- [x] `make check` (980 unit tests pass, tach + lint + reuse + bandit + docstrings + vulture clean)
- [ ] CI: GitHub Actions
- [ ] CodeRabbit + SonarCloud review