### PR TITLE
feat(hilfe): dim unusable agents, list candidate providers by protocol

### DIFF
--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -35,9 +35,11 @@ L1 is roster-driven: each agent's install steps live in its YAML file
 (``install.run_as_root`` / ``install.run_as_dev``), and the L1 template
 loops over the resolved selection.  Build emits an OCI label
 ``ai.terok.agents=<csv>``, an in-container manifest
-``/etc/terok/installed.env``, pre-rendered ``hilfe`` help fragments, and a
-baked agent→wire-protocol map (``agent-protocols.json``) that the
-in-container readiness check consumes — all derived from the same selection.
+``/etc/terok/installed.env``, pre-rendered ``hilfe`` dev-tool help
+fragments, and a baked per-agent facts map (``agent-protocols.json`` —
+wire protocol, default provider, and banner label) that the in-container
+readiness check and the ``hilfe`` agent banner consume — all derived from
+the same selection.
 """
 
 from __future__ import annotations
@@ -70,16 +72,38 @@ INSTALLED_ENV_PATH = "/etc/terok/installed.env"
 """In-container env file that scripts source to learn what's installed."""
 
 AGENT_PROTOCOLS_PATH = "/usr/local/share/terok/agent-protocols.json"
-"""In-container map of each installed agent to the wire protocol it speaks.
+"""In-container map of each installed agent to the roster facts the readiness
+check and the ``hilfe`` banner need.
 
-The readiness check (``terok-agents``) needs each agent's wire protocol to
-decide which authenticated providers it can talk to, and that mapping is the
-one piece of roster knowledge the container environment does not already
-carry.  Baked at L1 build time the same way the ``hilfe`` help fragments are,
-and read back by the in-container manifest generator."""
+Each entry carries the agent's wire ``protocol`` (which authenticated
+providers it can talk to), its default ``provider`` (for natives that bind
+one), and its banner ``label``.  These are the pieces of roster knowledge the
+container environment does not already carry.  Baked at L1 build time and read
+back by the in-container manifest generator (``terok-agents``).
 
-_HELP_SECTION_FILES: dict[str, str] = {"agent": "agents.txt", "dev_tool": "dev-tools.txt"}
-"""Maps each [`HelpSection`][terok_executor.roster.loader.HelpSection] to its fragment filename."""
+The filename is historical (it once held only protocols); the contents are now
+a small per-agent record.  Producer ([`stage_agent_facts`][terok_executor.container.build.stage_agent_facts])
+and consumer ship in the same wheel, baked into and read from the same image,
+so the shape is free to evolve in lockstep."""
+
+PROVIDER_PROTOCOLS_PATH = "/usr/local/share/terok/provider-protocols.json"
+"""In-container map of each wire protocol to the providers that serve it.
+
+The complement of [`AGENT_PROTOCOLS_PATH`][terok_executor.container.build.AGENT_PROTOCOLS_PATH]: agents say which protocol
+they speak, this says which providers speak it.  Lets ``hilfe`` list, under the
+providers section, the candidate providers a user could authenticate to enable
+a dimmed agent — including providers not yet authenticated, which the container
+environment does not carry.  Baked at L1 build time by
+[`stage_provider_protocols`][terok_executor.container.build.stage_provider_protocols]."""
+
+_HELP_SECTION_FILES: dict[str, str] = {"dev_tool": "dev-tools.txt"}
+"""Maps a [`HelpSection`][terok_executor.roster.loader.HelpSection] to its baked fragment filename.
+
+Only ``dev_tool`` is pre-rendered: dev tools aren't auth-gated, so a static
+``cat`` is enough.  The ``agent`` section is *not* baked here — the ``hilfe``
+banner renders it at runtime from the readiness manifest (so unusable agents
+can be dimmed), driven by the per-agent facts in ``agent-protocols.json``.
+"""
 
 _ESCAPE_RE = re.compile(r"\\(?:[0-7]{1,3}|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|[nrtbfav\\'\"])")
 """Backslash escapes recognised in roster ``help.label`` strings.
@@ -508,7 +532,8 @@ def build_base_images(
         try:
             prepare_build_context(context)
             stage_help_fragments(context / "help.d", selected)
-            stage_agent_protocols(context / "agent-protocols.json", selected)
+            stage_agent_facts(context / "agent-protocols.json", selected)
+            stage_provider_protocols(context / "provider-protocols.json", selected)
 
             # Single timestamp for both render and build-arg consistency
             cache_bust = str(int(time.time()))
@@ -741,6 +766,7 @@ def render_l1(
             "agents_label": AGENTS_LABEL,
             "installed_env_path": INSTALLED_ENV_PATH,
             "agent_protocols_path": AGENT_PROTOCOLS_PATH,
+            "provider_protocols_path": PROVIDER_PROTOCOLS_PATH,
         },
     )
 
@@ -816,23 +842,25 @@ def stage_toad_agents(dest: Path) -> None:
 
 
 def stage_help_fragments(dest: Path, agents: tuple[str, ...]) -> None:
-    """Render per-section ``hilfe`` help fragments into *dest*.
+    """Render the baked ``hilfe`` help fragments into *dest*.
 
-    Writes one file per section (currently ``agent`` and ``dev_tool``)
-    containing the labels of the selected agents that have a ``help:``
-    section, with backslash escapes (``\\033[...]``) interpreted into
-    real ANSI sequences so that ``hilfe`` only needs to ``cat`` them.
-    Empty sections are omitted entirely; ``hilfe`` skips missing files.
+    Writes one file per *bakeable* section — only ``dev_tool`` (see
+    [`_HELP_SECTION_FILES`][terok_executor.container.build._HELP_SECTION_FILES]) — holding the labels of the
+    selected entries that have a ``help:`` block, with backslash escapes
+    (``\\033[...]``) interpreted into real ANSI so that ``hilfe`` only needs to
+    ``cat`` them.  The ``agent`` section is deliberately not baked: ``hilfe``
+    renders it at runtime so unusable agents can be dimmed (see
+    [`stage_agent_facts`][terok_executor.container.build.stage_agent_facts]).  Empty sections are omitted;
+    ``hilfe`` skips missing files.
     """
     from terok_executor.roster import AgentRoster
 
-    roster = AgentRoster.shared()
-    helps = roster.helps
+    helps = AgentRoster.shared().helps
 
     by_section: dict[str, list[str]] = {}
     for name in agents:
         spec = helps.get(name)
-        if spec is None or not spec.label:
+        if spec is None or not spec.label or spec.section not in _HELP_SECTION_FILES:
             continue
         by_section.setdefault(spec.section, []).append(spec.label)
 
@@ -844,29 +872,80 @@ def stage_help_fragments(dest: Path, agents: tuple[str, ...]) -> None:
         (dest / _HELP_SECTION_FILES[section]).write_text(decoded, encoding="utf-8")
 
 
-def stage_agent_protocols(dest_file: Path, agents: tuple[str, ...]) -> None:
-    """Bake the agent→wire-protocol map for *agents* into *dest_file* as JSON.
+def stage_agent_facts(dest_file: Path, agents: tuple[str, ...]) -> None:
+    """Bake the per-agent facts the in-container readiness layer needs, as JSON.
 
-    Records the wire protocol of every selected entry that speaks one — the
-    LLM-backed agents (claude, codex, vibe).  Tools and harnesses are left
-    out: they carry no fixed protocol, so the in-container readiness check has
-    nothing to match them against a provider on.  This map is the only roster
-    fact that check cannot reconstruct from the container environment, so it
-    travels into the image the same way the ``hilfe`` help fragments do.
+    For every selected entry in the ``agent`` help section, records a small
+    record — ``{"protocol", "label"}`` — so that ``terok-agents`` can decide, at
+    runtime, whether each agent has an authenticated provider it can talk to,
+    and ``hilfe`` can render it bright or dimmed:
 
-    The file is always written — an empty object when nothing in the selection
-    speaks a protocol — so the Dockerfile ``COPY`` always has a source.
+    - ``protocol`` — the wire protocol the agent speaks (``None`` for entries
+      with no fixed protocol, e.g. the ``toad`` frontend).  An agent is usable
+      when *any* authenticated provider serves this protocol — not tied to a
+      single default — so the protocol, not a provider name, is the fact that
+      matters.  The provider→protocol universe is baked separately by
+      [`stage_provider_protocols`][terok_executor.container.build.stage_provider_protocols].
+    - ``label`` — the banner line, escapes already decoded to real ANSI.
+
+    These facts are the only roster knowledge the container environment cannot
+    reconstruct, so they travel into the image alongside the help fragments.
+    The file is always written — an empty object when the selection has no
+    agent-section entries — so the Dockerfile ``COPY`` always has a source.
     """
     from terok_executor.roster import AgentRoster
 
-    agents_by_name = AgentRoster.shared().agents
+    roster = AgentRoster.shared()
+    agents_by_name = roster.agents
+    helps = roster.helps
+
+    facts: dict[str, dict[str, str | None]] = {}
+    for name in agents:
+        spec = helps.get(name)
+        if spec is None or not spec.label or spec.section != "agent":
+            continue
+        agent = agents_by_name.get(name)
+        facts[name] = {
+            "protocol": agent.protocol if agent else None,
+            "label": _decode_label_escapes(spec.label),
+        }
+    dest_file.parent.mkdir(parents=True, exist_ok=True)
+    dest_file.write_text(json.dumps(facts, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def stage_provider_protocols(dest_file: Path, agents: tuple[str, ...]) -> None:
+    """Bake the wire-protocol → candidate-providers universe as JSON.
+
+    For every protocol any selected agent speaks, records the sorted list of
+    providers whose ``serves`` covers it — i.e. the providers a user could
+    authenticate to make those agents usable.  This is what lets ``hilfe`` turn
+    a dimmed agent's ``needs an openai-chat provider`` into an actionable list
+    under the providers section, including providers not yet authenticated
+    (which the container environment, carrying only *authenticated* providers,
+    cannot enumerate on its own).
+
+    Scoped to the protocols actually in play for this image, so an L1 without a
+    given agent doesn't advertise providers for a protocol nothing speaks.  The
+    file is always written — an empty object when no selected agent speaks a
+    protocol — so the Dockerfile ``COPY`` always has a source.
+    """
+    from terok_executor.roster import AgentRoster
+
+    roster = AgentRoster.shared()
+    agents_by_name = roster.agents
+    providers = roster.providers
+
     protocols = {
-        name: agents_by_name[name].protocol
+        agents_by_name[name].protocol
         for name in agents
         if name in agents_by_name and agents_by_name[name].protocol
     }
+    universe = {
+        protocol: sorted(name for name, prov in providers.items() if protocol in prov.serves)
+        for protocol in protocols
+    }
     dest_file.parent.mkdir(parents=True, exist_ok=True)
-    dest_file.write_text(json.dumps(protocols, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    dest_file.write_text(json.dumps(universe, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def stage_tmux_config(dest: Path) -> None:

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -37,9 +37,8 @@ loops over the resolved selection.  Build emits an OCI label
 ``ai.terok.agents=<csv>``, an in-container manifest
 ``/etc/terok/installed.env``, pre-rendered ``hilfe`` dev-tool help
 fragments, and a baked per-agent facts map (``agent-protocols.json`` —
-wire protocol, default provider, and banner label) that the in-container
-readiness check and the ``hilfe`` agent banner consume — all derived from
-the same selection.
+wire protocol and banner label) that the in-container readiness check and
+the ``hilfe`` agent banner consume — all derived from the same selection.
 """
 
 from __future__ import annotations
@@ -76,10 +75,12 @@ AGENT_PROTOCOLS_PATH = "/usr/local/share/terok/agent-protocols.json"
 check and the ``hilfe`` banner need.
 
 Each entry carries the agent's wire ``protocol`` (which authenticated
-providers it can talk to), its default ``provider`` (for natives that bind
-one), and its banner ``label``.  These are the pieces of roster knowledge the
-container environment does not already carry.  Baked at L1 build time and read
-back by the in-container manifest generator (``terok-agents``).
+providers it can talk to — ``null`` for entries with no fixed protocol) and its
+banner ``label``.  These are the pieces of roster knowledge the container
+environment does not already carry.  Usability turns on the protocol alone —
+any authenticated provider serving it works — so no provider name is recorded.
+Baked at L1 build time and read back by the in-container manifest generator
+(``terok-agents``).
 
 The filename is historical (it once held only protocols); the contents are now
 a small per-agent record.  Producer ([`stage_agent_facts`][terok_executor.container.build.stage_agent_facts])

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -844,8 +844,8 @@ def stage_toad_agents(dest: Path) -> None:
 def stage_help_fragments(dest: Path, agents: tuple[str, ...]) -> None:
     """Render the baked ``hilfe`` help fragments into *dest*.
 
-    Writes one file per *bakeable* section — only ``dev_tool`` (see
-    [`_HELP_SECTION_FILES`][terok_executor.container.build._HELP_SECTION_FILES]) — holding the labels of the
+    Writes one file per *bakeable* section — only ``dev_tool`` (see the
+    module-level ``_HELP_SECTION_FILES`` map) — holding the labels of the
     selected entries that have a ``help:`` block, with backslash escapes
     (``\\033[...]``) interpreted into real ANSI so that ``hilfe`` only needs to
     ``cat`` them.  The ``agent`` section is deliberately not baked: ``hilfe``

--- a/src/terok_executor/resources/agents/claude.yaml
+++ b/src/terok_executor/resources/agents/claude.yaml
@@ -100,4 +100,4 @@ install:
         ln -sf "$HOME/.local/bin/claude" "$SDK_BIN_DIR/claude"
 
 help:
-  label: '  \033[36mclaude\033[0m     - Claude Code CLI'
+  label: '  \033[36mclaude\033[0m     - Claude Code'

--- a/src/terok_executor/resources/agents/codex.yaml
+++ b/src/terok_executor/resources/agents/codex.yaml
@@ -98,4 +98,4 @@ install:
         npm cache clean --force
 
 help:
-  label: '  \033[36mcodex\033[0m      - OpenAI Codex CLI'
+  label: '  \033[36mcodex\033[0m      - OpenAI Codex'

--- a/src/terok_executor/resources/agents/copilot.yaml
+++ b/src/terok_executor/resources/agents/copilot.yaml
@@ -36,4 +36,4 @@ install:
         npm cache clean --force
 
 help:
-  label: '  \033[36mcopilot\033[0m    - GitHub Copilot CLI'
+  label: '  \033[36mcopilot\033[0m    - GitHub Copilot'

--- a/src/terok_executor/resources/agents/opencode.yaml
+++ b/src/terok_executor/resources/agents/opencode.yaml
@@ -73,4 +73,4 @@ install:
     RUN curl -fsSL https://opencode.ai/install | bash
 
 help:
-  label: '  \033[36mopencode\033[0m   - OpenCode CLI (\033[2mterok config import-opencode\033[0m)'
+  label: '  \033[36mopencode\033[0m   - OpenCode (\033[2mterok config import-opencode\033[0m)'

--- a/src/terok_executor/resources/agents/pi.yaml
+++ b/src/terok_executor/resources/agents/pi.yaml
@@ -82,4 +82,4 @@ install:
     RUN npm install -g @earendil-works/pi-coding-agent
 
 help:
-  label: '  \033[36mpi\033[0m         - Pi coding agent (\033[2mhttps://pi.dev\033[0m)'
+  label: '  \033[36mpi\033[0m         - Pi coding agent'

--- a/src/terok_executor/resources/agents/vibe.yaml
+++ b/src/terok_executor/resources/agents/vibe.yaml
@@ -86,4 +86,4 @@ install:
         pipx inject mistral-vibe mistralai
 
 help:
-  label: '  \033[36mvibe\033[0m       - Mistral Vibe CLI'
+  label: '  \033[36mvibe\033[0m       - Mistral Vibe'

--- a/src/terok_executor/resources/scripts/hilfe
+++ b/src/terok_executor/resources/scripts/hilfe
@@ -30,9 +30,10 @@ _terok_permission_mode() {
 
 _terok_help_dir=/usr/local/share/terok/help.d
 
-# Each section's contents are pre-rendered at L1 build time from the
-# roster YAML's `help:` blurbs (see terok_executor/container/build.py
-# stage_help_fragments).  Empty sections produce no file → silently skipped.
+# The dev-tools section is pre-rendered at L1 build time from the roster YAML's
+# `help:` blurbs (see terok_executor/container/build.py stage_help_fragments)
+# — dev tools aren't auth-gated, so a static `cat` is enough.  Empty sections
+# produce no file → silently skipped.
 _terok_section() {
     local title="$1" file="$2"
     [ -s "${_terok_help_dir}/${file}" ] || return 0
@@ -40,28 +41,47 @@ _terok_section() {
     cat "${_terok_help_dir}/${file}"
 }
 
-_terok_executors() { _terok_section 'Available AI agents:' agents.txt; }
-_terok_dev_tools() { _terok_section 'Dev tools:'           dev-tools.txt; }
+# The agent section is rendered at runtime by `terok-agents --banner`: it reads
+# the live readiness state and dims any agent with no authenticated provider it
+# can talk to, with the reason in parentheses.  Nothing prints when no agent is
+# installed (empty output → no header).
+_terok_executors() {
+    local _list
+    _list=$(terok-agents --banner 2>/dev/null) || return 0
+    [ -n "$_list" ] || return 0
+    printf '\n\033[1m%s\033[0m\n' 'Available AI agents:'
+    printf '%s\n' "$_list"
+}
+_terok_dev_tools() { _terok_section 'Dev tools:' dev-tools.txt; }
 
 # Agents (the CLI tools above) and providers (LLM endpoints) are independent
 # axes.  The authenticated providers the vault routes for this container come
-# from the materialized phantom-token env vars (one per provider).
+# from the materialized phantom-token env vars (one per provider); the
+# candidate providers per wire protocol — including ones not yet authenticated,
+# so a dimmed agent's "needs an X provider" is actionable — come from
+# `terok-agents --protocols` (baked roster knowledge the env doesn't carry).
 _terok_providers() {
-    local _list
+    local _list _byproto
     _list=$(printenv \
         | sed -n 's/^TEROK_PROVIDER_\(.*\)_TOKEN=.*/\1/p' \
         | tr '[:upper:]' '[:lower:]' | sort -u)
-    [ -n "$_list" ] || return 0
-    # Providers in magenta (distinct from the cyan agent/tool commands), joined
-    # with plain commas so the line reads as a sentence.
-    printf '\n\033[1mProviders (LLM endpoints):\033[0m '
-    local _first=1 _p
-    for _p in $_list; do
-        [ "$_first" -eq 1 ] || printf ', '
-        printf '\033[35m%s\033[0m' "$_p"
-        _first=0
-    done
+    _byproto=$(terok-agents --protocols 2>/dev/null)
+    # Nothing authenticated and nothing to suggest → skip the section entirely.
+    [ -n "$_list" ] || [ -n "$_byproto" ] || return 0
+
+    printf '\n\033[1mProviders (LLM endpoints):\033[0m'
+    if [ -n "$_list" ]; then
+        # Authenticated providers in magenta, joined so the line reads as a sentence.
+        local _first=1 _p
+        printf ' '
+        for _p in $_list; do
+            [ "$_first" -eq 1 ] || printf ', '
+            printf '\033[35m%s\033[0m' "$_p"
+            _first=0
+        done
+    fi
     printf '\n'
+    [ -n "$_byproto" ] && printf '%s\n' "$_byproto"
     printf '  Point any agent at a provider it speaks to: \033[36m<agent> --provider <name>\033[0m\n'
     printf '  (e.g. \033[36mopencode --provider openrouter\033[0m).  \033[36mopencode\033[0m reaches any of them;\n'
     printf '  native CLIs default to their own.  Ready pairs: \033[36mproviders\033[0m\n'

--- a/src/terok_executor/resources/scripts/terok-agents.py
+++ b/src/terok_executor/resources/scripts/terok-agents.py
@@ -5,16 +5,23 @@
 
 # terok:container — this file is deployed into task containers, not used on the host.
 
-"""Report which (agent, provider) pairs are ready to use in this container.
+"""Report which agents are usable, and which (agent, provider) pairs are ready.
 
-Writes ``/home/dev/.terok/agents.json`` listing, for every installed agent
-paired with every provider this container is authenticated for, whether the
-agent can actually use that provider (``ready`` — the provider serves the
-agent's wire protocol).  Installed-ness and authentication define which pairs
-*appear* at all, so the only per-pair fact worth recording is readiness.
+Writes ``/home/dev/.terok/agents.json`` with two views of the container's
+*actual runtime state*:
 
-The manifest reflects the container's *actual runtime state*, read from three
-in-container sources:
+  * ``pairs`` — every installed protocol-speaking agent paired with every
+    authenticated provider, flagged ``ready`` when the provider serves the
+    agent's wire protocol.  Consumed by the ``providers`` command.
+  * ``agents`` — one rollup per installed agent: its banner ``label``, whether
+    it is ``usable`` at all (has *some* authenticated provider it can talk to),
+    and a short ``reason`` when it is not.  Consumed by the ``hilfe`` banner,
+    which dims unusable agents.
+  * ``protocols`` — one row per wire protocol in play: its candidate providers
+    and which are authenticated.  Consumed by the ``hilfe`` providers section so
+    a dimmed ``needs an openai-chat provider`` maps to a list to act on.
+
+The views are derived from three in-container sources:
 
   * installed agents       — ``TEROK_INSTALLED_AGENTS`` in
     ``/etc/terok/installed.env``
@@ -22,32 +29,50 @@ in-container sources:
   * served protocols        — a ``TEROK_PROVIDER_<NAME>_BASE_<PROTOCOL>`` per
     protocol the provider actually serves
 
-The agent→protocol vocabulary is the one fact the environment does not carry;
-it is baked into the image at build time and read from
-``/usr/local/share/terok/agent-protocols.json``.
+plus two baked maps the environment cannot reconstruct: per-agent facts
+(protocol, label) in ``agent-protocols.json``, and the protocol → candidate
+providers universe in ``provider-protocols.json``.
 
-The manifest is generated at container startup; re-run the ``terok-agents``
-command at any time to refresh it.
+Run with no arguments to (re)write the manifest — done at container startup,
+and any time to refresh.  Run with ``--banner`` / ``--protocols`` to print just
+the agent list / candidate-provider list for the ``hilfe`` login banner,
+deriving them live without touching the file.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from collections.abc import Mapping
 from pathlib import Path
 
 # ── Container contract (paths and names the image build agrees on) ──
 
-MANIFEST_VERSION = 1
-"""Schema version of the emitted ``agents.json``."""
+MANIFEST_VERSION = 2
+"""Schema version of the emitted ``agents.json`` (2 added the ``agents`` rollup)."""
 
 INSTALLED_ENV_PATH = Path("/etc/terok/installed.env")
 """Image manifest carrying ``TEROK_INSTALLED_AGENTS=<comma,separated>``."""
 
-AGENT_PROTOCOLS_PATH = Path("/usr/local/share/terok/agent-protocols.json")
-"""Baked agent→wire-protocol map — the only non-environment input."""
+AGENT_FACTS_PATH = Path("/usr/local/share/terok/agent-protocols.json")
+"""Baked per-agent facts (protocol, label) — a non-environment input.
+Filename is historical; see the build-side constant ``AGENT_PROTOCOLS_PATH``
+for why the name outlived the protocols-only contents."""
+
+PROVIDER_PROTOCOLS_PATH = Path("/usr/local/share/terok/provider-protocols.json")
+"""Baked ``protocol → [providers that serve it]`` universe — lets the providers
+banner list the candidate providers a user could authenticate to enable a
+dimmed agent, including providers not yet authenticated."""
+
+_DIM = "\033[2m"
+_BOLD = "\033[1m"
+_MAGENTA = "\033[35m"
+_RESET = "\033[0m"
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+"""Matches the SGR escapes embedded in a baked banner label, so a dimmed line
+can be flattened to plain text before being wrapped in a single dim span."""
 
 MANIFEST_PATH = Path("/home/dev/.terok/agents.json")
 """Where the readiness manifest is written for agents and the operator to read."""
@@ -65,14 +90,35 @@ _BASE_MARKER = "_BASE_"
 # ── Entry point ──
 
 
-def main() -> int:
-    """Derive the readiness manifest from the live container state and write it."""
+def main(argv: list[str]) -> int:
+    """Write the readiness manifest, or render a ``hilfe`` section.
+
+    ``--banner`` prints the dimmed/bright agent list; ``--protocols`` prints the
+    per-protocol candidate-provider list for the providers section.  Both derive
+    live and leave the manifest file untouched — a login banner is a read, not a
+    checkpoint.  With no flag the manifest is (re)written.
+    """
     installed = _read_installed_agents(INSTALLED_ENV_PATH)
-    protocols = _read_agent_protocols(AGENT_PROTOCOLS_PATH)
-    manifest = build_manifest(installed, protocols, os.environ)
+    facts = _read_agent_facts(AGENT_FACTS_PATH)
+    universe = _read_provider_protocols(PROVIDER_PROTOCOLS_PATH)
+    manifest = build_manifest(installed, facts, universe, os.environ)
+
+    if "--banner" in argv[1:]:
+        _print_if_nonempty(render_agent_banner(manifest["agents"]))
+        return 0
+    if "--protocols" in argv[1:]:
+        _print_if_nonempty(render_provider_protocols(manifest["protocols"]))
+        return 0
+
     _write_manifest(MANIFEST_PATH, manifest)
     _print_summary(manifest)
     return 0
+
+
+def _print_if_nonempty(text: str) -> None:
+    """Print *text* only when it has content (an empty section prints nothing)."""
+    if text:
+        print(text)
 
 
 # ── Derivation (pure: three runtime inputs → the JSON shape) ──
@@ -80,47 +126,141 @@ def main() -> int:
 
 def build_manifest(
     installed_agents: set[str],
-    agent_protocols: dict[str, str],
+    agent_facts: dict[str, dict[str, str | None]],
+    provider_protocols: dict[str, list[str]],
     env: Mapping[str, str],
 ) -> dict[str, object]:
     """Return the readiness manifest for the given runtime state.
 
-    Pairs every *installed* protocol-speaking agent with every provider this
-    container is authenticated for, and records whether the pair is ``ready``
-    — i.e. the provider serves the agent's wire protocol.  Installed-ness and
-    authentication are the *enumeration domain* (an agent must be installed to
-    appear; a provider must be authenticated for the container to know it
-    exists at all), so they are filters, not per-pair fields: the only thing
-    that varies across a pair, and the only thing worth recording, is protocol
-    compatibility.
+    Produces three views over the same facts:
+
+    - ``pairs``: every *installed* protocol-speaking agent paired with every
+      authenticated provider, flagged ``ready`` when the provider serves the
+      agent's wire protocol.  Installed-ness and authentication are the
+      enumeration domain (filters, not fields); readiness is the only per-pair
+      fact worth recording.
+    - ``agents``: one rollup per installed agent — ``label``, whether it is
+      ``usable`` at all, and a ``reason`` when not.  This is what lets ``hilfe``
+      dim an agent the container can't actually run.
+    - ``protocols``: one row per wire protocol in play — its candidate providers
+      and which of them are authenticated.  This is what lets ``hilfe`` turn a
+      dimmed agent's ``needs an openai-chat provider`` into an actionable list.
 
     Args:
         installed_agents: Agent names present in this image (from
-            ``TEROK_INSTALLED_AGENTS``) — the agent enumeration filter.
-        agent_protocols: Agent name → wire protocol, for the agents that speak
-            one (baked from the roster).
+            ``TEROK_INSTALLED_AGENTS``) — the enumeration filter.
+        agent_facts: Agent name → ``{protocol, label}``, baked from the roster.
+        provider_protocols: Protocol → candidate provider names, baked from the
+            roster (the providers a user *could* authenticate, beyond the ones
+            the environment already carries).
         env: The container environment, scanned for authenticated providers
             and the protocols each one serves.
 
     Returns:
-        ``{"version": int, "pairs": [...]}`` where each pair carries
-        ``agent``, ``provider``, ``protocol``, and ``ready``.
+        ``{"version", "pairs", "agents", "protocols"}`` — see above per view.
     """
     authenticated = _authenticated_providers(env)
     served = _served_protocols(env)
 
     pairs: list[dict[str, object]] = []
-    for agent in sorted(agent_protocols):
-        if agent not in installed_agents:
+    agents: list[dict[str, object]] = []
+    for name in sorted(agent_facts):
+        if name not in installed_agents:
             continue
-        protocol = agent_protocols[agent]
-        wire = _protocol_token(protocol)
-        for provider in sorted(authenticated):
-            ready = wire in served.get(provider, frozenset())
-            pairs.append(
-                {"agent": agent, "provider": provider, "protocol": protocol, "ready": ready}
-            )
-    return {"version": MANIFEST_VERSION, "pairs": pairs}
+        protocol = agent_facts[name].get("protocol")
+        label = agent_facts[name].get("label") or name
+
+        if protocol:
+            wire = _protocol_token(protocol)
+            for prov in sorted(authenticated):
+                ready = wire in served.get(prov, frozenset())
+                pairs.append(
+                    {"agent": name, "provider": prov, "protocol": protocol, "ready": ready}
+                )
+
+        usable, reason = _assess(protocol, authenticated, served)
+        agents.append({"name": name, "label": label, "usable": usable, "reason": reason})
+
+    protocols = [
+        {
+            "protocol": protocol,
+            "candidates": candidates,
+            "authenticated": [p for p in candidates if p in authenticated],
+        }
+        for protocol, candidates in sorted(provider_protocols.items())
+    ]
+    return {"version": MANIFEST_VERSION, "pairs": pairs, "agents": agents, "protocols": protocols}
+
+
+def _assess(
+    protocol: str | None,
+    authenticated: set[str],
+    served: dict[str, set[str]],
+) -> tuple[bool, str]:
+    """Return ``(usable, reason)`` for one agent given the live provider state.
+
+    A protocol-speaking agent is usable when *some* authenticated provider's
+    ``serves`` covers its wire protocol — any compatible provider, not a single
+    default.  An agent with no fixed protocol (a frontend like ``toad``) has
+    nothing to assess, so it is always shown bright.
+
+    The ``reason`` (only meaningful when not usable) names the protocol no
+    authenticated provider speaks — ``needs an openai-chat provider`` — and the
+    providers section lists which providers would satisfy it.
+    """
+    if not protocol:
+        return True, ""
+    wire = _protocol_token(protocol)
+    if any(wire in served.get(p, frozenset()) for p in authenticated):
+        return True, ""
+    return False, f"needs an {protocol} provider"
+
+
+def render_agent_banner(agents: object) -> str:
+    """Render the ``agents`` rollup as ``hilfe``'s bright/dimmed agent list.
+
+    Usable agents print their baked label verbatim (the command stays cyan);
+    unusable ones are flattened to plain text, wrapped in a single dim span, and
+    suffixed with ``(reason)`` so the *why* travels with the *what*.
+    """
+    if not isinstance(agents, list):
+        return ""
+    lines: list[str] = []
+    for entry in agents:
+        if not isinstance(entry, dict):
+            continue
+        label = str(entry.get("label", ""))
+        if entry.get("usable"):
+            lines.append(label)
+        else:
+            plain = _ANSI_RE.sub("", label)
+            lines.append(f"{_DIM}{plain}  ({entry.get('reason', '')}){_RESET}")
+    return "\n".join(lines)
+
+
+def render_provider_protocols(protocols: object) -> str:
+    """Render the ``protocols`` rollup as ``hilfe``'s candidate-provider list.
+
+    One line per wire protocol: its candidate providers, with the authenticated
+    ones in magenta (matching the providers section's colour) and the rest
+    dimmed — so an agent dimmed with ``needs an openai-chat provider`` maps to a
+    concrete row of providers to authenticate.
+    """
+    if not isinstance(protocols, list):
+        return ""
+    rows = [r for r in protocols if isinstance(r, dict) and r.get("candidates")]
+    if not rows:
+        return ""
+    width = max(len(str(r["protocol"])) for r in rows)
+    lines = [f"  {_DIM}Providers by wire protocol (authenticate one to enable its agents):{_RESET}"]
+    for row in rows:
+        authed = set(row.get("authenticated") or [])
+        names = ", ".join(
+            f"{_MAGENTA}{p}{_RESET}" if p in authed else f"{_DIM}{p}{_RESET}"
+            for p in row["candidates"]
+        )
+        lines.append(f"    {str(row['protocol']):<{width}}  {names}")
+    return "\n".join(lines)
 
 
 def _authenticated_providers(env: Mapping[str, str]) -> set[str]:
@@ -185,11 +325,12 @@ def _read_installed_agents(path: Path) -> set[str]:
     return set()
 
 
-def _read_agent_protocols(path: Path) -> dict[str, str]:
-    """Return the baked agent→wire-protocol map, or empty when absent.
+def _read_agent_facts(path: Path) -> dict[str, dict[str, str | None]]:
+    """Return the baked per-agent facts map, or empty when absent.
 
-    A missing file or malformed JSON yields an empty map (the readiness check
-    then resolves nothing as compatible) rather than raising at startup.
+    Each value is normalised to ``{protocol, label}`` with missing keys
+    defaulted to ``None``.  A missing file or malformed JSON yields an empty map
+    (nothing resolves as usable) rather than raising at startup.
     """
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
@@ -197,7 +338,31 @@ def _read_agent_protocols(path: Path) -> dict[str, str]:
         return {}
     if not isinstance(data, dict):
         return {}
-    return {str(name): str(protocol) for name, protocol in data.items() if protocol}
+    facts: dict[str, dict[str, str | None]] = {}
+    for name, fact in data.items():
+        if not isinstance(fact, dict):
+            continue
+        facts[str(name)] = {"protocol": fact.get("protocol"), "label": fact.get("label")}
+    return facts
+
+
+def _read_provider_protocols(path: Path) -> dict[str, list[str]]:
+    """Return the baked ``protocol → [providers]`` universe, or empty when absent.
+
+    A missing file or malformed JSON yields an empty map (the providers section
+    simply lists no candidates) rather than raising at startup.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    universe: dict[str, list[str]] = {}
+    for protocol, providers in data.items():
+        if isinstance(providers, list):
+            universe[str(protocol)] = [str(p) for p in providers]
+    return universe
 
 
 def _write_manifest(path: Path, manifest: dict[str, object]) -> None:
@@ -221,7 +386,7 @@ def _print_summary(manifest: dict[str, object]) -> None:
 
 if __name__ == "__main__":
     try:
-        sys.exit(main())
+        sys.exit(main(sys.argv))
     except Exception as exc:  # noqa: BLE001 — advisory metadata must not abort init
         print(f"terok-agents: could not write readiness manifest: {exc}", file=sys.stderr)
         sys.exit(0)

--- a/src/terok_executor/resources/scripts/terok-agents.py
+++ b/src/terok_executor/resources/scripts/terok-agents.py
@@ -70,7 +70,7 @@ _DIM = "\033[2m"
 _BOLD = "\033[1m"
 _MAGENTA = "\033[35m"
 _RESET = "\033[0m"
-_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 """Matches the SGR escapes embedded in a baked banner label, so a dimmed line
 can be flattened to plain text before being wrapped in a single dim span."""
 
@@ -90,7 +90,7 @@ _BASE_MARKER = "_BASE_"
 # ── Entry point ──
 
 
-def main(argv: list[str]) -> int:
+def main(argv: list[str]) -> None:
     """Write the readiness manifest, or render a ``hilfe`` section.
 
     ``--banner`` prints the dimmed/bright agent list; ``--protocols`` prints the
@@ -98,21 +98,19 @@ def main(argv: list[str]) -> int:
     live and leave the manifest file untouched — a login banner is a read, not a
     checkpoint.  With no flag the manifest is (re)written.
     """
+    flags = argv[1:]
     installed = _read_installed_agents(INSTALLED_ENV_PATH)
     facts = _read_agent_facts(AGENT_FACTS_PATH)
     universe = _read_provider_protocols(PROVIDER_PROTOCOLS_PATH)
     manifest = build_manifest(installed, facts, universe, os.environ)
 
-    if "--banner" in argv[1:]:
+    if "--banner" in flags:
         _print_if_nonempty(render_agent_banner(manifest["agents"]))
-        return 0
-    if "--protocols" in argv[1:]:
+    elif "--protocols" in flags:
         _print_if_nonempty(render_provider_protocols(manifest["protocols"]))
-        return 0
-
-    _write_manifest(MANIFEST_PATH, manifest)
-    _print_summary(manifest)
-    return 0
+    else:
+        _write_manifest(MANIFEST_PATH, manifest)
+        _print_summary(manifest)
 
 
 def _print_if_nonempty(text: str) -> None:
@@ -385,8 +383,10 @@ def _print_summary(manifest: dict[str, object]) -> None:
 
 
 if __name__ == "__main__":
+    # Advisory metadata must never abort container init, so any failure is
+    # reported and swallowed — the command always exits 0.
     try:
-        sys.exit(main(sys.argv))
+        main(sys.argv)
     except Exception as exc:  # noqa: BLE001 — advisory metadata must not abort init
         print(f"terok-agents: could not write readiness manifest: {exc}", file=sys.stderr)
-        sys.exit(0)
+    sys.exit(0)

--- a/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok_executor/resources/templates/l1.agent-cli.Dockerfile.template
@@ -81,6 +81,7 @@ ARG AGENT_CACHE_BUST=0
 COPY scripts/ /tmp/terok-scripts/
 COPY help.d/ /usr/local/share/terok/help.d/
 COPY agent-protocols.json {{ agent_protocols_path }}
+COPY provider-protocols.json {{ provider_protocols_path }}
 
 # Always-on terok scripts (env helpers, banner, updaters).
 RUN set -eux; \

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -27,8 +27,9 @@ from terok_executor.container.build import (
     render_l0,
     render_l1,
     render_l1_sidecar,
-    stage_agent_protocols,
+    stage_agent_facts,
     stage_help_fragments,
+    stage_provider_protocols,
     stage_scripts,
     stage_tmux_config,
     stage_toad_agents,
@@ -899,23 +900,24 @@ class TestStageTmuxConfig:
 
 
 class TestStageHelpFragments:
-    """Verify per-section help fragment rendering for ``hilfe``."""
+    """Verify the baked dev-tool help fragment for ``hilfe``."""
 
-    def test_splits_by_section(self, tmp_path: Path) -> None:
+    def test_bakes_dev_tool_section_only(self, tmp_path: Path) -> None:
+        # The agent section is rendered at runtime now, so only dev-tools.txt
+        # is baked — agents.txt is never written.
         dest = tmp_path / "help.d"
         stage_help_fragments(dest, ("claude", "gh"))
-        assert (dest / "agents.txt").is_file()
         assert (dest / "dev-tools.txt").is_file()
-        assert "claude" in (dest / "agents.txt").read_text()
+        assert not (dest / "agents.txt").exists()
         assert "gh" in (dest / "dev-tools.txt").read_text()
 
     def test_decodes_ansi_escapes(self, tmp_path: Path) -> None:
         dest = tmp_path / "help.d"
-        stage_help_fragments(dest, ("claude",))
+        stage_help_fragments(dest, ("gh",))
         # \033 in the YAML must land as the literal ESC byte in the file so
         # that hilfe just `cat`s and gets coloured output.
-        assert "\x1b[" in (dest / "agents.txt").read_text()
-        assert r"\033[" not in (dest / "agents.txt").read_text()
+        assert "\x1b[" in (dest / "dev-tools.txt").read_text()
+        assert r"\033[" not in (dest / "dev-tools.txt").read_text()
 
     def test_omits_empty_sections(self, tmp_path: Path) -> None:
         # Selecting only an agent (no dev_tool) leaves dev-tools.txt absent.
@@ -931,34 +933,57 @@ class TestStageHelpFragments:
         assert _decode_label_escapes(r"\033[36m→ ähnlich\033[0m") == ("\x1b[36m→ ähnlich\x1b[0m")
 
 
-class TestStageAgentProtocols:
-    """Verify the baked agent→wire-protocol map for the readiness check."""
+class TestStageAgentFacts:
+    """Verify the baked per-agent facts map for the readiness check + banner."""
 
-    def test_bakes_protocol_speaking_agents(self, tmp_path: Path) -> None:
+    def test_bakes_protocol_and_label(self, tmp_path: Path) -> None:
         dest = tmp_path / "agent-protocols.json"
-        stage_agent_protocols(dest, ("claude", "codex", "vibe"))
+        stage_agent_facts(dest, ("claude", "codex", "vibe"))
         baked = json.loads(dest.read_text())
-        assert baked == {
-            "claude": "anthropic-messages",
-            "codex": "openai-responses",
-            "vibe": "openai-chat",
-        }
+        assert baked["claude"]["protocol"] == "anthropic-messages"
+        # The label is the decoded banner line (real ESC byte, no CLI suffix).
+        assert "Claude Code" in baked["claude"]["label"]
+        assert "\x1b[" in baked["claude"]["label"]
+        assert baked["codex"]["protocol"] == "openai-responses"
+        assert baked["vibe"]["protocol"] == "openai-chat"
+        # No provider field — usability is protocol-based, not default-bound.
+        assert "provider" not in baked["claude"]
 
-    def test_omits_agents_without_protocol(self, tmp_path: Path) -> None:
-        # Tools carry no fixed protocol → absent.  Harnesses now declare the
-        # protocol their adapters speak (opencode → openai-chat) so the readiness
-        # manifest can surface them paired with compatible providers.
+    def test_includes_agents_without_a_protocol(self, tmp_path: Path) -> None:
+        # Tools (gh) live in the dev-tool section → absent.  An agent-section
+        # entry with no wire protocol (copilot) is still recorded so the banner
+        # can list it; its protocol is null.
         dest = tmp_path / "agent-protocols.json"
-        stage_agent_protocols(dest, ("claude", "gh", "opencode"))
-        assert json.loads(dest.read_text()) == {
-            "claude": "anthropic-messages",
-            "opencode": "openai-chat",
-        }
+        stage_agent_facts(dest, ("claude", "gh", "copilot", "opencode"))
+        baked = json.loads(dest.read_text())
+        assert set(baked) == {"claude", "copilot", "opencode"}
+        assert baked["copilot"]["protocol"] is None
+        assert baked["opencode"]["protocol"] == "openai-chat"
 
-    def test_writes_empty_object_for_no_protocol_agents(self, tmp_path: Path) -> None:
+    def test_writes_empty_object_for_no_agent_section_entries(self, tmp_path: Path) -> None:
         # Always write a file so the Dockerfile COPY always has a source.
         dest = tmp_path / "agent-protocols.json"
-        stage_agent_protocols(dest, ("gh",))
+        stage_agent_facts(dest, ("gh",))
+        assert json.loads(dest.read_text()) == {}
+
+
+class TestStageProviderProtocols:
+    """Verify the baked protocol → candidate-providers universe."""
+
+    def test_bakes_candidates_for_protocols_in_play(self, tmp_path: Path) -> None:
+        dest = tmp_path / "provider-protocols.json"
+        stage_provider_protocols(dest, ("claude", "vibe"))
+        baked = json.loads(dest.read_text())
+        # claude → anthropic-messages, vibe → openai-chat; each lists its servers.
+        assert baked["anthropic-messages"] == ["anthropic", "openrouter"]
+        assert "mistral" in baked["openai-chat"] and "openrouter" in baked["openai-chat"]
+        # openai-responses isn't spoken by the selection → not advertised.
+        assert "openai-responses" not in baked
+
+    def test_writes_empty_object_when_no_protocol_in_play(self, tmp_path: Path) -> None:
+        # Only a tool selected → no protocols → empty (but file still written).
+        dest = tmp_path / "provider-protocols.json"
+        stage_provider_protocols(dest, ("gh",))
         assert json.loads(dest.read_text()) == {}
 
 

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -56,6 +56,29 @@ AGENT_PROTOCOLS = {
     "vibe": "openai-chat",
 }
 
+
+def _facts(protocols: dict[str, str]) -> dict[str, dict[str, str | None]]:
+    """Wrap a ``name → protocol`` map into the baked per-agent facts shape.
+
+    Each entry gains a synthetic banner ``label`` so the rollup and banner can
+    be exercised without the real roster.
+    """
+    return {
+        name: {"protocol": protocol, "label": f"  {name} - {name.title()}"}
+        for name, protocol in protocols.items()
+    }
+
+
+# The baked facts the generator reads: the three protocol-speaking natives.
+AGENT_FACTS = _facts(AGENT_PROTOCOLS)
+
+# The baked protocol → candidate-providers universe (mirrors the real roster).
+AGENT_UNIVERSE = {
+    "anthropic-messages": ["anthropic", "openrouter"],
+    "openai-responses": ["openai"],
+    "openai-chat": ["blablador", "kisski", "mistral", "openai", "openrouter"],
+}
+
 # A realistic in-container environment: anthropic (anthropic-messages),
 # openai (openai-responses), and openrouter (both openai-chat and
 # anthropic-messages) are authenticated; unrelated vars are noise.
@@ -85,7 +108,9 @@ class TestBuildManifest:
 
     def test_compatible_pairs_are_ready(self, generator: ModuleType) -> None:
         """An installed agent whose protocol the authed provider serves is ready."""
-        manifest = generator.build_manifest(set(AGENT_PROTOCOLS), AGENT_PROTOCOLS, AUTHED_ENV)
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
         # claude speaks anthropic-messages → anthropic and openrouter serve it.
         assert _pair(manifest, "claude", "anthropic")["ready"] is True
         assert _pair(manifest, "claude", "openrouter")["ready"] is True
@@ -100,8 +125,8 @@ class TestBuildManifest:
         """Harnesses declare openai-chat, so they appear paired with every authed
         openai-chat provider — the universal cross-provider path (must not be
         omitted from the manifest, as they were when harnesses had no protocol)."""
-        protocols = {**AGENT_PROTOCOLS, "opencode": "openai-chat", "pi": "openai-chat"}
-        manifest = generator.build_manifest(set(protocols), protocols, AUTHED_ENV)
+        facts = _facts({**AGENT_PROTOCOLS, "opencode": "openai-chat", "pi": "openai-chat"})
+        manifest = generator.build_manifest(set(facts), facts, AGENT_UNIVERSE, AUTHED_ENV)
         assert _pair(manifest, "opencode", "openrouter")["ready"] is True
         assert _pair(manifest, "pi", "openrouter")["ready"] is True
         # openai serves openai-responses (not -chat) here, so opencode isn't ready on it.
@@ -109,7 +134,9 @@ class TestBuildManifest:
 
     def test_incompatible_pairs_are_not_ready(self, generator: ModuleType) -> None:
         """A provider that does not serve the agent's protocol is not ready."""
-        manifest = generator.build_manifest(set(AGENT_PROTOCOLS), AGENT_PROTOCOLS, AUTHED_ENV)
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
         assert _pair(manifest, "codex", "anthropic")["ready"] is False
         # openrouter serves openai-chat + anthropic-messages, not openai-responses.
         assert _pair(manifest, "codex", "openrouter")["ready"] is False
@@ -119,7 +146,9 @@ class TestBuildManifest:
 
     def test_pair_shape(self, generator: ModuleType) -> None:
         """Each pair carries the agent/provider context and the lone ``ready`` flag."""
-        manifest = generator.build_manifest(set(AGENT_PROTOCOLS), AGENT_PROTOCOLS, AUTHED_ENV)
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
         assert _pair(manifest, "claude", "anthropic") == {
             "agent": "claude",
             "provider": "anthropic",
@@ -130,37 +159,166 @@ class TestBuildManifest:
     def test_uninstalled_agent_is_omitted(self, generator: ModuleType) -> None:
         """A protocol-known agent absent from the image is not enumerated at all."""
         # claude has a baked protocol but is absent from this image's selection.
-        manifest = generator.build_manifest({"codex", "vibe"}, AGENT_PROTOCOLS, AUTHED_ENV)
+        manifest = generator.build_manifest(
+            {"codex", "vibe"}, AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
         assert not [p for p in manifest["pairs"] if p["agent"] == "claude"]
 
     def test_full_matrix_is_emitted(self, generator: ModuleType) -> None:
         """Every installed protocol-speaking agent is paired with every authed provider."""
-        manifest = generator.build_manifest(set(AGENT_PROTOCOLS), AGENT_PROTOCOLS, AUTHED_ENV)
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
         # 3 agents × 3 authenticated providers.
         assert len(manifest["pairs"]) == 9
         assert manifest["version"] == generator.MANIFEST_VERSION
 
     def test_pairs_are_deterministically_ordered(self, generator: ModuleType) -> None:
         """Pairs sort by (agent, provider) so the file is stable across runs."""
-        manifest = generator.build_manifest(set(AGENT_PROTOCOLS), AGENT_PROTOCOLS, AUTHED_ENV)
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
         keys = [(p["agent"], p["provider"]) for p in manifest["pairs"]]
         assert keys == sorted(keys)
 
     def test_no_authenticated_providers_yields_no_pairs(self, generator: ModuleType) -> None:
         """With nothing authenticated there is no provider to pair an agent with."""
-        manifest = generator.build_manifest(set(AGENT_PROTOCOLS), AGENT_PROTOCOLS, {"PATH": "/bin"})
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, {"PATH": "/bin"}
+        )
         assert manifest["pairs"] == []
 
-    def test_agents_without_protocol_are_absent(self, generator: ModuleType) -> None:
-        """An agent missing from the baked protocol map is never enumerated.
+    def test_agents_absent_from_facts_are_not_paired(self, generator: ModuleType) -> None:
+        """An agent missing from the baked facts map is never paired.
 
-        Tools and harnesses speak no fixed protocol, so they never appear even
-        when installed — compatibility is undefined for them.
+        Tools (gh) are baked into the dev-tool section, not the facts map, so
+        they never contribute a pair even when installed.
         """
-        installed = set(AGENT_PROTOCOLS) | {"gh", "opencode"}
-        manifest = generator.build_manifest(installed, AGENT_PROTOCOLS, AUTHED_ENV)
+        installed = set(AGENT_FACTS) | {"gh"}
+        manifest = generator.build_manifest(installed, AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV)
         named_agents = {p["agent"] for p in manifest["pairs"]}
-        assert named_agents == set(AGENT_PROTOCOLS)
+        assert named_agents == set(AGENT_FACTS)
+
+
+class TestAgentRollup:
+    """The ``agents`` view: usable/reason per installed agent, for the banner."""
+
+    def _rollup(self, manifest: dict, name: str) -> dict:
+        matches = [a for a in manifest["agents"] if a["name"] == name]
+        assert len(matches) == 1, f"expected one rollup for {name}, got {matches}"
+        return matches[0]
+
+    def test_usable_when_a_provider_serves_the_protocol(self, generator: ModuleType) -> None:
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
+        claude = self._rollup(manifest, "claude")
+        assert claude["usable"] is True
+        assert claude["reason"] == ""
+
+    def test_unusable_reason_names_the_protocol_not_a_provider(self, generator: ModuleType) -> None:
+        """Reason names the wire protocol — any compatible provider satisfies it,
+        so it must not name a single 'default' provider."""
+        # Only anthropic is authenticated → codex (openai-responses) is out.
+        env = {
+            "TEROK_PROVIDER_ANTHROPIC_TOKEN": "terok-p-aaa",
+            "TEROK_PROVIDER_ANTHROPIC_BASE_ANTHROPIC_MESSAGES": f"{_LOOPBACK}/v1",
+        }
+        manifest = generator.build_manifest(set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, env)
+        codex = self._rollup(manifest, "codex")
+        assert codex["usable"] is False
+        assert codex["reason"] == "needs an openai-responses provider"
+        # claude can reach anthropic → still usable.
+        assert self._rollup(manifest, "claude")["usable"] is True
+
+    def test_usable_via_any_compatible_provider_not_the_default(
+        self, generator: ModuleType
+    ) -> None:
+        """vibe (openai-chat) is usable because openrouter serves openai-chat —
+        even though 'mistral' (its roster default) is not authenticated."""
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
+        vibe = self._rollup(manifest, "vibe")
+        assert vibe["usable"] is True
+        assert vibe["reason"] == ""
+
+    def test_agent_without_protocol_is_always_usable(self, generator: ModuleType) -> None:
+        """A pure frontend (toad: no protocol) has nothing to assess → bright."""
+        facts = {"toad": {"protocol": None, "label": "  toad - Toad"}}
+        manifest = generator.build_manifest({"toad"}, facts, {}, {"PATH": "/bin"})
+        toad = self._rollup(manifest, "toad")
+        assert toad["usable"] is True
+        assert toad["reason"] == ""
+
+    def test_banner_keeps_usable_labels_and_dims_the_rest(self, generator: ModuleType) -> None:
+        """Usable agents print verbatim; unusable ones are stripped, dimmed, annotated."""
+        env = {
+            "TEROK_PROVIDER_ANTHROPIC_TOKEN": "terok-p-aaa",
+            "TEROK_PROVIDER_ANTHROPIC_BASE_ANTHROPIC_MESSAGES": f"{_LOOPBACK}/v1",
+        }
+        facts = {
+            "claude": {
+                "protocol": "anthropic-messages",
+                "label": "  \033[36mclaude\033[0m - Claude Code",
+            },
+            "codex": {
+                "protocol": "openai-responses",
+                "label": "  \033[36mcodex\033[0m - OpenAI Codex",
+            },
+        }
+        manifest = generator.build_manifest(set(facts), facts, AGENT_UNIVERSE, env)
+        banner = generator.render_agent_banner(manifest["agents"])
+        lines = banner.splitlines()
+        # claude usable → its cyan label is printed as-is.
+        assert "  \033[36mclaude\033[0m - Claude Code" in lines[0]
+        # codex unusable → dimmed, embedded ANSI stripped, reason appended.
+        assert lines[1].startswith("\033[2m")
+        assert "\033[36m" not in lines[1]
+        assert "(needs an openai-responses provider)" in lines[1]
+
+    def test_banner_tolerates_non_list_input(self, generator: ModuleType) -> None:
+        assert generator.render_agent_banner(None) == ""
+
+
+class TestProtocolRollup:
+    """The ``protocols`` view: candidate providers per protocol, for the section."""
+
+    def _row(self, manifest: dict, protocol: str) -> dict:
+        matches = [r for r in manifest["protocols"] if r["protocol"] == protocol]
+        assert len(matches) == 1, f"expected one row for {protocol}, got {matches}"
+        return matches[0]
+
+    def test_lists_candidates_and_marks_authenticated(self, generator: ModuleType) -> None:
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
+        chat = self._row(manifest, "openai-chat")
+        assert chat["candidates"] == ["blablador", "kisski", "mistral", "openai", "openrouter"]
+        # Of those, only openai + openrouter are authenticated in AUTHED_ENV.
+        assert chat["authenticated"] == ["openai", "openrouter"]
+
+    def test_candidates_listed_even_when_none_authenticated(self, generator: ModuleType) -> None:
+        """The point of the universe: surface providers to authenticate when zero are."""
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, {"PATH": "/x"}
+        )
+        chat = self._row(manifest, "openai-chat")
+        assert chat["candidates"]  # non-empty
+        assert chat["authenticated"] == []
+
+    def test_render_marks_authed_magenta_and_rest_dim(self, generator: ModuleType) -> None:
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
+        out = generator.render_provider_protocols(manifest["protocols"])
+        assert "openai-chat" in out
+        # authenticated provider → magenta; unauthenticated candidate → dim.
+        assert "\033[35mopenrouter\033[0m" in out
+        assert "\033[2mblablador\033[0m" in out
+
+    def test_render_tolerates_non_list_input(self, generator: ModuleType) -> None:
+        assert generator.render_provider_protocols(None) == ""
 
 
 class TestEnvironmentScanning:
@@ -199,22 +357,53 @@ class TestSourcesAndSink:
         """A missing manifest yields an empty set rather than raising."""
         assert generator._read_installed_agents(tmp_path / "absent.env") == set()
 
-    def test_read_agent_protocols(self, generator: ModuleType, tmp_path: Path) -> None:
-        """The baked map round-trips, dropping blank protocols."""
+    def test_read_agent_facts(self, generator: ModuleType, tmp_path: Path) -> None:
+        """The baked facts round-trip, normalising a missing protocol to ``None``."""
         baked = tmp_path / "agent-protocols.json"
-        baked.write_text(json.dumps({"claude": "anthropic-messages", "copilot": ""}))
-        assert generator._read_agent_protocols(baked) == {"claude": "anthropic-messages"}
+        baked.write_text(
+            json.dumps(
+                {
+                    "claude": {
+                        "protocol": "anthropic-messages",
+                        "label": "  claude - Claude Code",
+                    },
+                    "toad": {"label": "  toad - Toad"},
+                }
+            )
+        )
+        facts = generator._read_agent_facts(baked)
+        assert facts["claude"]["protocol"] == "anthropic-messages"
+        # Missing protocol key defaults to None, not KeyError.
+        assert facts["toad"]["protocol"] is None
+        assert facts["toad"]["label"] == "  toad - Toad"
 
-    def test_read_agent_protocols_malformed(self, generator: ModuleType, tmp_path: Path) -> None:
+    def test_read_agent_facts_malformed(self, generator: ModuleType, tmp_path: Path) -> None:
         """Malformed JSON yields an empty map rather than raising."""
         baked = tmp_path / "agent-protocols.json"
         baked.write_text("{not json")
-        assert generator._read_agent_protocols(baked) == {}
+        assert generator._read_agent_facts(baked) == {}
+
+    def test_read_provider_protocols(self, generator: ModuleType, tmp_path: Path) -> None:
+        """The baked protocol→providers universe round-trips; non-list values drop."""
+        baked = tmp_path / "provider-protocols.json"
+        baked.write_text(
+            json.dumps({"anthropic-messages": ["anthropic", "openrouter"], "bogus": "nope"})
+        )
+        universe = generator._read_provider_protocols(baked)
+        assert universe == {"anthropic-messages": ["anthropic", "openrouter"]}
+
+    def test_read_provider_protocols_malformed(self, generator: ModuleType, tmp_path: Path) -> None:
+        """Malformed JSON yields an empty map rather than raising."""
+        baked = tmp_path / "provider-protocols.json"
+        baked.write_text("{not json")
+        assert generator._read_provider_protocols(baked) == {}
 
     def test_write_manifest_round_trips(self, generator: ModuleType, tmp_path: Path) -> None:
         """The manifest is written as JSON under a freshly created parent dir."""
         out = tmp_path / "nested" / "agents.json"
-        manifest = generator.build_manifest(set(AGENT_PROTOCOLS), AGENT_PROTOCOLS, AUTHED_ENV)
+        manifest = generator.build_manifest(
+            set(AGENT_FACTS), AGENT_FACTS, AGENT_UNIVERSE, AUTHED_ENV
+        )
         generator._write_manifest(out, manifest)
         assert json.loads(out.read_text()) == manifest
 


### PR DESCRIPTION
## What

The in-container `hilfe` banner now shows whether each agent is actually usable:

- **Agents dim** when no authenticated provider serves their wire protocol, with the reason in parentheses — e.g. `vibe — Mistral Vibe (needs an openai-chat provider)`. Usable agents keep their cyan label.
- The **Providers section lists candidate providers per wire protocol** (authenticated highlighted in magenta, the rest dimmed), so a dimmed `needs an openai-chat provider` maps to a concrete row to authenticate. It shows **even when nothing is authenticated** — exactly when it's most needed.
- **Label cleanups** at the YAML source: dropped the repeated "CLI" from claude/codex/copilot/vibe/opencode and the `https://pi.dev` URL from pi.

```
Available AI agents:
  claude     - Claude Code
  codex      - OpenAI Codex  (needs an openai-responses provider)     ← dim
  vibe       - Mistral Vibe  (needs an openai-chat provider)          ← dim
  toad       - Multi-agent TUI (ACP)

Providers (LLM endpoints): anthropic
  Providers by wire protocol (authenticate one to enable its agents):
    anthropic-messages  anthropic, openrouter
    openai-chat         blablador, kisski, mistral, openai, openrouter
    openai-responses    openai
```

## How (SSOT / declarative)

- Usability is computed in **one place** — `build_manifest()` in `terok-agents`, which now emits `agents` and `protocols` rollups alongside the existing `pairs`. `hilfe` calls `terok-agents --banner` / `--protocols` to render live (no file write); the `providers` command is unchanged.
- The reason **names the wire protocol, not a provider**: an agent is usable via *any* provider serving its protocol, never tied to a single default.
- `agents.txt` is **retired** — the agent section is no longer baked; `stage_help_fragments` now bakes only `dev-tools.txt`.
- The baked `agent-protocols.json` (same filename) is widened to per-agent `{protocol, label}`; a new `provider-protocols.json` carries the `protocol → providers` universe (the container env carries only *authenticated* providers, so candidates must be baked).

## Not covered — copilot

`copilot` stays **bright** (treated as "can't assess"). It has no provider binding at all, and it can't simply declare `provider.default: github` because the roster enforces one-provider-↔-one-vault-route and `github` is already bound by `gh` (`roster/loader.py`). Properly wiring copilot's auth is tracked in **terok-ai/terok#555** and is out of scope here.

## Tests

- Reworked `tests/unit/test_build.py` (`stage_agent_facts`, `stage_provider_protocols`, dev-tool-only fragments) and `tests/unit/test_readiness.py` (protocol-based reasons, `agents`/`protocols` rollups, banner + candidate-list renderers). All green locally.
- `ruff check`/`format` clean; `hilfe` passes `bash -n` and a full banner run.

Draft: opening for CI to run the full `make check` (local env can't build `sqlcipher3` on py3.14).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The help banner now renders agent status and available protocols at runtime, including suggested providers for supported protocols.
  * Provider availability display is enhanced to combine authenticated providers with protocol-based suggestions.
  * Help labels for several AI agents were shortened (removed “CLI” where applicable).

* **Bug Fixes**
  * Improved resilience when agent or provider data is missing or malformed, preventing startup/help failures.
  * Help fragment rendering is more consistent, including clearer behavior for empty sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->