### PR TITLE
docs: fix vault socket paths, supervisor lifecycle claim, add Pi to roster table

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ runs across many projects.  Below it, terok-executor delegates the
 host-side security boundary
 ([terok-sandbox](https://github.com/terok-ai/terok-sandbox)): the
 credential vault, the git gate, the egress firewall hooks, the
-systemd service lifecycle.
+per-container supervisor lifecycle (OCI `createRuntime`/`poststop`
+hooks).
 
 ## Commands
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -9,6 +9,7 @@
 | Vibe | API key | Mistral Vibe |
 | Copilot | — | GitHub Copilot (not proxied yet) |
 | Blablador | API key | Helmholtz Blablador via OpenCode |
+| Pi | — (reuses co-installed providers) | [Pi](https://pi.dev/) multi-provider harness; routes through the phantom tokens of co-installed agents |
 | KISSKI | API key | KISSKI AcademicCloud via OpenCode |
 
 \* OAuth support for Claude and Codex is experimental.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -81,19 +81,18 @@ their SDK supports:
 gh has no env var for base URL. It supports `http_unix_socket` in its
 config file, which routes all API traffic through a Unix socket.
 
-The init script (`init-ssh-and-repo.sh`) starts a socat bridge:
+The `shared_config_patch` mechanism writes the vault socket path into
+`~/.config/gh/config.yml` during `terok-executor auth gh` — the
+`{vault_socket}` template token, resolved per transport mode:
 
-```bash
-socat UNIX-LISTEN:/tmp/terok-gh-proxy.sock,fork \
-  TCP:host.containers.internal:${TEROK_TOKEN_BROKER_PORT} &
-```
+- **socket mode**: `/run/terok/vault.sock` — the supervisor's vault
+  socket, bind-mounted into the container.
+- **TCP mode**: `/tmp/terok-vault.sock` — a socat bridge started by
+  terok-sandbox's `ensure-bridges.sh`, forwarding to
+  `host.containers.internal:${TEROK_TOKEN_BROKER_PORT}`.
 
-The socket is created **inside** the container by the container's own
-process. SELinux allows `container_t -> container_t` socket connections.
-The TCP hop to the host token broker crosses the container boundary safely.
-
-The `http_unix_socket` path is written to `~/.config/gh/config.yml`
-by the `shared_config_patch` mechanism during `terok-executor auth gh`.
+Either way gh's API traffic reaches the vault token broker, which
+substitutes the phantom token before forwarding upstream.
 
 ### YAML-driven shared_config_patch
 
@@ -148,9 +147,10 @@ vault:
   by the environment builder for glab specifically. glab has no YAML field
   for this because it's a routing concern, not a credential concern.
 
-- **socat bridge**: Started by `init-ssh-and-repo.sh` when `TEROK_TOKEN_BROKER_PORT`
-  and `GH_TOKEN` are both set. The socket path is hardcoded to
-  `/tmp/terok-gh-proxy.sock` (matching the `shared_config_patch`).
+- **socat bridge**: In TCP mode, terok-sandbox's `ensure-bridges.sh`
+  exposes the broker as `/tmp/terok-vault.sock` for socket-only clients
+  (gh, claude). In socket mode no bridge is needed — the broker socket is
+  bind-mounted at `/run/terok/vault.sock`.
 
 ## Auth Flow
 


### PR DESCRIPTION
Part of a docs-vs-source audit across the terok stack (companion to terok-ai/terok#1080).

- `docs/vault.md` described a gh-specific `/tmp/terok-gh-proxy.sock` socat bridge started by `init-ssh-and-repo.sh`. Neither exists: gh's `http_unix_socket` is patched with the `{vault_socket}` template token (`credentials/vault_config.py`), which resolves to the bind-mounted `/run/terok/vault.sock` in socket mode or `/tmp/terok-vault.sock` in TCP mode — the latter bridged by terok-sandbox's `ensure-bridges.sh`.
- README: terok-sandbox manages the per-container supervisor via OCI `createRuntime`/`poststop` hooks; "the systemd service lifecycle" was retired with the pre-supervisor layout.
- `docs/agents.md`: the shipped roster includes Pi (`agents/pi.yaml`, `kind: harness`); documented it in the agent table.

Markdown-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Pi agent to the supported agents list as a multi-provider harness option
  * Updated system architecture documentation with clarified lifecycle management explanations
  * Enhanced integration documentation with improved details on configuration workflows and network handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->