### PR TITLE
refactor: split auth container into caller-driven AuthSession

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.0.149a25"
+version = "0.0.149a26"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -60,7 +60,13 @@ from .container.inject import inject_prompt
 from .container.runner import AgentRunner
 
 # -- Credentials (auth flows, extractors, vault commands) ----------------------
-from .credentials.auth import AUTH_PROVIDERS, Authenticator
+from .credentials.auth import (
+    AUTH_PROVIDERS,
+    Authenticator,
+    AuthSession,
+    prepare_oauth_session,
+    store_api_key,
+)
 from .credentials.vault_commands import VAULT_COMMANDS, scan_leaked_credentials
 
 # -- Krun (KVM-microVM) provisioning + runtime factory -----------------------
@@ -126,6 +132,9 @@ __all__ = [
     # Auth
     "AUTH_PROVIDERS",
     "Authenticator",
+    "AuthSession",
+    "prepare_oauth_session",
+    "store_api_key",
     # Instructions
     "bundled_default_instructions",
     "resolve_instructions",

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -174,6 +175,41 @@ class Authenticator:
             image=image,
             expose_token=expose_token,
             oauth_enabled=oauth_enabled,
+        )
+
+    def prepare_oauth(
+        self,
+        project_id: str | None,
+        *,
+        mounts_dir: Path,
+        image: str,
+        expose_token: bool = False,
+        credential_set: str = "default",
+    ) -> AuthSession:
+        """Build an [`AuthSession`][terok_executor.AuthSession] without running it.
+
+        Frontends that own their own UI loop (e.g. the terok Textual TUI,
+        which wants to dispatch the OAuth container into a new terminal
+        tab or via tmux instead of inline) build the session here, run
+        ``session.argv`` however they like, then call ``session.capture()``
+        on success.  The CLI's blocking ``authenticate`` path is just
+        another such caller — see ``_run_auth_container``.
+        """
+        info = AUTH_PROVIDERS.get(self.provider)
+        if not info:
+            available = ", ".join(AUTH_PROVIDERS)
+            raise SystemExit(f"Unknown auth provider: {self.provider}. Available: {available}")
+        if not info.supports_oauth:
+            raise SystemExit(
+                f"Provider {self.provider!r} does not support OAuth — use store_api_key() instead."
+            )
+        return prepare_oauth_session(
+            info,
+            project_id,
+            mounts_dir=mounts_dir,
+            image=image,
+            expose_token=expose_token,
+            credential_set=credential_set,
         )
 
 
@@ -354,6 +390,163 @@ def _prompt_api_key(info: AuthProvider) -> str:
     return key
 
 
+@dataclass
+class AuthSession:
+    """A prepared-but-not-run OAuth auth container session.
+
+    Built by [`Authenticator.prepare_oauth`][terok_executor.Authenticator.prepare_oauth]
+    (or the module-level [`prepare_oauth_session`][terok_executor.prepare_oauth_session]
+    helper).  Hold-don't-call: the caller is responsible for running
+    ``argv`` (synchronously, in a new terminal tab, suspended TUI, etc.)
+    and calling ``capture()`` afterwards.  Use as a context manager so
+    the temp dir and any dangling container are cleaned up on exit.
+    """
+
+    provider: AuthProvider
+    """Provider descriptor (label, banner hint, mount points)."""
+
+    project_id: str | None
+    """Project scope for the banner; ``None`` for host-wide auth."""
+
+    container_name: str
+    """Podman container name (used for cleanup and ``-it`` log clarity)."""
+
+    argv: list[str]
+    """The ``podman run …`` command line — run this however you like."""
+
+    banner: str
+    """Banner text to display before launching ``argv``."""
+
+    auth_dir: Path
+    """Temp dir bind-mounted as the container's auth config target.
+
+    Lives until ``cleanup()`` (or ``__exit__``).  Credential extraction
+    in ``capture()`` reads from here, so don't remove it manually.
+    """
+
+    mounts_dir: Path
+    """Base directory for the shared post-capture mount (OAuth providers only)."""
+
+    credential_set: str = "default"
+    """Which credential set in the vault DB receives the captured token."""
+
+    expose_token: bool = False
+    """When True, real credential files are copied into the shared mount (tier 3)."""
+
+    _tmpdir: tempfile.TemporaryDirectory[str] | None = field(
+        default=None, repr=False, compare=False
+    )
+    """Internal: backing temp-dir handle, released by ``cleanup``."""
+
+    @property
+    def title(self) -> str:
+        """Short human-readable title (``"Authenticating Claude (host-wide)"``)."""
+        scope = f"for project: {self.project_id}" if self.project_id else "(host-wide)"
+        return f"Authenticating {self.provider.label} {scope}"
+
+    def capture(self) -> None:
+        """Extract credentials from ``auth_dir``, store them in the vault DB.
+
+        Call after ``argv`` exits successfully.  Safe to call multiple
+        times (the underlying extractor is idempotent on a stable
+        credential file).
+        """
+        _capture_credentials(
+            self.provider.name,
+            self.auth_dir,
+            self.credential_set,
+            mounts_base=self.mounts_dir,
+            auth_provider=self.provider,
+            expose_token=self.expose_token,
+        )
+
+    def cleanup(self) -> None:
+        """Release the temp dir and force-remove any lingering container.
+
+        Idempotent.  ``__exit__`` calls this automatically.
+        """
+        subprocess.run(
+            ["podman", "rm", "-f", self.container_name],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if self._tmpdir is not None:
+            self._tmpdir.cleanup()
+            self._tmpdir = None
+
+    def __enter__(self) -> AuthSession:
+        """Return self; the heavy lifting already happened in the factory."""
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        """Run ``cleanup`` on context-manager exit."""
+        self.cleanup()
+
+
+def prepare_oauth_session(
+    provider: AuthProvider,
+    project_id: str | None,
+    *,
+    mounts_dir: Path,
+    image: str,
+    expose_token: bool = False,
+    credential_set: str = "default",
+) -> AuthSession:
+    """Build an [`AuthSession`][terok_executor.AuthSession] without running it.
+
+    Creates a fresh temp dir, computes the ``podman run`` argv, and
+    cleans up any leftover container of the same name (so re-auth
+    after a previous abort isn't blocked).  The caller drives execution
+    and credential capture; see [`AuthSession`][terok_executor.AuthSession].
+
+    The temp dir uses a clean slate so the vendor auth flow re-runs end
+    to end — no stale config, no cached sessions.
+    """
+    _check_podman()
+
+    tmpdir = tempfile.TemporaryDirectory(prefix=f"terok-auth-{provider.name}-")
+    host_dir = Path(tmpdir.name)
+
+    # ``project_id`` must lead the container name; Podman rejects names
+    # starting with ``_`` or other non-alphanumeric chars, so the
+    # host-wide caller passes ``None`` and we fall back to ``host``.
+    name_prefix = project_id or "host"
+    container_name = f"{name_prefix}-auth-{provider.name}"
+    _cleanup_existing_container(container_name)
+
+    cmd = ["podman", "run", "--rm", *podman_userns_args(), "-it"]
+    if provider.extra_run_args:
+        cmd.extend(provider.extra_run_args)
+    cmd.extend(["-v", f"{host_dir}:{provider.container_mount}:Z"])
+    cmd.extend(["--name", container_name])
+    cmd.append(image)
+    cmd.extend(provider.command)
+
+    scope = f"for project: {project_id}" if project_id else "(host-wide)"
+    banner_lines = [
+        f"Authenticating {provider.label} {scope}",
+        "",
+        *provider.banner_hint.splitlines(),
+        "",
+        f"$ {' '.join(map(str, cmd))}",
+        "",
+    ]
+
+    return AuthSession(
+        provider=provider,
+        project_id=project_id,
+        container_name=container_name,
+        argv=cmd,
+        banner="\n".join(banner_lines),
+        auth_dir=host_dir,
+        mounts_dir=mounts_dir,
+        credential_set=credential_set,
+        expose_token=expose_token,
+        _tmpdir=tmpdir,
+    )
+
+
 def _run_auth_container(
     project_id: str | None,
     provider: AuthProvider,
@@ -363,57 +556,24 @@ def _run_auth_container(
     credential_set: str = "default",
     expose_token: bool = False,
 ) -> None:
-    """Run an auth container, capture credentials to the DB.
+    """Synchronous CLI helper: prepare a session, run it inline, capture.
 
-    Uses a **temporary directory** as the container mount target so the
-    vendor auth flow writes credential files into a disposable location.
-    After the container exits, per-provider extractors parse the credential
-    files and store them in the credential DB.  The shared config mount
-    (settings, memories) is untouched — no real secrets land there.
+    Thin wrapper around [`prepare_oauth_session`][terok_executor.prepare_oauth_session]
+    that preserves the original ``terok auth`` behaviour — print banner,
+    run ``podman`` in the foreground, capture on success, swallow 130
+    (Ctrl-C inside the container) without surfacing as failure.
     """
-    import tempfile
-
-    _check_podman()
-
-    # Use an empty temp dir as the mount target.  The auth tool starts with
-    # a clean slate (no existing config, sessions, or cached auth) which
-    # forces a full re-authentication flow.  After the container exits, the
-    # extractor reads the credential file from the temp dir and stores it
-    # in the DB.  The shared config mount is never written to.
-    with tempfile.TemporaryDirectory(prefix=f"terok-auth-{provider.name}-") as tmpdir:
-        host_dir = Path(tmpdir)
-
-        # ``project_id`` must lead the container name; Podman rejects names
-        # starting with ``_`` or other non-alphanumeric chars, so the
-        # host-wide caller passes ``None`` and we fall back to ``host``.
-        name_prefix = project_id or "host"
-        container_name = f"{name_prefix}-auth-{provider.name}"
-        _cleanup_existing_container(container_name)
-
-        cmd = ["podman", "run", "--rm"]
-        cmd.extend(podman_userns_args())
-        cmd.append("-it")
-        if provider.extra_run_args:
-            cmd.extend(provider.extra_run_args)
-        cmd.extend(["-v", f"{host_dir}:{provider.container_mount}:Z"])
-        cmd.extend(["--name", container_name])
-        cmd.append(image)
-        cmd.extend(provider.command)
-
-        # Banner
-        if project_id:
-            print(f"Authenticating {provider.label} for project: {project_id}")
-        else:
-            print(f"Authenticating {provider.label} (host-wide)")
-        print()
-        for line in provider.banner_hint.splitlines():
-            print(line)
-        print()
-        print("$", " ".join(map(str, cmd)))
-        print()
-
+    with prepare_oauth_session(
+        provider,
+        project_id,
+        mounts_dir=mounts_dir,
+        image=image,
+        expose_token=expose_token,
+        credential_set=credential_set,
+    ) as session:
+        print(session.banner)
         try:
-            subprocess.run(cmd, check=True)
+            subprocess.run(session.argv, check=True)
         except subprocess.CalledProcessError as e:
             if e.returncode == 130:
                 print("\nAuthentication container stopped.")
@@ -421,23 +581,9 @@ def _run_auth_container(
             raise SystemExit(f"Auth failed: {e}")
         except KeyboardInterrupt:
             print("\nAuthentication interrupted.")
-            subprocess.run(
-                ["podman", "rm", "-f", container_name],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                check=False,
-            )
-            return
+            return  # session.cleanup() runs via __exit__ and removes the container
 
-        # Extract credentials from the temp dir and store in DB
-        _capture_credentials(
-            provider.name,
-            host_dir,
-            credential_set,
-            mounts_base=mounts_dir,
-            auth_provider=provider,
-            expose_token=expose_token,
-        )
+        session.capture()
 
 
 def _check_podman() -> None:

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -573,7 +573,10 @@ def _run_auth_container(
     ) as session:
         print(session.banner)
         try:
-            subprocess.run(session.argv, check=True)
+            # argv is built by prepare_oauth_session from the bundled roster
+            # command + a resolved image tag, no shell, no untrusted input;
+            # the foreground run is intentional for the CLI.
+            subprocess.run(session.argv, check=True)  # nosec B603
         except subprocess.CalledProcessError as e:
             if e.returncode == 130:
                 print("\nAuthentication container stopped.")

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -1081,3 +1081,109 @@ class TestAuthenticateOauthGate:
                     image="img:tag",
                     oauth_enabled=False,
                 )
+
+
+class TestPrepareOauthSession:
+    """Verify the hold-don't-call session API the TUI dispatches against."""
+
+    def _provider(self) -> object:
+        from terok_executor.credentials.auth import AuthProvider
+
+        return AuthProvider(
+            name="claude",
+            label="Claude",
+            host_dir_name="_claude-config",
+            container_mount="/home/dev/.claude",
+            command=["claude"],
+            banner_hint="Banner line one.\nBanner line two.",
+            modes=("oauth", "api_key"),
+        )
+
+    def test_argv_includes_provider_command_and_mount(self, tmp_path: Path) -> None:
+        """``argv`` ends with the provider command and contains the temp-dir mount."""
+        from terok_executor.credentials.auth import prepare_oauth_session
+
+        with patch("terok_executor.credentials.auth._check_podman"):
+            with prepare_oauth_session(
+                self._provider(), None, mounts_dir=tmp_path, image="terok-l1:test"
+            ) as session:
+                assert session.argv[0] == "podman"
+                assert "terok-l1:test" in session.argv
+                assert session.argv[-1] == "claude"
+                mount_arg = f"{session.auth_dir}:/home/dev/.claude:Z"
+                assert mount_arg in session.argv
+                assert session.auth_dir.is_dir()
+        assert not session.auth_dir.exists()  # cleanup ran
+
+    def test_title_and_banner_reflect_scope(self, tmp_path: Path) -> None:
+        """Banner mentions the provider label and either the project or host-wide scope."""
+        from terok_executor.credentials.auth import prepare_oauth_session
+
+        with patch("terok_executor.credentials.auth._check_podman"):
+            with prepare_oauth_session(
+                self._provider(), "myproj", mounts_dir=tmp_path, image="img"
+            ) as session:
+                assert "Claude" in session.title
+                assert "myproj" in session.title
+                assert "Banner line one." in session.banner
+                assert "$ podman run" in session.banner
+
+    def test_capture_delegates_to_capture_credentials(self, tmp_path: Path) -> None:
+        """``session.capture()`` forwards to ``_capture_credentials`` with stored kwargs."""
+        from terok_executor.credentials.auth import prepare_oauth_session
+
+        with patch("terok_executor.credentials.auth._check_podman"):
+            with prepare_oauth_session(
+                self._provider(),
+                "myproj",
+                mounts_dir=tmp_path,
+                image="img",
+                credential_set="work",
+                expose_token=True,
+            ) as session:
+                with patch("terok_executor.credentials.auth._capture_credentials") as mock_cap:
+                    session.capture()
+                mock_cap.assert_called_once_with(
+                    "claude",
+                    session.auth_dir,
+                    "work",
+                    mounts_base=tmp_path,
+                    auth_provider=session.provider,
+                    expose_token=True,
+                )
+
+    def test_cleanup_is_idempotent(self, tmp_path: Path) -> None:
+        """Calling ``cleanup`` twice does not raise."""
+        from terok_executor.credentials.auth import prepare_oauth_session
+
+        with patch("terok_executor.credentials.auth._check_podman"):
+            session = prepare_oauth_session(
+                self._provider(), None, mounts_dir=tmp_path, image="img"
+            )
+        session.cleanup()
+        session.cleanup()
+
+    def test_authenticator_prepare_oauth_rejects_api_key_only_provider(
+        self, tmp_path: Path
+    ) -> None:
+        """API-key-only providers can't be prepared for OAuth — early failure."""
+        import pytest
+
+        from terok_executor.credentials.auth import Authenticator, AuthProvider
+
+        api_only = AuthProvider(
+            name="blablador",
+            label="Blablador",
+            host_dir_name="_blablador-config",
+            container_mount="/home/dev/.blablador",
+            command=["true"],
+            banner_hint="",
+            modes=("api_key",),
+        )
+        with patch.dict(
+            "terok_executor.credentials.auth.AUTH_PROVIDERS",
+            {"blablador": api_only},
+            clear=True,
+        ):
+            with pytest.raises(SystemExit, match="does not support OAuth"):
+                Authenticator("blablador").prepare_oauth(None, mounts_dir=tmp_path, image="img")


### PR DESCRIPTION
## Summary

- Introduces `AuthSession` (hold-don't-call container handle) plus `prepare_oauth_session` / `Authenticator.prepare_oauth` factories so frontends with their own UI loop can dispatch the OAuth auth container outside the executor's `subprocess.run` path — into a new terminal tab, via tmux, or with the TUI suspended.
- `AuthSession` is a context manager that owns the temp dir + dangling-container cleanup; `session.capture()` does the extract-and-store step after the caller has run `session.argv` however it likes.
- `_run_auth_container` becomes a thin wrapper around the session — same CLI behaviour, same test mocking points.
- Promotes `AuthSession`, `prepare_oauth_session`, and `store_api_key` (already non-interactive) to `__all__`.

Motivation: the terok TUI dispatches `worker_actions:auth` into a `stdin=DEVNULL` subprocess, which makes `Authenticator.run` unable to either prompt for an API key (the `input()` call gets EOF) or attach a TTY to `podman run -it`. The TUI side of that fix lives in a separate terok PR; this is the executor-side seam it needs.

## Test plan

- [x] `make check` (lint, tach, tests, docstrings, security, REUSE)
- [x] 5 new `TestPrepareOauthSession` cases covering argv shape, banner/title, capture delegation, idempotent cleanup, OAuth-rejected-for-API-key-only providers
- [x] All 49 existing `test_auth_capture.py` cases still pass — `_run_auth_container` keeps its signature and call shape so existing mocks are untouched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OAuth authentication flow with a prepared-session approach, clearer prompts (project-scoped or host-wide) and a visible container-run hint.

* **Refactor**
  * OAuth execution now uses a prepared session abstraction for safer cleanup and more reliable credential capture.

* **Tests**
  * Added unit tests covering session preparation, banner text, mount labeling, credential capture behavior, and rejection of API-key-only providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->