### PR TITLE
chore(deps): adopt terok-sandbox AppArmor dnsmasq tier fallback

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3407,13 +3407,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/t
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.124a21"
+version = "0.0.124a22"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.124a22-py3-none-any.whl", hash = "sha256:2831bac04641d79a33fc43f594c6b047acbb0ee2f2146dc87e10c6fca0978a81"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3427,24 +3428,23 @@ pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/terok_clearance-0.6.14a7-py3-none-any.whl"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", rev = "feat/apparmor-dnsmasq-profile"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a10/terok_shield-0.6.42a10-py3-none-any.whl"}
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/apparmor-dnsmasq-profile"
-resolved_reference = "89dbfd43336fde182d2311bc13f40f072369ef1c"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a22/terok_sandbox-0.0.124a22-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.42a9"
+version = "0.6.42a10"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_shield-0.6.42a10-py3-none-any.whl", hash = "sha256:fedb948bb7fa2dd063b03056675679f11af89f9a188438f4ebc27a8e52abbc7a"},
+]
 
 [package.dependencies]
 pydantic = ">=2.0"
@@ -3452,10 +3452,8 @@ PyYAML = ">=6.0"
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-shield.git"
-reference = "feat/apparmor-dnsmasq-profile"
-resolved_reference = "dba9e1808dd4a737565e55cdd9ea69e60606b453"
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a10/terok_shield-0.6.42a10-py3-none-any.whl"
 
 [[package]]
 name = "terok-util"
@@ -3873,4 +3871,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "7c40007298136c5376626c114d84b50bf96c6dc14d92ffd61fc15a2df49a2e8d"
+content-hash = "b72ab3dcf1c23853650d65d9c64717f2a60c923d76f55f6c9538868a373eff2b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2378,14 +2378,14 @@ re2 = ["google-re2 (>=1.1)"]
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev", "docs"]
 files = [
-    {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
-    {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
+    {file = "platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"},
+    {file = "platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7"},
 ]
 
 [[package]]
@@ -3412,9 +3412,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.124a21-py3-none-any.whl", hash = "sha256:0919ce1dbf89613be6743e20c43007595ee7bc43e132e5387712beed9ddc0916"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3422,18 +3421,20 @@ cryptography = ">=46.0.7"
 jinja2 = ">=3.1"
 keyring = ">=25.0"
 packaging = ">=24"
-platformdirs = ">=4.9.6"
+platformdirs = ">=4.10.0"
 prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/terok_clearance-0.6.14a7-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a9/terok_shield-0.6.42a9-py3-none-any.whl"}
+terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", rev = "feat/apparmor-dnsmasq-profile"}
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a21/terok_sandbox-0.0.124a21-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/apparmor-dnsmasq-profile"
+resolved_reference = "89dbfd43336fde182d2311bc13f40f072369ef1c"
 
 [[package]]
 name = "terok-shield"
@@ -3442,9 +3443,8 @@ description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_shield-0.6.42a9-py3-none-any.whl", hash = "sha256:0b70cd297908a96b2c5fcc483c81a31c3103f0c798a4e493454f20120476e48d"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 pydantic = ">=2.0"
@@ -3452,8 +3452,10 @@ PyYAML = ">=6.0"
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a9/terok_shield-0.6.42a9-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-shield.git"
+reference = "feat/apparmor-dnsmasq-profile"
+resolved_reference = "dba9e1808dd4a737565e55cdd9ea69e60606b453"
 
 [[package]]
 name = "terok-util"
@@ -3871,4 +3873,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "91f06661d5b70997ed12c9047323d8dd995df48bf07af7ff172224a72194298b"
+content-hash = "7c40007298136c5376626c114d84b50bf96c6dc14d92ffd61fc15a2df49a2e8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 dependencies = [
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/apparmor-dnsmasq-profile",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a22/terok_sandbox-0.0.124a22-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl",
     "ruamel.yaml>=0.18",
     "Jinja2>=3.1",
@@ -54,7 +54,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.0.149a27"
+version = "0.0.149a28"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a21/terok_sandbox-0.0.124a21-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/apparmor-dnsmasq-profile",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl",
     "ruamel.yaml>=0.18",
     "Jinja2>=3.1",


### PR DESCRIPTION
Picks up the AppArmor-confinement detection + `dig`-tier fallback (terok-shield via terok-sandbox) so containers no longer fail to launch on hosts that confine `/usr/sbin/dnsmasq` with an enforcing AppArmor profile. No executor code change — the advisory flows through the re-exported `check_environment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)