### PR TITLE
docs: homepage URL, terok cross-link, and docs-dependency refresh

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 `terok-executor` runs an AI coding agent inside a hardened, rootless
 Podman container — one CLI command to launch, or one Python class to
-embed in your own tooling.
+embed in your own tooling. It is the single-task runtime used by [terok](https://terok-ai.github.io/terok/).
 
 ![terok ecosystem — terok-executor sits between project orchestration and the hardened runtime](img/architecture.svg)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3847,4 +3847,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "ae66efeb3e7a038eada5f70555abb08bd67a5a30fc8011190ca2c2dcd653d008"
+content-hash = "11b1688d7c8509e8203a838af7c985731e58a9c2ea3f8740091475a0a6366a8b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://terok.ai/"
+Homepage = "https://terok-ai.github.io/terok-executor/"
 Repository = "https://github.com/terok-ai/terok-executor"
 Documentation = "https://terok-ai.github.io/terok-executor/"
 Issues = "https://github.com/terok-ai/terok-executor/issues"
@@ -75,8 +75,8 @@ pytest-timeout = ">=2.0"
 
 [tool.poetry.group.docs.dependencies]
 properdocs = ">=1.6.7"
-mkdocs-material = ">=9.0"
-mkdocstrings = {extras = ["python"], version = ">=0.24"}
+mkdocs-material = ">=9.7.6"
+mkdocstrings = {extras = ["python"], version = ">=0.26"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"


### PR DESCRIPTION
Change Homepage URL from https://terok.ai/ to https://terok-ai.github.io/terok-executor/ for verified link on PyPI. Also add subtle link to main terok docs in index.md.