### PR TITLE
refactor(credentials): centralize the stored credential-type read

### DIFF
--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -553,6 +553,7 @@ def _inject_vault_tokens(
     gates DB-level failure handling: a hard failure (terok project mode)
     versus a soft-fail to an empty dict (standalone default).
     """
+    from terok_executor.credentials.extractors import credential_type
     from terok_executor.integrations.sandbox import SandboxConfig
 
     cfg = SandboxConfig()
@@ -581,7 +582,7 @@ def _inject_vault_tokens(
         tokens: dict[str, str] = {}
         for name in routed:
             cred = db.load_credential(credential_set, name)
-            credential_types[name] = (cred.get("type") if cred else None) or "api_key"
+            credential_types[name] = credential_type(cred)
             tokens[name] = db.create_token(scope, task_id, credential_set, name)
 
         # Per-container port if the caller allocated one (production

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -708,7 +708,7 @@ def _capture_credentials(
     is **not** stored in the vault DB — Claude manages its own token lifecycle
     directly, and vault-side refresh would invalidate the exposed token.
     """
-    from .extractors import extract_credential
+    from .extractors import CRED_TYPE_OAUTH, credential_type, extract_credential
 
     try:
         cred_data = extract_credential(provider_name, auth_dir)
@@ -730,7 +730,7 @@ def _capture_credentials(
                 print(f"  {f}")
         return
 
-    is_oauth = cred_data.get("type") == "oauth"
+    is_oauth = credential_type(cred_data) == CRED_TYPE_OAUTH
     post_capture = _OAUTH_MOUNT_WRITERS.get(provider_name) if is_oauth else None
     # Tier 3 bypass: the host-side vault never refreshes the token, so the
     # container must own its lifecycle.  Storing in the DB would let the

--- a/src/terok_executor/credentials/extractors.py
+++ b/src/terok_executor/credentials/extractors.py
@@ -33,6 +33,24 @@ from .vendor_files import (
 )
 
 # ---------------------------------------------------------------------------
+# Stored credential type (the ``type`` annotation terok keeps beside the token)
+# ---------------------------------------------------------------------------
+
+CRED_TYPE_KEY = "type"
+CRED_TYPE_OAUTH = "oauth"
+CRED_TYPE_API_KEY = "api_key"
+
+
+def credential_type(cred: dict | None) -> str:
+    """Return a stored credential's ``type``, defaulting to api-key.
+
+    Centralises the ``type``/``api_key`` literals the token-injection and
+    post-auth paths share; a missing record or absent field reads as an API key.
+    """
+    return (cred or {}).get(CRED_TYPE_KEY) or CRED_TYPE_API_KEY
+
+
+# ---------------------------------------------------------------------------
 # Individual extractors (scannable catalog entries)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_credential_extractors.py
+++ b/tests/unit/test_credential_extractors.py
@@ -11,6 +11,9 @@ from pathlib import Path
 import pytest
 
 from terok_executor.credentials.extractors import (
+    CRED_TYPE_API_KEY,
+    CRED_TYPE_OAUTH,
+    credential_type,
     extract_api_key_env,
     extract_claude_oauth,
     extract_codex_oauth,
@@ -19,6 +22,19 @@ from terok_executor.credentials.extractors import (
     extract_glab_token,
     extract_json_api_key,
 )
+
+
+class TestCredentialType:
+    """``credential_type`` reads the stored type, defaulting to api-key."""
+
+    def test_reads_stored_type(self) -> None:
+        assert credential_type({"type": CRED_TYPE_OAUTH}) == CRED_TYPE_OAUTH
+
+    def test_absent_field_defaults_to_api_key(self) -> None:
+        assert credential_type({"key": "sk-x"}) == CRED_TYPE_API_KEY
+
+    def test_none_record_defaults_to_api_key(self) -> None:
+        assert credential_type(None) == CRED_TYPE_API_KEY
 
 
 class TestClaudeOAuth:


### PR DESCRIPTION
## What

The token-injection path (`container/env.py`) and the post-auth OAuth-detection
path (`credentials/auth.py`) each inlined the `"type"`/`"api_key"` credential-record
literals when reading a stored credential's type. This extracts a small
`credential_type()` helper plus the type constants (`CRED_TYPE_KEY`,
`CRED_TYPE_OAUTH`, `CRED_TYPE_API_KEY`) into `credentials/extractors.py`, so both
sites read the stored type the same way — a missing record or absent field reads
as an API key.

## Why

Removes duplicated magic literals across the two read sites and gives the
credential-record `type` annotation a single definition. `vault_config`'s
`_stored_credential_type` is intentionally left as-is: it's a distinct
DB-opening reader with `None`-able semantics (it falls back to the route's
declared default rather than api-key).

## Tests

`TestCredentialType` covers the stored / absent / `None` cases. Full unit
suite green (1068), tach clean (no new module dependency — both consumers
already import `extractors`).