### PR TITLE
fix: seed initial prompt through the right argv surface per provider

### DIFF
--- a/src/terok_executor/provider/agents.py
+++ b/src/terok_executor/provider/agents.py
@@ -420,7 +420,12 @@ def _generate_claude_wrapper(cfg: WrapperConfig) -> str:
 
     # Pick up the task's initial prompt on bare interactive launch when no
     # resume is being injected.  Mirrors the generic wrapper's behaviour.
-    lines.extend(initial_prompt_block("/home/dev/.terok/claude-session.txt"))
+    lines.extend(
+        initial_prompt_block(
+            "/home/dev/.terok/claude-session.txt",
+            provider=claude_provider,
+        )
+    )
 
     # Git env vars and exec — with optional timeout.
     # _terok_resume_or_fresh guards against stale session IDs: if the agent

--- a/src/terok_executor/provider/wrappers.py
+++ b/src/terok_executor/provider/wrappers.py
@@ -164,7 +164,41 @@ def _opencode_plugin_block(provider: AgentProvider) -> list[str]:
     ]
 
 
-def initial_prompt_block(session_path: str | None) -> list[str]:
+def _interactive_seed_argv_prefix(provider: AgentProvider | None) -> list[str]:
+    """Argv tokens placed before the prompt when seeding it via ``$@``.
+
+    Most CLIs accept a bare positional string as the initial conversation
+    message (Claude, Codex, Vibe).  Two families need help:
+
+    * **OpenCode-based** (opencode itself + blablador / kisski / openrouter):
+      yargs binds the first positional of the default TUI command to a
+      working-directory path
+      (`sst/opencode v1.15.7 packages/opencode/src/cli/cmd/tui/thread.ts:79-87
+      <https://github.com/anomalyco/opencode/blob/v1.15.7/packages/opencode/src/cli/cmd/tui/thread.ts#L79-L87>`_).
+      Routing through the ``run`` subcommand makes opencode treat the text
+      as a prompt instead of attempting ``chdir`` into it.
+
+    * **GitHub Copilot**: the upstream CLI is closed-source, and the
+      `official docs
+      <https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/run-cli-programmatically>`_
+      only sanction ``-p <prompt>`` and stdin for non-interactive seeding;
+      bare positional is undocumented.  Routing through ``-p`` keeps us on
+      the supported surface.
+    """
+    if provider is None:
+        return []
+    if provider.uses_opencode_instructions:
+        return ["run"]
+    if provider.name == "copilot":
+        return ["-p"]
+    return []
+
+
+def initial_prompt_block(
+    session_path: str | None,
+    *,
+    provider: AgentProvider | None = None,
+) -> list[str]:
     """Emit bash lines that pick up the task's initial prompt as the first message.
 
     Fires only on a bare interactive launch (no user args, no headless timeout)
@@ -174,15 +208,21 @@ def initial_prompt_block(session_path: str | None) -> list[str]:
 
     The renamed copy is preserved as a paper trail; the user can ``mv`` it
     back to recover from a launch that crashed before the session was saved.
+
+    *provider* shapes the seeded argv so the prompt is interpreted as a
+    conversation message and not as some CLI's positional cwd / unrelated
+    argument — see [`_interactive_seed_argv_prefix`][terok_executor.provider.wrappers._interactive_seed_argv_prefix].
     """
     guards = ['[ -z "$_timeout" ]', "[ $# -eq 0 ]"]
     if session_path:
         guards.append(f"[ ! -s {session_path} ]")
     guards.append(f"[ -s {INITIAL_PROMPT_PATH} ]")
+    prefix_tokens = _interactive_seed_argv_prefix(provider)
+    prefix = "".join(f"{shlex.quote(t)} " for t in prefix_tokens)
     return [
         "    # Pick up the task's initial prompt as the first message (one-shot).",
         f"    if {' && '.join(guards)}; then",
-        f'        set -- "$(cat {INITIAL_PROMPT_PATH})"',
+        f'        set -- {prefix}"$(cat {INITIAL_PROMPT_PATH})"',
         f"        mv {INITIAL_PROMPT_PATH} {INITIAL_PROMPT_CONSUMED_PATH}",
         "    fi",
     ]
@@ -457,7 +497,7 @@ def _generate_generic_wrapper(provider: AgentProvider) -> str:
     lines.extend(_opencode_plugin_block(provider))
     lines.extend(_session_resume_block(provider, session_path))
     lines.extend(_codex_instr_block(provider))
-    lines.extend(initial_prompt_block(session_path))
+    lines.extend(initial_prompt_block(session_path, provider=provider))
     lines.extend(_vibe_capture_fn(provider, session_path))
 
     headless_cmd = _wrap_invocation(

--- a/src/terok_executor/provider/wrappers.py
+++ b/src/terok_executor/provider/wrappers.py
@@ -211,7 +211,7 @@ def initial_prompt_block(
 
     *provider* shapes the seeded argv so the prompt is interpreted as a
     conversation message and not as some CLI's positional cwd / unrelated
-    argument — see [`_interactive_seed_argv_prefix`][terok_executor.provider.wrappers._interactive_seed_argv_prefix].
+    argument — see ``_interactive_seed_argv_prefix``.
     """
     guards = ['[ -z "$_timeout" ]', "[ $# -eq 0 ]"]
     if session_path:

--- a/tests/unit/test_headless_providers.py
+++ b/tests/unit/test_headless_providers.py
@@ -258,23 +258,30 @@ class TestGenerateAgentWrapper:
         prepend ``run`` because their default TUI binds positional[0] to a
         cwd path.  Copilot prepends ``-p`` because its CLI documents
         ``-p <prompt>`` / stdin as the only non-interactive seed forms.
-        Everything else (Claude, Codex, Vibe) accepts a bare positional.
+        Everything else (Claude, Codex, Vibe, Pi) accepts a bare positional.
         """
+        bare = f'set -- "$(cat {INITIAL_PROMPT_PATH})"'
+        run = f'set -- run "$(cat {INITIAL_PROMPT_PATH})"'
+        dash_p = f'set -- -p "$(cat {INITIAL_PROMPT_PATH})"'
         expected: dict[str, str] = {
-            "opencode": f'set -- run "$(cat {INITIAL_PROMPT_PATH})"',
-            "blablador": f'set -- run "$(cat {INITIAL_PROMPT_PATH})"',
-            "kisski": f'set -- run "$(cat {INITIAL_PROMPT_PATH})"',
-            "openrouter": f'set -- run "$(cat {INITIAL_PROMPT_PATH})"',
-            "copilot": f'set -- -p "$(cat {INITIAL_PROMPT_PATH})"',
-            "claude": f'set -- "$(cat {INITIAL_PROMPT_PATH})"',
-            "codex": f'set -- "$(cat {INITIAL_PROMPT_PATH})"',
-            "vibe": f'set -- "$(cat {INITIAL_PROMPT_PATH})"',
+            "opencode": run,
+            "blablador": run,
+            "kisski": run,
+            "openrouter": run,
+            "copilot": dash_p,
+            "claude": bare,
+            "codex": bare,
+            "vibe": bare,
+            "pi": bare,
         }
-        for name, line in expected.items():
-            if name not in AGENT_PROVIDERS:
-                continue
+        # Every registered provider must have an explicit decision recorded
+        # here — new providers can't sneak in without an audit of their CLI
+        # against the seed-shape categories above.
+        missing = set(AGENT_PROVIDERS) - set(expected)
+        assert not missing, f"missing seed-shape decision for: {sorted(missing)}"
+        for name in AGENT_PROVIDERS:
             wrapper = _provider_wrapper(name)
-            assert line in wrapper, f"{name} should emit `{line}`"
+            assert expected[name] in wrapper, f"{name} should emit `{expected[name]}`"
 
     def test_initial_prompt_skipped_when_session_present(self) -> None:
         """Wrappers with a session_file gate the prompt pickup on no resume."""

--- a/tests/unit/test_headless_providers.py
+++ b/tests/unit/test_headless_providers.py
@@ -238,14 +238,43 @@ class TestGenerateAgentWrapper:
             )
 
     def test_all_wrappers_pick_up_initial_prompt(self) -> None:
-        """Every provider's wrapper consumes initial-prompt.txt one-shot."""
+        """Every provider's wrapper consumes initial-prompt.txt one-shot.
+
+        The seeded argv shape varies by provider (see
+        [`test_initial_prompt_seed_shape_per_provider`][tests.unit.test_headless_providers.TestAgentWrappers.test_initial_prompt_seed_shape_per_provider]).
+        """
         for name in AGENT_PROVIDERS:
             wrapper = _provider_wrapper(name)
             assert INITIAL_PROMPT_PATH in wrapper, f"{name} missing initial-prompt pickup"
             assert INITIAL_PROMPT_CONSUMED_PATH in wrapper, f"{name} missing one-shot rename"
-            assert f'set -- "$(cat {INITIAL_PROMPT_PATH})"' in wrapper, (
-                f"{name} should set positional args from the prompt file"
+            assert f'"$(cat {INITIAL_PROMPT_PATH})"' in wrapper, (
+                f"{name} should reference the prompt file in its set -- line"
             )
+
+    def test_initial_prompt_seed_shape_per_provider(self) -> None:
+        """The seed argv routes the prompt through the right CLI surface.
+
+        OpenCode-based providers (opencode, blablador, kisski, openrouter)
+        prepend ``run`` because their default TUI binds positional[0] to a
+        cwd path.  Copilot prepends ``-p`` because its CLI documents
+        ``-p <prompt>`` / stdin as the only non-interactive seed forms.
+        Everything else (Claude, Codex, Vibe) accepts a bare positional.
+        """
+        expected: dict[str, str] = {
+            "opencode": f'set -- run "$(cat {INITIAL_PROMPT_PATH})"',
+            "blablador": f'set -- run "$(cat {INITIAL_PROMPT_PATH})"',
+            "kisski": f'set -- run "$(cat {INITIAL_PROMPT_PATH})"',
+            "openrouter": f'set -- run "$(cat {INITIAL_PROMPT_PATH})"',
+            "copilot": f'set -- -p "$(cat {INITIAL_PROMPT_PATH})"',
+            "claude": f'set -- "$(cat {INITIAL_PROMPT_PATH})"',
+            "codex": f'set -- "$(cat {INITIAL_PROMPT_PATH})"',
+            "vibe": f'set -- "$(cat {INITIAL_PROMPT_PATH})"',
+        }
+        for name, line in expected.items():
+            if name not in AGENT_PROVIDERS:
+                continue
+            wrapper = _provider_wrapper(name)
+            assert line in wrapper, f"{name} should emit `{line}`"
 
     def test_initial_prompt_skipped_when_session_present(self) -> None:
         """Wrappers with a session_file gate the prompt pickup on no resume."""


### PR DESCRIPTION
## Summary

When a task ships with an initial prompt (`/home/dev/.terok/initial-prompt.txt`) and the user lands in a `bash` shell first, then types an agent name, the generated wrapper picks up the prompt and does `set -- \"\$(cat initial-prompt.txt)\"` before invoking the binary. That argv shape works for Claude (which accepts a positional as the seed message) but breaks two families:

- **OpenCode-based** (`opencode`, `blablador`, `kisski`, `openrouter`): sst/opencode binds the default-command positional to a working directory ([`packages/opencode/src/cli/cmd/tui/thread.ts:79-87`](https://github.com/anomalyco/opencode/blob/v1.15.7/packages/opencode/src/cli/cmd/tui/thread.ts#L79-L87) — `command: \"\$0 [project]\"`, then `process.chdir(next)` at L135). The prompt text reaches `chdir` and the user sees:

  ```
  Error: Failed to change directory to /workspace/tel me a joke
  ```

  Routing through the `run` subcommand makes the same text a prompt.

- **GitHub Copilot**: bare positional is undocumented; the [official CLI docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/run-cli-programmatically) sanction `-p <prompt>` and stdin only. Routing through `-p` keeps us on the supported surface. Copilot is closed-source so this is best-effort — we'll find out in practice if it misbehaves.

Codex and Vibe were verified against upstream sources to already accept bare positionals as initial prompts ([`codex-rs/tui/src/cli.rs:8-15`](https://github.com/openai/codex/blob/main/codex-rs/tui/src/cli.rs#L8-L15); [`vibe/cli/entrypoint.py:42-47`](https://github.com/mistralai/mistral-vibe/blob/main/vibe/cli/entrypoint.py#L42-L47)) — left as today.

## Implementation

- `initial_prompt_block` now takes the provider and dispatches via a new `_interactive_seed_argv_prefix` helper.
- Generic and Claude call sites both pass their provider in.
- `_interactive_seed_argv_prefix` returns `[\"run\"]` for OpenCode-based providers (`uses_opencode_instructions`), `[\"-p\"]` for Copilot, `[]` otherwise.

## Test plan

- [x] `make check` green (982 unit tests pass; ruff, tach, security, docstrings ≥95%, REUSE, vulture all clean).
- [x] Existing `test_all_wrappers_pick_up_initial_prompt` relaxed to assert the prompt-file substring, with a new sibling test `test_initial_prompt_seed_shape_per_provider` pinning the exact `set -- …` line for every provider.
- [ ] Manual repro — bash → `blablador` with a prompt no longer errors (will verify on a fresh container build).
- [ ] Manual smoke — bash → `copilot` (untested upstream behavior; verify the seeded `-p` form works).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Initial prompts are now correctly formatted according to each provider's CLI requirements, ensuring proper initialization across different agent types.

* **Tests**
  * Extended test coverage for initial prompt handling across provider configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok-executor/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->