### PR TITLE
refactor(roster): declare each agent's provider launcher in YAML

### DIFF
--- a/src/terok_executor/provider/providers.py
+++ b/src/terok_executor/provider/providers.py
@@ -150,6 +150,36 @@ class ProviderBinding:
     """Optional shared-config patch applied after auth (e.g. Codex/Vibe config.toml)."""
 
 
+LAUNCHER_ON_PROVIDER_SELECT = "on_provider_select"
+"""Launcher mode: run only when a provider override is selected (default = bare binary)."""
+
+LAUNCHER_ALWAYS = "always"
+"""Launcher mode: run on every invocation (the launcher does per-run prep)."""
+
+
+@dataclass(frozen=True)
+class Launcher:
+    """How an agent's wrapper hands off to a per-task launcher script.
+
+    A launcher script preps the agent — rewrites provider config, scopes a
+    picker, injects instructions — before exec-ing the binary.  ``mode`` decides
+    when the wrapper routes through it:
+
+    - [`LAUNCHER_ON_PROVIDER_SELECT`][terok_executor.provider.providers.LAUNCHER_ON_PROVIDER_SELECT]
+      — only when a provider override is selected; the default path runs the bare
+      binary (a config-rewriting launcher has nothing to do without a selection).
+    - [`LAUNCHER_ALWAYS`][terok_executor.provider.providers.LAUNCHER_ALWAYS] —
+      every invocation (the launcher does per-run prep the bare binary can't,
+      such as instruction injection).
+    """
+
+    script: str
+    """Launcher script name on PATH (e.g. ``"pi-provider"``)."""
+
+    mode: str
+    """When the launcher runs — one of the ``LAUNCHER_*`` modes."""
+
+
 @dataclass(frozen=True)
 class Agent:
     """Describes how to run one AI coding agent (all modes: interactive + headless)."""
@@ -262,6 +292,12 @@ class Agent:
     """How this agent routes to a provider — see [`ProviderBinding`][terok_executor.provider.providers.ProviderBinding].
 
     ``None`` for entries with no vault route of their own (harnesses, copilot)."""
+
+    launcher: Launcher | None = None
+    """Per-task launcher the wrapper hands off to — see [`Launcher`][terok_executor.provider.providers.Launcher].
+
+    ``None`` runs the bare binary (any provider override arriving via env instead,
+    e.g. Claude)."""
 
     @property
     def uses_opencode_instructions(self) -> bool:

--- a/src/terok_executor/provider/wrappers.py
+++ b/src/terok_executor/provider/wrappers.py
@@ -24,7 +24,7 @@ from typing import Any
 
 from jinja2 import BaseLoader, Environment
 
-from .providers import AGENTS, Agent
+from .providers import AGENTS, LAUNCHER_ALWAYS, LAUNCHER_ON_PROVIDER_SELECT, Agent
 
 INITIAL_PROMPT_PATH = "/home/dev/.terok/initial-prompt.txt"
 """Container path of the per-task initial prompt the TUI/CLI writes at launch."""
@@ -39,18 +39,6 @@ CONTAINER_WORKSPACE = "/workspace"
 """Container path the host-side repo is bind-mounted at (see container/env.py)."""
 
 _TEMPLATE_NAME = "agent-wrappers.sh.j2"
-
-_PROVIDER_LAUNCHERS: dict[str, str] = {
-    "opencode": "opencode-provider",
-    "codex": "codex-provider",
-    "vibe": "vibe-provider",
-}
-"""Agents whose wrapper routes a runtime-selected provider through a launcher script.
-
-A selected provider (``TEROK_PROVIDER`` or an explicit ``--provider``) is handed
-to the named ``*-provider`` script, which rewrites the agent's config to point
-at that provider before launching it.  Claude takes its override as plain
-environment instead (see the ``claude`` wrapper) and so is absent here."""
 
 
 # ── Public API ──────────────────────────────────────────────────────────────
@@ -105,17 +93,23 @@ def _wrapper_context(agent: Agent) -> dict[str, object]:
         if session_path and agent.resume_flag
         else ""
     )
-    # Agents with a launcher run through a ``_runner`` array so a runtime
-    # provider selection can swap the binary for ``<launcher> --provider NAME``
-    # (which rewrites the agent's config before launching).  Every other agent
-    # runs its binary verbatim.
-    provider_launcher = _PROVIDER_LAUNCHERS.get(agent.name, "")
-    cmd = '"${_runner[@]}"' if provider_launcher else binary
-    if agent.name == "pi":
-        # Pi has no config-rewriting launcher; instead it runs through
-        # ``pi-provider``, which peeks/validates ``--provider``, scopes the picker
-        # via ``TEROK_PI_PROVIDER``, and opens Pi on the container default.
-        cmd = "pi-provider"
+    # The agent's launcher (declared in its YAML ``wrapper.launcher``) decides
+    # how the command is built.  ``on_provider_select`` agents run through a
+    # ``_runner`` array so a runtime selection can swap the bare binary for
+    # ``<launcher> --provider NAME`` (which rewrites their config); the
+    # ``provider_launcher`` value drives that array in the template.  ``always``
+    # agents run their launcher on every invocation (it does per-run prep, e.g.
+    # picker scoping + instruction injection).  No launcher → the bare binary.
+    launcher = agent.launcher
+    if launcher is not None and launcher.mode == LAUNCHER_ALWAYS:
+        provider_launcher = ""
+        cmd = launcher.script
+    elif launcher is not None and launcher.mode == LAUNCHER_ON_PROVIDER_SELECT:
+        provider_launcher = launcher.script
+        cmd = '"${_runner[@]}"'
+    else:
+        provider_launcher = ""
+        cmd = binary
     return {
         "name": agent.name,
         "binary": binary,

--- a/src/terok_executor/resources/agents/codex.yaml
+++ b/src/terok_executor/resources/agents/codex.yaml
@@ -30,6 +30,9 @@ capabilities:
 # instead; the egress firewall blocks the OAuth handshake either way.
 wrapper:
   refuse_subcommands: [login, logout]
+  launcher:
+    script: codex-provider
+    mode: on_provider_select
 
 # The endpoint Codex routes to (upstream, the /backend-api/ → chatgpt.com
 # split, token refresh) lives in resources/providers/openai.yaml.

--- a/src/terok_executor/resources/agents/opencode.yaml
+++ b/src/terok_executor/resources/agents/opencode.yaml
@@ -13,6 +13,11 @@ binary: opencode
 # authenticated openai-chat provider — the universal cross-provider path.
 protocol: openai-chat
 
+wrapper:
+  launcher:
+    script: opencode-provider
+    mode: on_provider_select
+
 git_identity:
   name: OpenCode
   email: noreply@opencode.ai

--- a/src/terok_executor/resources/agents/pi.yaml
+++ b/src/terok_executor/resources/agents/pi.yaml
@@ -20,6 +20,15 @@ binary: pi
 # with every authenticated openai-chat provider (see pi-vault-routes.ts).
 protocol: openai-chat
 
+# Pi runs through pi-provider on every launch (mode: always): it scopes the
+# picker to the selected/default provider and injects the per-task instructions,
+# work the bare binary can't do.  The other launchers route only on an explicit
+# provider selection; Pi needs its prep unconditionally.
+wrapper:
+  launcher:
+    script: pi-provider
+    mode: always
+
 git_identity:
   name: Pi
   email: noreply@earendil.works

--- a/src/terok_executor/resources/agents/vibe.yaml
+++ b/src/terok_executor/resources/agents/vibe.yaml
@@ -7,6 +7,11 @@ kind: native
 label: Mistral Vibe
 binary: vibe
 
+wrapper:
+  launcher:
+    script: vibe-provider
+    mode: on_provider_select
+
 git_identity:
   name: Vibe
   email: noreply@mistral.ai

--- a/src/terok_executor/roster/schema.py
+++ b/src/terok_executor/roster/schema.py
@@ -37,7 +37,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
 
 from terok_executor.credentials.auth import AuthKeyConfig, AuthProvider, api_key_command
-from terok_executor.provider.providers import Agent, ProviderBinding
+from terok_executor.provider.providers import Agent, Launcher, ProviderBinding
 
 from .types import (
     HELP_SECTIONS,
@@ -127,10 +127,22 @@ class RawCapabilities(StrictModel):
     log_format: Literal["plain", "claude-stream-json"] = "plain"
 
 
+class RawLauncher(StrictModel):
+    """``wrapper.launcher:`` — the per-task launcher script and when it runs."""
+
+    script: str
+    mode: Literal["on_provider_select", "always"]
+
+    def to_dataclass(self) -> Launcher:
+        """Project to a runtime [`Launcher`][terok_executor.provider.providers.Launcher]."""
+        return Launcher(script=self.script, mode=self.mode)
+
+
 class RawWrapper(StrictModel):
     """``wrapper:`` — in-container shell-wrapper behavior."""
 
     refuse_subcommands: list[str] = Field(default_factory=list)
+    launcher: RawLauncher | None = None
 
 
 class RawOpenCode(StrictModel):
@@ -538,6 +550,7 @@ class RawAgentYaml(StrictModel):
             refuse_subcommands=tuple(wrap.refuse_subcommands),
             protocol=self.protocol,
             provider_binding=self.provider.to_dataclass() if self.provider else None,
+            launcher=wrap.launcher.to_dataclass() if wrap.launcher else None,
         )
 
 
@@ -555,6 +568,7 @@ __all__ = [
     "RawInstall",
     "RawMountSpec",
     "RawOAuthRefresh",
+    "RawLauncher",
     "RawOpenCode",
     "RawProvider",
     "RawProviderAuth",

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -110,6 +110,12 @@ class TestRuntimeProviderWrappers:
         wrapper = generate_agent_wrapper(AGENTS["opencode"])
         assert '_runner=(opencode-provider --provider "$_provider")' in wrapper
 
+    def test_pi_always_routes_through_its_launcher(self) -> None:
+        """Pi (launcher mode ``always``) runs pi-provider every launch, no _runner array."""
+        wrapper = generate_agent_wrapper(AGENTS["pi"])
+        assert "pi-provider" in wrapper
+        assert "_runner=(" not in wrapper
+
     def test_harnesses_declare_manifest_protocol(self) -> None:
         """opencode/pi declare openai-chat so the readiness manifest surfaces them
         paired with openai-chat providers — the universal cross-provider path."""


### PR DESCRIPTION
## What

Make each agent's provider launcher a declarative part of its YAML
(`wrapper.launcher: {script, mode}`) instead of two hardcodes in the wrapper
generator — a Python dict of which agents have a launcher, plus a name check
for pi's always-on one.

## Why

The launcher is agent configuration, so it belongs in the YAML alongside the
rest of the agent's wrapper behavior — self-documenting, and the generator
loses its special-cases. The two modes capture the real distinction:
`on_provider_select` (default = bare binary, launcher only on an explicit
provider — the config-rewriting launchers) and `always` (every launch — pi,
which must run each time to scope its picker and inject instructions). Wrapper
output is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced launcher configuration system enabling flexible agent invocation modes, with settings applied to Codex, OpenCode, Pi, and Vibe agents.
  * Added support for conditional launcher execution based on provider selection or always-on modes.

* **Tests**
  * Added test verifying Pi agent launcher routing behavior on each invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->