### PR TITLE
feat(agents): provider-aware Pi git identity; stop fabricating vendor emails

### DIFF
--- a/src/terok_executor/resources/agents/copilot.yaml
+++ b/src/terok_executor/resources/agents/copilot.yaml
@@ -9,7 +9,7 @@ binary: copilot
 
 git_identity:
   name: Copilot
-  email: noreply@github.com
+  email: copilot@github.com
 
 headless:
   prompt_flag: "-p"

--- a/src/terok_executor/resources/agents/opencode.yaml
+++ b/src/terok_executor/resources/agents/opencode.yaml
@@ -19,7 +19,7 @@ wrapper:
     mode: on_provider_select
 
 git_identity:
-  name: OpenCode
+  name: opencode
   email: noreply@opencode.ai
 
 headless:

--- a/src/terok_executor/resources/agents/pi.yaml
+++ b/src/terok_executor/resources/agents/pi.yaml
@@ -29,9 +29,14 @@ wrapper:
     script: pi-provider
     mode: always
 
+# Placeholder identity.  ``pi-git-identity.ts`` (installed below) rewrites this
+# slot at commit time to the live provider/model — ``Pi (<model>) <pi@<provider>>``
+# — while leaving the human committer terok sets untouched.  If that extension
+# ever fails to load, commits stay honestly attributed to terok's own domain
+# rather than a fabricated vendor address.
 git_identity:
   name: Pi
-  email: noreply@earendil.works
+  email: noreply@terok.ai
 
 headless:
   # ``pi --mode json "<prompt>"`` — prompt is positional, JSON event
@@ -70,6 +75,8 @@ install:
                 /etc/profile.d/pi-env.sh; \
         install -D -m 0644 /tmp/terok-scripts/pi-vault-routes.ts \
                 /usr/local/share/terok/pi-extensions/vault-routes.ts; \
+        install -D -m 0644 /tmp/terok-scripts/pi-git-identity.ts \
+                /usr/local/share/terok/pi-extensions/git-identity.ts; \
         install -m 0755 /tmp/terok-scripts/pi-provider /usr/local/bin/pi-provider
   run_as_dev: |
     RUN npm install -g @earendil-works/pi-coding-agent

--- a/src/terok_executor/resources/agents/vibe.yaml
+++ b/src/terok_executor/resources/agents/vibe.yaml
@@ -13,8 +13,8 @@ wrapper:
     mode: on_provider_select
 
 git_identity:
-  name: Vibe
-  email: noreply@mistral.ai
+  name: Mistral Vibe
+  email: vibe@mistral.ai
 
 headless:
   prompt_flag: "--prompt"

--- a/src/terok_executor/resources/scripts/pi-env.sh
+++ b/src/terok_executor/resources/scripts/pi-env.sh
@@ -17,15 +17,20 @@ export PI_OFFLINE=1
 # Pi reaches Anthropic (and the rest) without an env alias or a credential-file
 # read in this snippet.
 
-# Symlink terok's vault-routing extension into Pi's auto-discovery dir
+# Symlink terok's Pi extensions into Pi's auto-discovery dir
 # (~/.pi/agent/extensions/).  Pi only auto-discovers ``*.ts`` extensions, so the
-# link must be ``.ts`` (the file is plain ESM, which is valid TypeScript).  We
-# ship it at a system-wide path because the user's config dir is a bind mount we
-# don't own.
-_pi_ext_link="${HOME}/.pi/agent/extensions/terok-vault-routes.ts"
-_pi_ext_src="/usr/local/share/terok/pi-extensions/vault-routes.ts"
-if [ -f "$_pi_ext_src" ] && [ ! -L "$_pi_ext_link" ]; then
-    mkdir -p "$(dirname "$_pi_ext_link")"
-    ln -sf "$_pi_ext_src" "$_pi_ext_link"
+# links must be ``.ts`` (the files are plain ESM, which is valid TypeScript).  We
+# ship them at a system-wide path because the user's config dir is a bind mount
+# we don't own.  Linking the whole directory keeps this snippet agnostic to how
+# many extensions terok ships (vault-routes, git-identity, …).
+_pi_ext_dir="/usr/local/share/terok/pi-extensions"
+_pi_ext_link_dir="${HOME}/.pi/agent/extensions"
+if [ -d "$_pi_ext_dir" ]; then
+    mkdir -p "$_pi_ext_link_dir"
+    for _pi_ext_src in "$_pi_ext_dir"/*.ts; do
+        [ -f "$_pi_ext_src" ] || continue
+        _pi_ext_link="${_pi_ext_link_dir}/terok-$(basename "$_pi_ext_src")"
+        [ -L "$_pi_ext_link" ] || ln -sf "$_pi_ext_src" "$_pi_ext_link"
+    done
 fi
-unset _pi_ext_link _pi_ext_src
+unset _pi_ext_dir _pi_ext_link_dir _pi_ext_src _pi_ext_link

--- a/src/terok_executor/resources/scripts/pi-env.sh
+++ b/src/terok_executor/resources/scripts/pi-env.sh
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 #
+# shellcheck shell=bash
+#
 # /etc/profile.d/ snippet for Pi (https://pi.dev).  Sourced by every
 # login shell — including the ``bash -lc`` wrappers terok uses for
 # headless task runs, so the symlink + env aliases are in place before
@@ -25,12 +27,12 @@ export PI_OFFLINE=1
 # many extensions terok ships (vault-routes, git-identity, …).
 _pi_ext_dir="/usr/local/share/terok/pi-extensions"
 _pi_ext_link_dir="${HOME}/.pi/agent/extensions"
-if [ -d "$_pi_ext_dir" ]; then
+if [[ -d "$_pi_ext_dir" ]]; then
     mkdir -p "$_pi_ext_link_dir"
     for _pi_ext_src in "$_pi_ext_dir"/*.ts; do
-        [ -f "$_pi_ext_src" ] || continue
+        [[ -f "$_pi_ext_src" ]] || continue
         _pi_ext_link="${_pi_ext_link_dir}/terok-$(basename "$_pi_ext_src")"
-        [ -L "$_pi_ext_link" ] || ln -sf "$_pi_ext_src" "$_pi_ext_link"
+        [[ -L "$_pi_ext_link" ]] || ln -sf "$_pi_ext_src" "$_pi_ext_link"
     done
 fi
 unset _pi_ext_dir _pi_ext_link_dir _pi_ext_src _pi_ext_link

--- a/src/terok_executor/resources/scripts/pi-git-identity.ts
+++ b/src/terok_executor/resources/scripts/pi-git-identity.ts
@@ -74,7 +74,7 @@ export function specializeGitIdentity(
 	return next;
 }
 
-export default function (pi: ExtensionAPI): void {
+export default function registerGitIdentity(pi: ExtensionAPI): void {
 	const cwd = process.cwd();
 	let provider = "unknown";
 	let modelId = "unknown";

--- a/src/terok_executor/resources/scripts/pi-git-identity.ts
+++ b/src/terok_executor/resources/scripts/pi-git-identity.ts
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+// SPDX-License-Identifier: Apache-2.0
+//
+// Pi extension that specializes terok's git author identity to the *live*
+// provider/model, without disturbing the human terok records as committer.
+//
+// terok bakes GIT_AUTHOR_* / GIT_COMMITTER_* into the container env per its
+// authorship policy (``agent-human`` → author=agent, committer=human, etc.),
+// using the placeholder ``noreply@terok.ai`` for whichever slot it considers
+// "the agent".  Pi is multi-provider and the model can change mid-session, so a
+// static value can't say *which* backend actually wrote a commit.  This
+// extension closes that gap: on every bash spawn it rewrites only the slot(s)
+// still holding terok's placeholder, turning
+//
+//     Pi <noreply@terok.ai>                       (terok's honest placeholder)
+//
+// into a provider-tagged pair derived from the model in play at commit time
+//
+//     Pi (claude-opus-4-8) <pi@anthropic>         (anthropic backend)
+//     Pi (devstral-2)       <pi@mistral>          (after a mid-session switch)
+//
+// The ``pi@<provider>`` address is deliberately domain-less: non-routable,
+// git-accepted, and honest — it names the provider that did the work rather
+// than impersonating a vendor's real ``noreply@`` mailbox.  A slot terok set to
+// anything else (the human committer, or a real configured identity) never
+// matches the sentinel and is passed through untouched, so terok's
+// author/committer policy is preserved across every authorship mode.
+//
+// Adapted from Christian Tietze's "Make the pi Coding Agent Identify the Model
+// in Commits" (https://christiantietze.de/posts/2026/03/pi-coding-agent-git-commit-identify-the-model-audit-trail/),
+// narrowed to rewrite only terok's placeholder so the human committer survives.
+//
+// Self-contained: must be a ``.ts`` file — Pi only auto-discovers ``*.ts``
+// extensions in ~/.pi/agent/extensions/.  Plain ESM is valid TypeScript.
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createBashTool } from "@earendil-works/pi-coding-agent";
+
+// The placeholder terok bakes into the "agent" slot of GIT_AUTHOR_* /
+// GIT_COMMITTER_*.  Must stay in lockstep with ``git_identity.email`` in
+// ``resources/agents/pi.yaml`` — the two are shipped together.
+const TEROK_SENTINEL_EMAIL = "noreply@terok.ai";
+
+const GIT_IDENTITY_ROLES = ["GIT_AUTHOR", "GIT_COMMITTER"] as const;
+
+/** Derive Pi's provider-tagged git identity for the active model. */
+function piIdentity(provider: string, modelId: string): { name: string; email: string } {
+	return { name: `Pi (${modelId})`, email: `pi@${provider}` };
+}
+
+/**
+ * Return ``env`` with every terok-placeholder identity slot specialized to the
+ * live provider/model, and all other slots left exactly as terok set them.
+ *
+ * Pure and side-effect-free so the rewrite rule can be reasoned about (and
+ * tested) without standing up Pi or a container.
+ */
+export function specializeGitIdentity(
+	env: NodeJS.ProcessEnv,
+	provider: string,
+	modelId: string,
+): NodeJS.ProcessEnv {
+	const { name, email } = piIdentity(provider, modelId);
+	const next = { ...env };
+	for (const role of GIT_IDENTITY_ROLES) {
+		// Exact-match the placeholder only: an empty, unset, human, or otherwise
+		// real identity never equals the sentinel and is left exactly as terok
+		// set it.
+		if (env[`${role}_EMAIL`] === TEROK_SENTINEL_EMAIL) {
+			next[`${role}_NAME`] = name;
+			next[`${role}_EMAIL`] = email;
+		}
+	}
+	return next;
+}
+
+export default function (pi: ExtensionAPI): void {
+	const cwd = process.cwd();
+	let provider = "unknown";
+	let modelId = "unknown";
+
+	// Seed from the model resolved at startup, then track every switch so a
+	// mid-session provider change is reflected in the very next commit.
+	pi.on("session_start", async (_event, ctx) => {
+		if (ctx.model) {
+			provider = ctx.model.provider;
+			modelId = ctx.model.id;
+		}
+	});
+	pi.on("model_select", async (event) => {
+		provider = event.model.provider;
+		modelId = event.model.id;
+	});
+
+	// Pi builds each bash subprocess env from a getShellEnv() snapshot and then
+	// applies this hook — so the spawn hook, not process.env, is the reliable
+	// place to reach the git the agent runs.
+	pi.registerTool(
+		createBashTool(cwd, {
+			spawnHook: ({ command, cwd, env }) => ({
+				command,
+				cwd,
+				env: specializeGitIdentity(env, provider, modelId),
+			}),
+		}),
+	);
+}

--- a/src/terok_executor/roster/schema.py
+++ b/src/terok_executor/roster/schema.py
@@ -477,6 +477,11 @@ _DEFAULT_CAPABILITIES = RawCapabilities()
 _DEFAULT_WRAPPER = RawWrapper()
 _DEFAULT_GIT_IDENTITY = RawGitIdentity()
 
+# Git author email for any agent whose roster entry omits ``git_identity.email``.
+# Deliberately terok's own domain — never a fabricated vendor address — so an
+# unconfigured agent is honestly attributed rather than impersonating a provider.
+_FALLBACK_GIT_EMAIL = "noreply@terok.ai"
+
 
 class RawAgentYaml(StrictModel):
     """Full schema for one agent YAML file.
@@ -531,7 +536,7 @@ class RawAgentYaml(StrictModel):
             label=self.resolve_label(name),
             binary=self.binary or name,
             git_author_name=gi.name or name.capitalize(),
-            git_author_email=gi.email or f"noreply@{name}.ai",
+            git_author_email=gi.email or _FALLBACK_GIT_EMAIL,
             headless_subcommand=hl.subcommand,
             prompt_flag=hl.prompt_flag,
             auto_approve_env=dict(aa.env),


### PR DESCRIPTION
## Why

An audit of the git author identities terok injects per agent found several **fabricated vendor-shaped emails** — addresses no vendor tool actually stamps:

| Agent | Was | Reality in the wild |
|-------|-----|---------------------|
| **Pi** | `Pi <noreply@earendil.works>` | Pi has no built-in identity; it never uses earendil.works |
| **Copilot** | `noreply@github.com` | no Copilot surface emits this (`copilot@github.com` is the editor co-author) |
| **Vibe** | `Vibe <noreply@mistral.ai>` | vendor uses `Mistral Vibe <vibe@mistral.ai>` |
| **fallback** | `noreply@{name}.ai` | synthesizes a plausible-but-fake vendor domain for any unconfigured agent |

Claude (`noreply@anthropic.com`) and Codex (`noreply@openai.com`) already matched their tools' documented defaults and are unchanged.

The Pi case is the headline: it landed `Pi <noreply@earendil.works>` verbatim in real history (e.g. mkdocs-terok#88). Pi is multi-provider and the model can switch mid-session, so no static value can say *which* backend wrote a commit.

## What

**Email corrections** (one-liners): Copilot → `copilot@github.com`; Vibe → `Mistral Vibe <vibe@mistral.ai>`; opencode → lowercase name (matches its own co-author trailer; email was already correct); fallback → `noreply@terok.ai` (our own domain — never a fake vendor one).

**`pi-git-identity.ts`** — a Pi extension that, on every bash spawn, rewrites **only** the slot still holding terok's `noreply@terok.ai` placeholder into a provider-tagged pair derived from the live model:

```
Pi (claude-opus-4-8) <pi@anthropic>     # author
Jiří Vyskočil <jiri@vyskocil.com>       # committer — untouched
```

Keyed on an exact match of the placeholder, so an empty, unset, human, or real configured identity passes through verbatim — terok's authorship policy is fully preserved across every mode. The `pi@<provider>` form is deliberately domain-less: non-routable, git-accepted, honest. If the extension ever fails to load, commits fall back to the honest `Pi <noreply@terok.ai>` rather than a fabricated vendor address.

Adapted from [Christian Tietze's "Make the pi Coding Agent Identify the Model in Commits"](https://christiantietze.de/posts/2026/03/pi-coding-agent-git-commit-identify-the-model-audit-trail/), **narrowed to preserve the human committer** (his version overwrites both author and committer).

`pi-env.sh` now symlinks the whole `pi-extensions/` directory instead of one hardcoded file, so future terok extensions auto-discover.

## Testing

- `ruff check` / `ruff format --check` / `reuse lint` — clean
- `pytest tests/unit/test_roster.py` — 84 passed; full unit suite 1059 passed (remaining failures are local-only `nft`/`podman` environmental gaps, unrelated to this change)
- Container/runtime behavior of the Pi extension needs podman — not exercised in CI here; verify on the test machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pi agent now applies provider/model-tagged commit identities for spawned subprocesses
  * Pi agent auto-discovers and links all installed Pi extensions

* **Chores**
  * Updated git identity values for Copilot, OpenCode, Pi, and Vibe agents
  * Default fallback git email changed to noreply@terok.ai
<!-- end of auto-generated comment: release notes by coderabbit.ai -->