### PR TITLE
fix(roster): mount glab's config writable so the tool can start

### DIFF
--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -443,7 +443,11 @@ def _shared_config_mounts(
 
     Providers in *expose_credential_providers* keep the writable mount —
     used by terok's experimental ``expose_oauth_token`` mode where the
-    agent intentionally manages its own token.
+    agent intentionally manages its own token.  Mounts flagged
+    [`writable`][terok_executor.roster.types.MountDef.writable] skip the shadow
+    too: their credential file doubles as a settings file the tool rewrites on
+    startup (e.g. glab's ``config.yml``), so the read-only shadow would abort
+    the tool — it rides the shared mount writable instead.
     """
     specs: list[VolumeSpec] = []
 
@@ -452,7 +456,7 @@ def _shared_config_mounts(
         host_dir.mkdir(parents=True, exist_ok=True)
         specs.append(VolumeSpec(host_dir, m.container_path))
 
-        if not m.credential_file or m.provider in expose_credential_providers:
+        if not m.credential_file or m.writable or m.provider in expose_credential_providers:
             continue
 
         host_file = host_dir / m.credential_file

--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -13,6 +13,12 @@ provider:
   default: gitlab
   credential_type: pat
   credential_file: config.yml
+  # glab keeps credentials AND settings in the same config.yml and rewrites it
+  # on startup, so the read-only credential shadow (terok#873) would abort it.
+  # Mount it writable: glab reaches the API through GITLAB_TOKEN/GITLAB_API_HOST
+  # env (a phantom token), and the file persists settings across tasks in the
+  # shared mount instead of being contained per-container.
+  credential_file_writable: true
   token_env:
     _default: GITLAB_TOKEN
 

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -489,6 +489,7 @@ def load_roster() -> AgentRoster:
             agents[name] = spec.to_agent(name)
 
         credential_file = spec.provider.credential_file if spec.provider else ""
+        credential_file_writable = bool(spec.provider and spec.provider.credential_file_writable)
 
         # Agents capture credentials only through an explicit ``auth:`` block;
         # the harness-driven providers' API-key capture is synthesized from
@@ -511,6 +512,7 @@ def load_roster() -> AgentRoster:
                     label=f"{auth_prov.label} config",
                     credential_file=credential_file,
                     provider=name,
+                    writable=credential_file_writable,
                 )
 
         for m in spec.mounts:

--- a/src/terok_executor/roster/schema.py
+++ b/src/terok_executor/roster/schema.py
@@ -436,6 +436,15 @@ class RawProviderBinding(StrictModel):
     base_url_env: str = ""
     socket_env: str = ""
     credential_file: str = ""
+    credential_file_writable: bool = Field(
+        default=False,
+        description=(
+            "Mount the credential file writable instead of under a read-only shadow. "
+            "Set when the tool stores credentials and settings in the same file it must "
+            "rewrite on startup (e.g. glab's config.yml) — the shadow would block the "
+            "write, and the file persists in the shared mount instead of being contained."
+        ),
+    )
     credential_type: Literal["api_key", "oauth", "oauth_token", "pat"] = "api_key"
     config_patch: dict | None = None
 

--- a/src/terok_executor/roster/types.py
+++ b/src/terok_executor/roster/types.py
@@ -47,6 +47,18 @@ class MountDef:
     [`ContainerEnvSpec.expose_credential_providers`][terok_executor.ContainerEnvSpec.expose_credential_providers].
     """
 
+    writable: bool = False
+    """Mount [`credential_file`][terok_executor.roster.types.MountDef.credential_file]
+    writable instead of under a read-only shadow.
+
+    Set for tools whose credential file doubles as their settings file and is
+    rewritten on startup (e.g. glab's ``config.yml``): the read-only shadow
+    would abort the tool, so the file rides the shared mount writable and
+    persists across tasks — trading the per-container credential containment of
+    [terok-ai/terok#873](https://github.com/terok-ai/terok/issues/873) for a
+    tool that runs at all.  Sourced from ``provider.credential_file_writable``.
+    """
+
 
 @dataclass(frozen=True)
 class VaultRoute:

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -1253,6 +1253,19 @@ class TestSharedConfigMountsUnit:
         cred = [m for m in mounts if m.container_path == "/home/dev/.claude/.credentials.json"]
         assert cred == []
 
+    def test_writable_credential_file_skips_ro_shadow(self, roster, tmp_path):
+        """A ``credential_file_writable`` provider (glab) gets no ro shadow.
+
+        glab's config.yml is both credentials and settings, rewritten on
+        startup, so the shadow would abort it — only the rw dir mount remains.
+        """
+        mounts = _shared_config_mounts(roster, tmp_path)
+        shadow = [m for m in mounts if m.container_path == "/home/dev/.config/glab-cli/config.yml"]
+        assert shadow == []
+        dir_mount = [m for m in mounts if m.container_path == "/home/dev/.config/glab-cli"]
+        assert len(dir_mount) == 1
+        assert dir_mount[0].read_only is False
+
 
 class TestExposedProviderMaterialization:
     """`_materialize_exposed_providers` surfaces exposed creds as TEROK_PROVIDER_* handles."""


### PR DESCRIPTION
## Problem

glab won't start in task containers. glab's real config dir is `~/.config/glab-cli`, and the credential-containment model (terok-ai/terok#873) layers `config.yml` **read-only** over the shared mount. But glab keeps **credentials *and* settings in that single `config.yml`** and rewrites it on startup — so the read-only bind (0644 on a read-only FS) makes glab refuse to run.

This is the asymmetry with `gh`, which survives the same model: gh's credentials (`hosts.yml`) and settings (`config.yml`) are **separate files**, so the read-only shadow sits on a file gh doesn't rewrite. glab has no separable cred file, so the shadow blocks the very file it must write.

## Fix

Add a `credential_file_writable` flag to `RawProviderBinding` → `MountDef.writable`. `_shared_config_mounts` skips the read-only shadow for a flagged mount, leaving the credential file on the **writable** shared dir. Set it on glab.

glab reaches the API entirely through the `GITLAB_TOKEN` / `GITLAB_API_HOST` phantom env (already injected), so it doesn't need the file for auth; the file rides the shared mount writable so glab starts and its settings persist across tasks.

### Tradeoff (intentional)

Because glab can't separate creds from settings, a writable shared `config.yml` weakens the per-container containment of #873: a token a container writes there is visible to other containers sharing the mount. We accept this for glab — the container only ever holds a phantom token (the real credential stays in the vault), and the alternative is a tool that doesn't run. `credential_file` stays set so leak-scan and doctor still cover the file.

Only glab needs the flag; gh/claude/codex/vibe use separate creds-only files that aren't rewritten on startup.

## Test

- `test_writable_credential_file_skips_ro_shadow`: glab gets no read-only shadow on `config.yml`, only the writable dir mount.
- Existing shadow tests (claude/gh) still pass — normal providers are unaffected.
- env-builder / vault / doctor / roster / schema unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for writable credential-file mounts for providers that rewrite credentials/settings in the same file.
  * Updated provider configuration so certain tool credentials stay writable instead of being treated as read-only.

* **Bug Fixes**
  * Prevented read-only credential shadow mounts from being created when a mount is explicitly writable.

* **Tests**
  * Added coverage to verify writable credential mounts behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->