### PR TITLE
chore: pin terok-sandbox to the podman-events PR head

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3407,13 +3407,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.0/tero
 
 [[package]]
 name = "terok-sandbox"
-version = "0.1.1a2"
+version = "0.1.1a3"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.1.1a3-py3-none-any.whl", hash = "sha256:184005a490ddc078176c0edbf67756fcfe87dc985bd65da178ab37d17489e307"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3431,10 +3432,8 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.1.1a1/terok_util-0.1.1a1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/terok-ai/terok-sandbox.git"
-reference = "refs/pull/375/head"
-resolved_reference = "f1b8b6987d477cbe8c3157a470a0f9b53bb2c201"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.1.1a3/terok_sandbox-0.1.1a3-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3848,4 +3847,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "08333bf5497cbdb8bf9486e03f88ca33b562e2d2c1a1fc916ae898a662174a86"
+content-hash = "ae66efeb3e7a038eada5f70555abb08bd67a5a30fc8011190ca2c2dcd653d008"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3412,9 +3412,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.1.1a2-py3-none-any.whl", hash = "sha256:47e7fde536cd07763f4f00de59e38291d7205e87732f6ef334ebae23bd1f8905"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3432,8 +3431,10 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.1.1a1/terok_util-0.1.1a1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.1.1a2/terok_sandbox-0.1.1a2-py3-none-any.whl"
+type = "git"
+url = "https://github.com/terok-ai/terok-sandbox.git"
+reference = "refs/pull/375/head"
+resolved_reference = "f1b8b6987d477cbe8c3157a470a0f9b53bb2c201"
 
 [[package]]
 name = "terok-shield"
@@ -3847,4 +3848,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "437d5d0c3b750b48a402101def712a45196cb2e9c5bf4c69feefbc53c73e74eb"
+content-hash = "08333bf5497cbdb8bf9486e03f88ca33b562e2d2c1a1fc916ae898a662174a86"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.1.1a2/terok_sandbox-0.1.1a2-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/terok-ai/terok-sandbox.git@refs/pull/375/head",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.1.1a1/terok_util-0.1.1a1-py3-none-any.whl",
     "ruamel.yaml>=0.18",
     "Jinja2>=3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 dependencies = [
-    "terok-sandbox @ git+https://github.com/terok-ai/terok-sandbox.git@refs/pull/375/head",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.1.1a3/terok_sandbox-0.1.1a3-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.1.1a1/terok_util-0.1.1a1-py3-none-any.whl",
     "ruamel.yaml>=0.18",
     "Jinja2>=3.1",
@@ -54,7 +54,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.1.1a2"
+version = "0.1.1a3"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"


### PR DESCRIPTION
> **Chain link:** Part of the event-driven TUI chain: terok-ai/terok-sandbox#375 → this → terok-ai/terok#1062.

terok-executor pins `terok-sandbox` by URL, and terok pins `terok-sandbox` directly too — so for terok#1062 to resolve the event-stream build without a conflicting-URL-pin error, executor must point at the same source. This repoints `terok-sandbox` at #375's PR head (`refs/pull/375/head`, upstream — carries tags so dynamic-versioning resolves a real version, not `0.0.0`).

Pure dependency pin; no code change. The release script rewrites this git dep into the alpha-wheel URL when the chain is released from the bottom up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the package to a new development release to pick up recent fixes.
  * Updated the terok-sandbox dependency to a later development wheel to align with the package release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->