### PR TITLE
feat: codex emits OPENAI_API_KEY phantom for env-var consumers

### DIFF
--- a/src/terok_executor/resources/agents/codex.yaml
+++ b/src/terok_executor/resources/agents/codex.yaml
@@ -45,6 +45,15 @@ vault:
     toml_set:
       openai_base_url: "{vault_url}/v1"
       chatgpt_base_url: "{vault_url}/backend-api/"
+  # Codex itself reads its bearer from ``auth.json`` + the patched
+  # ``config.toml``, not from env.  These phantom env vars are emitted
+  # for env-var-only consumers (e.g. Pi) so that any other agent in the
+  # same container can route through the vault using the OAuth phantom
+  # token under OpenAI's standard env-var name.
+  phantom_env:
+    OPENAI_API_KEY: true
+  oauth_phantom_env:
+    OPENAI_API_KEY: true
   # OAuth refresh -- endpoint, client_id, and grant shape extracted from the
   # Codex CLI source (codex-rs/login/src/auth/manager.rs v0.123.0).  The CLI
   # itself can be redirected at its own refresh attempts via the


### PR DESCRIPTION
## Summary

- `codex.yaml`'s vault route previously emitted no env-var phantom — it routes the codex CLI exclusively via the mounted `auth.json` credential file + `shared_config_patch` that rewrites `openai_base_url` in `config.toml`. Net effect: any env-var-only consumer in the same container (e.g. Pi from terok-ai/terok-executor#370) never sees an OpenAI bearer even with codex co-installed.
- This PR adds `phantom_env: {OPENAI_API_KEY: true}` and `oauth_phantom_env: {OPENAI_API_KEY: true}` so the phantom token is also exported under OpenAI's standard env-var name. The codex CLI itself doesn't read `OPENAI_API_KEY` from env (its auth path is `auth.json` + `config.toml`), so its behavior is unchanged.

Same pattern as `claude.yaml`'s `phantom_env: {ANTHROPIC_API_KEY: true}` + `oauth_phantom_env: {CLAUDE_CODE_OAUTH_TOKEN: true}` twin entries.

## Test plan

- [x] `make lint` clean
- [x] `tests/unit/test_roster.py` + `tests/unit/test_headless_providers.py` green
- [ ] Manual: with both `codex` and `pi` installed and a valid Codex OAuth credential in the vault, confirm Pi's OpenAI requests reach the vault and return a response — to be validated on the test machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)