### PR TITLE
docs: add PyPI version badge and logo, fix architecture SVG on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://terok-ai.github.io/terok/terok-logo-w.svg">
+    <img src="https://terok-ai.github.io/terok/terok-logo-b.svg" alt="terok-executor" width="120">
+  </picture>
+</p>
+
 # terok-executor
 
+[![PyPI](https://img.shields.io/pypi/v/terok-executor)](https://pypi.org/project/terok-executor/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![REUSE status](https://api.reuse.software/badge/github.com/terok-ai/terok-executor)](https://api.reuse.software/info/github.com/terok-ai/terok-executor)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=terok-ai_terok-executor&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=terok-ai_terok-executor)
@@ -13,7 +21,7 @@ host.  Use it on its own as a CLI, or import its `AgentRunner` from
 Python when you want library-grade control.
 
 <p align="center">
-  <img src="docs/img/architecture.svg" alt="terok ecosystem — terok-executor sits between project orchestration and the hardened runtime">
+  <img src="https://terok-ai.github.io/terok/img/architecture.svg" alt="terok ecosystem — terok-executor sits between project orchestration and the hardened runtime">
 </p>
 
 ## Quick start


### PR DESCRIPTION
Part of an ecosystem-wide README pass across the 7 terok PyPI projects.

- **PyPI version badge** — links to the PyPI project page. shields.io auto-colors it (orange while pre-1.0, blue at ≥1.0), so it doubles as an at-a-glance maturity signal.
- **terok logo** — adds the shared light/dark `<picture>` block already used by the main `terok` README.
- **Architecture diagram now renders on PyPI** — the image used a *relative* path (`docs/…`), which PyPI cannot resolve (it has no repo base to anchor relatives against), so the diagram showed broken on the project page while the logo — an absolute URL — rendered fine. It was **never** an SVG-vs-PNG issue. Switched to the canonical absolute URL `https://terok-ai.github.io/terok/img/architecture.svg` (byte-identical image, already served as `image/svg+xml`); it renders on PyPI, GitHub, and IDE markdown previews alike.

Takes effect on the live PyPI page at this package's next release — the `long_description` is baked into the published artifact, so existing releases are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with a logo header featuring light and dark theme variants
  * Added PyPI version badge for quick access to package version information
  * Updated architecture diagram reference with new image URL

<!-- end of auto-generated comment: release notes by coderabbit.ai -->