### PR TITLE
feat(auth): force device-code login non-interactively via device_auth

### DIFF
--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -338,8 +338,14 @@ def _handle_auth(
     agent: str,
     api_key: str | None = None,
     base_image: str | None = None,
+    device_auth: bool = False,
 ) -> None:
-    """Run auth flow for an agent."""
+    """Run auth flow for an agent.
+
+    With *device_auth* the interactive method chooser is skipped and the
+    provider's headless device-code login runs directly — for remote or
+    headless hosts where the browser callback can't open.
+    """
     from .credentials.auth import AUTH_PROVIDERS, Authenticator, store_api_key
 
     if api_key is not None:
@@ -361,6 +367,7 @@ def _handle_auth(
             None,
             mounts_dir=mounts_dir(),
             image=lambda: ImageBuilder(base).ensure_default_l1(),
+            device_auth=device_auth,
         )
 
     # Write vault URLs to shared config files (e.g. Vibe config.toml, gh config.yml)
@@ -773,6 +780,11 @@ AUTH_COMMAND = CommandDef(
     args=(
         ArgDef(name="agent", help="Agent or tool name (claude, codex, gh, ...)"),
         ArgDef(name="--api-key", help="Store an API key directly (skip interactive auth)"),
+        ArgDef(
+            name="--device-auth",
+            action="store_true",
+            help="Force the headless device-code login (skip the method chooser)",
+        ),
         ArgDef(
             name="--base-image",
             help=(

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -344,9 +344,20 @@ def _handle_auth(
 
     With *device_auth* the interactive method chooser is skipped and the
     provider's headless device-code login runs directly — for remote or
-    headless hosts where the browser callback can't open.
+    headless hosts where the browser callback can't open.  ``--api-key`` and
+    ``--device-auth`` are mutually exclusive; passing both takes the API-key
+    route (no container) and warns that ``--device-auth`` was ignored.
     """
     from .credentials.auth import AUTH_PROVIDERS, Authenticator, store_api_key
+
+    if api_key is not None and device_auth:
+        import sys
+
+        print(
+            "Warning: --device-auth is ignored when --api-key is given; "
+            "the API key takes precedence (no auth container is launched).",
+            file=sys.stderr,
+        )
 
     if api_key is not None:
         if not api_key.strip():

--- a/src/terok_executor/credentials/auth.py
+++ b/src/terok_executor/credentials/auth.py
@@ -185,13 +185,15 @@ class Authenticator:
         expose_token: bool = False,
         oauth_enabled: bool = True,
         credential_set: str = "default",
+        device_auth: bool = False,
     ) -> None:
         """Run the auth flow for ``self.provider``; see module-level docs.
 
         Mirrors the parameters of the underlying ``authenticate`` free
         function — instance-bound ``self.provider`` replaces the old
-        positional ``provider`` arg.  The device-code login is offered as a
-        method in that flow's prompt, so it needs no parameter here.
+        positional ``provider`` arg.  The device-code login is normally
+        offered as a method in that flow's prompt; pass *device_auth* to
+        skip the prompt and force it (the headless ``--device-auth`` path).
         """
         authenticate(
             project_id,
@@ -201,6 +203,7 @@ class Authenticator:
             expose_token=expose_token,
             oauth_enabled=oauth_enabled,
             credential_set=credential_set,
+            device_auth=device_auth,
         )
 
     def prepare_oauth(
@@ -255,6 +258,7 @@ def authenticate(
     expose_token: bool = False,
     oauth_enabled: bool = True,
     credential_set: str = "default",
+    device_auth: bool = False,
 ) -> None:
     """Run the auth flow for *provider*, optionally scoped to a project.
 
@@ -264,6 +268,11 @@ def authenticate(
     the roster declares (``modes:``, ``device_auth``) intersected with what the
     caller permits via *oauth_enabled*.  One method runs straight through; two or
     more prompt the user to choose.
+
+    Pass *device_auth* to force the device-code variant non-interactively
+    (the headless ``--device-auth`` path): the menu is skipped and the
+    device-code login runs straight through.  Raises ``SystemExit`` if the
+    provider has no device-code login or OAuth is gated off.
 
     Args:
         project_id: Project identifier used for container naming and the
@@ -339,6 +348,22 @@ def authenticate(
             methods.append(("OAuth login — device code", lambda: _oauth(device=True)))
     if has_api_key:
         methods.append(("API key", _api_key))
+
+    if device_auth:
+        # Headless force: bypass the chooser and run the device-code login
+        # directly.  Reuses the OAuth gate's hint when the path is closed.
+        if not has_oauth:
+            raise SystemExit(
+                f"Device-code auth for {provider!r} requires OAuth, but it is "
+                f"disabled by the caller's gating policy.  For terok this "
+                f"typically means the experimental flag and/or the "
+                f"provider-specific allow_oauth/expose_oauth_token config "
+                f"keys are unset."
+            )
+        if not info.supports_device_auth:
+            raise SystemExit(f"Provider {provider!r} has no device-code login.")
+        _oauth(device=True)
+        return
 
     if not methods:
         # Provider declares only OAuth and the caller's gate is closed.

--- a/tests/unit/test_auth_capture.py
+++ b/tests/unit/test_auth_capture.py
@@ -1460,3 +1460,78 @@ class TestAuthenticateCredentialSet:
         ):
             authenticate(None, "vibe", mounts_dir=tmp_path)
         mock_store.assert_called_once_with("vibe", "sk", credential_set="default")
+
+
+class TestDeviceAuthForcePath:
+    """``authenticate(device_auth=True)`` skips the chooser and forces device-code."""
+
+    @staticmethod
+    def _codex(*, device_auth: bool = True) -> object:
+        from terok_executor.credentials.auth import AuthProvider
+
+        return AuthProvider(
+            name="codex",
+            label="Codex",
+            host_dir_name="_codex-config",
+            container_mount="/home/dev/.codex",
+            command=["setup-codex-auth.sh"],
+            banner_hint="",
+            modes=("oauth", "api_key"),
+            api_key_hint="hint",
+            device_auth=device_auth,
+        )
+
+    def test_forces_device_login_without_prompt(self, tmp_path: Path) -> None:
+        """No ``input`` is read and the container runs with ``device_auth=True``."""
+        from terok_executor.credentials.auth import authenticate
+
+        def _boom(*_a: object, **_k: object) -> str:
+            raise AssertionError("device_auth must not prompt")
+
+        with (
+            patch.dict(
+                "terok_executor.credentials.auth.AUTH_PROVIDERS",
+                {"codex": self._codex()},
+                clear=True,
+            ),
+            patch("builtins.input", _boom),
+            patch("terok_executor.credentials.auth._run_auth_container") as mock_run,
+        ):
+            authenticate(None, "codex", mounts_dir=tmp_path, image="l1:tag", device_auth=True)
+
+        assert mock_run.call_args.kwargs["device_auth"] is True
+
+    def test_unsupported_provider_raises(self, tmp_path: Path) -> None:
+        """Forcing device-auth on a provider that lacks it is a hard error."""
+        from terok_executor.credentials.auth import authenticate
+
+        with (
+            patch.dict(
+                "terok_executor.credentials.auth.AUTH_PROVIDERS",
+                {"codex": self._codex(device_auth=False)},
+                clear=True,
+            ),
+            pytest.raises(SystemExit, match="no device-code login"),
+        ):
+            authenticate(None, "codex", mounts_dir=tmp_path, image="l1:tag", device_auth=True)
+
+    def test_oauth_gated_off_raises(self, tmp_path: Path) -> None:
+        """A closed OAuth gate blocks the device-code variant too."""
+        from terok_executor.credentials.auth import authenticate
+
+        with (
+            patch.dict(
+                "terok_executor.credentials.auth.AUTH_PROVIDERS",
+                {"codex": self._codex()},
+                clear=True,
+            ),
+            pytest.raises(SystemExit, match="requires OAuth"),
+        ):
+            authenticate(
+                None,
+                "codex",
+                mounts_dir=tmp_path,
+                image="l1:tag",
+                oauth_enabled=False,
+                device_auth=True,
+            )

--- a/tests/unit/test_authenticator.py
+++ b/tests/unit/test_authenticator.py
@@ -36,6 +36,7 @@ def test_run_delegates_with_bound_provider() -> None:
         expose_token=True,
         oauth_enabled=False,
         credential_set="proj-123",
+        device_auth=False,
     )
 
 
@@ -51,7 +52,15 @@ def test_run_defaults_match_underlying_fn() -> None:
         expose_token=False,
         oauth_enabled=True,
         credential_set="default",
+        device_auth=False,
     )
+
+
+def test_run_forwards_device_auth() -> None:
+    """``device_auth=True`` rides through to the underlying fn."""
+    with mock.patch("terok_executor.credentials.auth.authenticate") as auth:
+        Authenticator("codex").run(None, mounts_dir=Path("/m"), device_auth=True)
+    assert auth.call_args.kwargs["device_auth"] is True
 
 
 def test_provider_is_frozen() -> None:

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -48,6 +48,16 @@ def test_handle_auth_oauth_path_routes_through_authenticator() -> None:
     cls.return_value.run.assert_called_once()
 
 
+def test_handle_auth_device_auth_forwards_to_run() -> None:
+    """``--device-auth`` rides through to ``Authenticator.run(device_auth=True)``."""
+    with (
+        mock.patch("terok_executor.credentials.auth.Authenticator") as cls,
+        mock.patch("terok_executor.credentials.vault_config.write_vault_config"),
+    ):
+        _handle_auth(agent="codex", device_auth=True)
+    assert cls.return_value.run.call_args.kwargs["device_auth"] is True
+
+
 def test_handle_auth_empty_api_key_raises() -> None:
     """Empty api_key surfaces as a clean SystemExit, not an obscure failure."""
     with pytest.raises(SystemExit, match="cannot be empty"):

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -58,6 +58,19 @@ def test_handle_auth_device_auth_forwards_to_run() -> None:
     assert cls.return_value.run.call_args.kwargs["device_auth"] is True
 
 
+def test_handle_auth_api_key_and_device_auth_warns_and_takes_api_key(capsys) -> None:
+    """Both flags given → API key wins, `--device-auth` is ignored with a warning."""
+    with (
+        mock.patch("terok_executor.credentials.auth.store_api_key") as store,
+        mock.patch("terok_executor.credentials.auth.Authenticator") as cls,
+        mock.patch("terok_executor.credentials.vault_config.write_vault_config"),
+    ):
+        _handle_auth(agent="codex", api_key="sk-test", device_auth=True)
+    store.assert_called_once()  # API-key route taken
+    cls.return_value.run.assert_not_called()  # no auth container
+    assert "--device-auth is ignored" in capsys.readouterr().err
+
+
 def test_handle_auth_empty_api_key_raises() -> None:
     """Empty api_key surfaces as a clean SystemExit, not an obscure failure."""
     with pytest.raises(SystemExit, match="cannot be empty"):


### PR DESCRIPTION
## What

Elevate the OAuth **device-code** variant to a first-class, scriptable method alongside the interactive chooser.

- `authenticate()` / `Authenticator.run()` gain a `device_auth` flag that skips the method prompt and runs the headless device-code login straight through.
- The `terok-executor auth` CLI exposes it as `--device-auth`.
- Validates the provider declares device-auth and that the OAuth gate is open, raising a clear `SystemExit` otherwise.

## Why

This is the **bottom of a 2-repo PR chain**. terok's new `terok auth <provider> --device-auth` flag and its TUI device-code chooser both forward through to this param (terok lacks stdin in the worker/headless paths, so it can't drive the executor's interactive menu — it needs the programmatic flag).

The interactive menu already listed device-code; this adds the non-interactive seam.

## Tests

- `Authenticator.run` forwards `device_auth`.
- `_handle_auth` forwards `--device-auth`.
- Force-path runs device login without prompting; raises on unsupported provider / closed OAuth gate.

Podman-dependent auth tests are unchanged and run on the test machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `--device-auth` option for authentication, enabling non-interactive device-code login.
* **Bug Fixes**
  * Forced device-auth now bypasses the interactive authentication method chooser and uses the correct headless flow.
  * Added clear validation and failure behavior when device-auth is unsupported or when OAuth is disabled.
  * If both `--api-key` and `--device-auth` are provided, the API key path takes precedence and a warning is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->