### PR TITLE
refactor(roster): typed token_env map (replaces phantom_env/oauth_phantom_env)

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -131,8 +131,9 @@ vault:
   auth_header: dynamic           # OAuth -> Bearer, API key -> x-api-key
   credential_type: oauth
   credential_file: .credentials.json
-  phantom_env:
-    ANTHROPIC_API_KEY: true      # env var gets the phantom token
+  token_env:                     # phantom-token env var, keyed by credential type
+    oauth: CLAUDE_CODE_OAUTH_TOKEN
+    _default: ANTHROPIC_API_KEY  # fallback for any non-OAuth credential
   base_url_env: ANTHROPIC_BASE_URL  # optional: env var for token broker URL
   shared_config_patch: ...       # optional: file patch for token broker URL
 ```

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -453,8 +453,8 @@ def _inject_vault_tokens(
 
     Handles three orthogonal concerns:
 
-    - **Auth**: selects ``phantom_env`` vs ``oauth_phantom_env`` based on the
-      stored credential type (Phase 1).
+    - **Auth**: picks the phantom-token env var from ``token_env`` keyed by
+      the stored credential type (Phase 1).
     - **Transport**: resolves the shared vault address and writes it into
       every route's ``socket_env`` / ``base_url_env`` (Phase 2).
     - **SSH signer**: creates a phantom token for the SSH signer when the
@@ -535,12 +535,10 @@ def _inject_vault_tokens(
         if name not in routed:
             continue
 
-        is_oauth = credential_types.get(name) == "oauth"
-        token_vars = (
-            route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
-        )
-        for env_var in token_vars:
-            env[env_var] = tokens[name]
+        stored_type = credential_types.get(name, "")
+        token_var = route.token_env.get(stored_type) or route.token_env.get("_default")
+        if token_var:
+            env[token_var] = tokens[name]
 
         if route.socket_env:
             env[route.socket_env] = location.socket

--- a/src/terok_executor/doctor.py
+++ b/src/terok_executor/doctor.py
@@ -222,8 +222,8 @@ def _make_phantom_token_checks(roster: AgentRoster) -> list[DoctorCheck]:
     seen_vars: set[str] = set()
 
     for name, route in roster.vault_routes.items():
-        # Collect all phantom env vars (api_key + oauth types)
-        env_vars = list(route.phantom_env.keys()) + list(route.oauth_phantom_env.keys())
+        # Collect all phantom-token env var names (deduped downstream)
+        env_vars = list(route.token_env.values())
         for var in env_vars:
             if var in seen_vars:
                 continue

--- a/src/terok_executor/resources/agents/blablador.yaml
+++ b/src/terok_executor/resources/agents/blablador.yaml
@@ -35,8 +35,8 @@ vault:
   auth_prefix: "Bearer "
   credential_type: api_key
   credential_file: config.json
-  phantom_env:
-    BLABLADOR_API_KEY: true
+  token_env:
+    _default: BLABLADOR_API_KEY
 
 opencode:
   display_name: Helmholtz Blablador

--- a/src/terok_executor/resources/agents/claude.yaml
+++ b/src/terok_executor/resources/agents/claude.yaml
@@ -59,10 +59,9 @@ vault:
     token_url: https://platform.claude.com/v1/oauth/token
     client_id: 9d1c250a-e61b-44d9-88ed-5944d1962f5e
     scope: "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload"
-  phantom_env:
-    ANTHROPIC_API_KEY: true
-  oauth_phantom_env:
-    CLAUDE_CODE_OAUTH_TOKEN: true
+  token_env:
+    oauth: CLAUDE_CODE_OAUTH_TOKEN
+    _default: ANTHROPIC_API_KEY
   base_url_env: ANTHROPIC_BASE_URL
   socket_env: ANTHROPIC_UNIX_SOCKET
 

--- a/src/terok_executor/resources/agents/coderabbit.yaml
+++ b/src/terok_executor/resources/agents/coderabbit.yaml
@@ -13,8 +13,8 @@ vault:
   auth_header: Authorization
   auth_prefix: "Bearer "
   credential_type: api_key
-  phantom_env:
-    CODERABBIT_API_KEY: true
+  token_env:
+    _default: CODERABBIT_API_KEY
   # No base_url_env: the CLI has no API endpoint override.  It does
   # honour HTTPS_PROXY, but the token broker is a reverse proxy
   # (route-prefix), not a forward proxy (CONNECT tunnel).

--- a/src/terok_executor/resources/agents/codex.yaml
+++ b/src/terok_executor/resources/agents/codex.yaml
@@ -50,10 +50,8 @@ vault:
   # for env-var-only consumers (e.g. Pi) so that any other agent in the
   # same container can route through the vault using the OAuth phantom
   # token under OpenAI's standard env-var name.
-  phantom_env:
-    OPENAI_API_KEY: true
-  oauth_phantom_env:
-    OPENAI_API_KEY: true
+  token_env:
+    _default: OPENAI_API_KEY
   # OAuth refresh -- endpoint, client_id, and grant shape extracted from the
   # Codex CLI source (codex-rs/login/src/auth/manager.rs v0.123.0).  The CLI
   # itself can be redirected at its own refresh attempts via the

--- a/src/terok_executor/resources/agents/gh.yaml
+++ b/src/terok_executor/resources/agents/gh.yaml
@@ -14,8 +14,8 @@ vault:
   auth_prefix: "token "
   credential_type: oauth_token
   credential_file: hosts.yml
-  phantom_env:
-    GH_TOKEN: true
+  token_env:
+    _default: GH_TOKEN
   shared_config_patch:
     file: config.yml
     yaml_set: {http_unix_socket: "{vault_socket}"}

--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -14,8 +14,8 @@ vault:
   auth_prefix: ""
   credential_type: pat
   credential_file: config.yml
-  phantom_env:
-    GITLAB_TOKEN: true
+  token_env:
+    _default: GITLAB_TOKEN
   # gitlab.com carries both the API and ``git push`` traffic on the same
   # apex; an nft host-deny would also kill pushes.  Read-only credential
   # containment is the actual containment story for this provider.

--- a/src/terok_executor/resources/agents/kisski.yaml
+++ b/src/terok_executor/resources/agents/kisski.yaml
@@ -35,8 +35,8 @@ vault:
   auth_prefix: "Bearer "
   credential_type: api_key
   credential_file: config.json
-  phantom_env:
-    KISSKI_API_KEY: true
+  token_env:
+    _default: KISSKI_API_KEY
 
 opencode:
   display_name: KISSKI

--- a/src/terok_executor/resources/agents/openrouter.yaml
+++ b/src/terok_executor/resources/agents/openrouter.yaml
@@ -35,8 +35,8 @@ vault:
   auth_prefix: "Bearer "
   credential_type: api_key
   credential_file: config.json
-  phantom_env:
-    OPENROUTER_API_KEY: true
+  token_env:
+    _default: OPENROUTER_API_KEY
 
 opencode:
   display_name: OpenRouter

--- a/src/terok_executor/resources/agents/sonar.yaml
+++ b/src/terok_executor/resources/agents/sonar.yaml
@@ -13,8 +13,8 @@ vault:
   auth_header: Authorization
   auth_prefix: "Bearer "
   credential_type: api_key
-  phantom_env:
-    SONAR_TOKEN: true
+  token_env:
+    _default: SONAR_TOKEN
   base_url_env: SONAR_HOST_URL
   # sonarcloud.io serves API + project pages + docs + badges on the same
   # apex; an nft host-deny would block legitimate browsing/curling in

--- a/src/terok_executor/resources/agents/vibe.yaml
+++ b/src/terok_executor/resources/agents/vibe.yaml
@@ -45,8 +45,8 @@ vault:
   auth_prefix: "Bearer "
   credential_type: api_key
   credential_file: .env
-  phantom_env:
-    MISTRAL_API_KEY: true
+  token_env:
+    _default: MISTRAL_API_KEY
   shared_config_patch:
     file: config.toml
     toml_table: providers

--- a/src/terok_executor/roster/schema.py
+++ b/src/terok_executor/roster/schema.py
@@ -240,8 +240,7 @@ class RawVault(StrictModel):
     auth_prefix: str = "Bearer "
     credential_type: Literal["api_key", "oauth", "oauth_token", "pat"] = "api_key"
     credential_file: str = ""
-    phantom_env: dict[str, bool] = Field(default_factory=dict)
-    oauth_phantom_env: dict[str, bool] = Field(default_factory=dict)
+    token_env: dict[str, str] = Field(default_factory=dict)
     base_url_env: str = ""
     socket_env: str = ""
     shared_config_patch: dict | None = None
@@ -274,8 +273,7 @@ class RawVault(StrictModel):
             auth_prefix=self.auth_prefix,
             credential_type=self.credential_type,
             credential_file=self.credential_file,
-            phantom_env=dict(self.phantom_env),
-            oauth_phantom_env=dict(self.oauth_phantom_env),
+            token_env=dict(self.token_env),
             base_url_env=self.base_url_env,
             socket_env=self.socket_env,
             shared_config_patch=self.shared_config_patch,

--- a/src/terok_executor/roster/types.py
+++ b/src/terok_executor/roster/types.py
@@ -82,14 +82,16 @@ class VaultRoute:
     credential_file: str = ""
     """Credential file path relative to the auth mount."""
 
-    phantom_env: dict[str, bool] = field(default_factory=dict)
-    """Phantom env vars for API-key credentials (e.g. ``{"ANTHROPIC_API_KEY": true}``)."""
+    token_env: dict[str, str] = field(default_factory=dict)
+    """Phantom-token env var name, keyed by stored credential type.
 
-    oauth_phantom_env: dict[str, bool] = field(default_factory=dict)
-    """Phantom env vars for OAuth credentials (e.g. ``{"CLAUDE_CODE_OAUTH_TOKEN": true}``).
-
-    When the stored credential type is ``"oauth"`` and this is non-empty, these
-    env vars are injected *instead of* [`phantom_env`][terok_executor.roster.types.VaultRoute.phantom_env].
+    The named env var carries the phantom token the agent reads in place of
+    the real credential.  Keys are credential types (``"oauth"``, ``"pat"``,
+    …); ``"_default"`` is the fallback for any type without an explicit
+    entry.  Most agents read one env var regardless of type
+    (``{"_default": "MISTRAL_API_KEY"}``); Claude swaps the name when an
+    OAuth token is stored
+    (``{"oauth": "CLAUDE_CODE_OAUTH_TOKEN", "_default": "ANTHROPIC_API_KEY"}``).
     """
 
     base_url_env: str = ""

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -484,10 +484,10 @@ class TestVaultTokenInjection:
             result = assemble_container_env(base_spec, roster, caller_manages_vault=False)
         assert "ANTHROPIC_API_KEY" not in result.env
 
-    def test_vault_oauth_credential_uses_oauth_phantom_env(
+    def test_vault_oauth_credential_uses_oauth_token_env(
         self, workspace, envs_dir, roster, tmp_path
     ):
-        """OAuth credential selects oauth_phantom_env (e.g. CLAUDE_CODE_OAUTH_TOKEN)."""
+        """OAuth credential selects the oauth ``token_env`` entry (CLAUDE_CODE_OAUTH_TOKEN)."""
         cfg = _make_vault_db(tmp_path, cred_data={"type": "oauth", "access_token": "oa-tok"})
         spec = _spec(workspace, envs_dir, credential_scope="test-project")
         with patch("terok_executor.integrations.sandbox.SandboxConfig", return_value=cfg):
@@ -498,8 +498,8 @@ class TestVaultTokenInjection:
         # API key env var must NOT be set when OAuth credential is stored
         assert "ANTHROPIC_API_KEY" not in result.env
 
-    def test_vault_api_key_falls_back_to_phantom_env(self, workspace, envs_dir, roster, tmp_path):
-        """API-key credential uses phantom_env even when oauth_phantom_env exists."""
+    def test_vault_api_key_uses_default_token_env(self, workspace, envs_dir, roster, tmp_path):
+        """API-key credential falls back to the ``_default`` ``token_env`` entry."""
         cfg = _make_vault_db(tmp_path)
         spec = _spec(workspace, envs_dir, credential_scope="test-project")
         with patch("terok_executor.integrations.sandbox.SandboxConfig", return_value=cfg):

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -36,8 +36,8 @@ class TestVaultRoutesParsed:
         assert route.upstream == "https://api.anthropic.com"
         assert route.auth_header == "dynamic"
         assert route.oauth_extra_headers == {"anthropic-beta": "oauth-2025-04-20"}
-        assert "ANTHROPIC_API_KEY" in route.phantom_env
-        assert "CLAUDE_CODE_OAUTH_TOKEN" in route.oauth_phantom_env
+        assert route.token_env["_default"] == "ANTHROPIC_API_KEY"
+        assert route.token_env["oauth"] == "CLAUDE_CODE_OAUTH_TOKEN"
         assert route.base_url_env == "ANTHROPIC_BASE_URL"
         assert route.socket_env == "ANTHROPIC_UNIX_SOCKET"
 
@@ -66,12 +66,12 @@ class TestVaultRoutesParsed:
         assert route.auth_prefix == ""
         assert route.route_prefix == "gl"
 
-    def test_api_key_only_providers_have_no_oauth_phantom_env(self) -> None:
-        """Providers without OAuth support have empty oauth_phantom_env."""
+    def test_api_key_only_providers_use_default_token_env(self) -> None:
+        """Providers without OAuth support map only ``_default`` in token_env."""
         for name in ("vibe", "blablador", "kisski"):
             route = AgentRoster.shared().vault_routes.get(name)
             assert route is not None, f"{name} missing vault route"
-            assert route.oauth_phantom_env == {}, f"{name} should have no oauth_phantom_env"
+            assert list(route.token_env) == ["_default"], f"{name} should only map _default"
             assert route.socket_env == "", f"{name} should have no socket_env"
 
     def test_opencode_agents_have_routes(self) -> None:
@@ -550,20 +550,20 @@ class TestToVaultRoute:
         assert route is not None
         assert route.socket_env == ""
 
-    def test_oauth_phantom_env_parsed(self) -> None:
-        """oauth_phantom_env is parsed from YAML data."""
+    def test_token_env_parsed(self) -> None:
+        """token_env is parsed from YAML data, keyed by credential type."""
         route = _vault_route(
             "test",
             {
                 "vault": {
                     "route_prefix": "test",
                     "upstream": "https://example.com",
-                    "oauth_phantom_env": {"MY_OAUTH_TOKEN": True},
+                    "token_env": {"oauth": "MY_OAUTH_TOKEN", "_default": "MY_API_KEY"},
                 }
             },
         )
         assert route is not None
-        assert route.oauth_phantom_env == {"MY_OAUTH_TOKEN": True}
+        assert route.token_env == {"oauth": "MY_OAUTH_TOKEN", "_default": "MY_API_KEY"}
 
     def test_missing_required_field_raises(self) -> None:
         """Missing route_prefix or upstream raises ValidationError."""


### PR DESCRIPTION
## What

Replaces the vault route's `phantom_env` / `oauth_phantom_env` pair with a single
typed `token_env` map.

The two fields were `dict[str, bool]` where the **key** was an env-var name and the
**value** was always `true` — a set masquerading as a map, with vendor env-var names
used as schema keys. They collapse into one map keyed by **credential type**, with
`_default` as the fallback:

```yaml
token_env:
  oauth: CLAUDE_CODE_OAUTH_TOKEN
  _default: ANTHROPIC_API_KEY
```

## Behaviour

Injection becomes `token_env[stored_type] or token_env["_default"]`, reproducing the
previous OAuth-vs-API-key selection **exactly**. `routes.json` output is
**byte-identical** (it never carried these fields). All 10 agent YAMLs, the env
builder, the doctor phantom-token check, docs, and tests are updated.

## Verification

- `routes.json` byte-identical to pre-change output
- `ruff` clean; 131 vault/env unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
