### PR TITLE
chore(deps): pin third-party major-0 runtime deps to exact patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
           version-file: "pyproject.toml"
           args: format --check
 
+      - name: ASCII-only pyproject
+        run: |
+          ! LC_ALL=C grep -nP '[^\x00-\x7F]' pyproject.toml
+
   docstring-coverage:
     if: github.repository == 'terok-ai/terok-executor'
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,37 @@ those run on a dedicated test machine.
 
 - Markdown files under `docs/` are lowercase by convention; root-level
   files (`README.md`, `AGENTS.md`) are not.
+
+## Dependency Pinning & `pyproject.toml` Hygiene
+
+**Version pinning policy.** Runtime/production dependencies — those pulled in
+by a plain `pip install` / `pipx install` of this package (the
+`[project].dependencies` table) — are pinned by the dependency's major
+version:
+
+- **Third-party, major 0 (`0.y.z`)** → pin to an **exact patch**
+  (`pkg==0.y.z`). Pre-1.0 packages promise no compatibility across either
+  minors *or* patches, so a floating range invites silent breakage.
+- **Third-party, major ≥ 1** → pin by **range** (e.g. `pkg>=2.6`), trusting
+  the package to honour semver. If a specific `>=1` dependency is known to
+  break semver, tighten it deliberately.
+- **Sibling `terok-*` deps** → **exempt**: keep ranges (or their
+  release-wheel URL pin). We guarantee patch-level API stability across the
+  sibling packages, so a `0.y` range there will not silently break — do
+  *not* exact-pin them (it would fight the multi-repo release/PR-chain flow).
+
+Dev / test / docs / tooling dependencies (the `[tool.poetry.group.*]` groups)
+are **exempt** — they are not shipped to installers and exact-pinning them is
+an unwarranted maintenance burden the developers can absorb. After changing
+any pin, run `poetry lock` and commit `pyproject.toml` and `poetry.lock`
+together.
+
+**No comments in `pyproject.toml`.** Do **not** add comments to
+`pyproject.toml`, with the single exception of the standing dependency-pinning
+policy note above the `dependencies` table. In particular **never** add a
+comment about a dependency that is temporarily pinned to a git branch during a
+multi-repo PR chain, and never mention the PR-chain workflow in
+`pyproject.toml` at all. Cross-repo merges are performed by a script that does
+not understand comments, so any stray dev-cycle comment is carried straight
+into a production release. Keep such rationale in commit messages, PR
+descriptions, or this file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,12 +71,13 @@ an unwarranted maintenance burden the developers can absorb. After changing
 any pin, run `poetry lock` and commit `pyproject.toml` and `poetry.lock`
 together.
 
-**No comments in `pyproject.toml`.** Do **not** add comments to
-`pyproject.toml`, with the single exception of the standing dependency-pinning
-policy note above the `dependencies` table. In particular **never** add a
-comment about a dependency that is temporarily pinned to a git branch during a
-multi-repo PR chain, and never mention the PR-chain workflow in
-`pyproject.toml` at all. Cross-repo merges are performed by a script that does
-not understand comments, so any stray dev-cycle comment is carried straight
-into a production release. Keep such rationale in commit messages, PR
-descriptions, or this file.
+**Comment discipline in `pyproject.toml`.** The dependency tables stay
+comment-free and self-documenting, apart from the standing policy pointer
+above them. **Never** comment on why a dependency -- especially a sibling
+`terok-*` package -- is pinned a certain way, and never mention dev-cycle
+state (temporary git-branch pins, the multi-repo PR chain): cross-repo
+merges are performed by a script that does not understand comments, so any
+such note is carried straight into a production release. Keep pin
+rationale in commit messages, PR descriptions, or this file. Ordinary
+explanatory comments in `[tool.*]` sections are fine. `pyproject.toml`
+stays ASCII-only.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ test: test-unit
 
 # Run linter and format checker (fast, run before commits)
 lint:
+	@if LC_ALL=C grep -nP '[^\x00-\x7F]' pyproject.toml; then echo "pyproject.toml must be ASCII-only"; exit 1; fi
 	mkdir -p $(REPORTS_DIR)
 	poetry run ruff check --exit-zero --output-format=json --output-file=$(RUFF_REPORT) .
 	poetry run ruff check .

--- a/poetry.lock
+++ b/poetry.lock
@@ -3860,4 +3860,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "e1edc7de5d2de369eefb871cf31ada086fa514e29cf52ec21bd4b82e67d8c094"
+content-hash = "eadb649fb7616541648868536a1e852ec39c401c6c5e6fb951db2b362f85bfe6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,18 +16,19 @@ maintainers = [
 keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
+# Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
+# pyproject.toml Hygiene").  No other comments belong in this file — a
+# comment-blind release script would carry them into a production release.
 dependencies = [
-    # 0.3.0 floor: write_sidecar (the canonical sidecar writer this
-    # package calls) entered the public API in that release.
     "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.3.2a1/terok_sandbox-0.3.2a1-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.2.0/terok_util-0.2.0-py3-none-any.whl",
-    "ruamel.yaml>=0.18",
-    "Jinja2>=3.1",
-    "tomli-w>=1.0",
-    "prompt-toolkit>=3.0",
-    "pydantic>=2.9",
-    "rich>=13.0",
-    "agent-client-protocol>=0.10.1",
+    "ruamel.yaml==0.19.1",
+    "Jinja2~=3.1",
+    "tomli-w~=1.2",
+    "prompt-toolkit~=3.0",
+    "pydantic~=2.13",
+    "rich~=15.0",
+    "agent-client-protocol==0.10.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,10 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
-# pyproject.toml Hygiene").  No other comments belong in this file — a
-# comment-blind release script would carry them into a production release.
+# pyproject.toml Hygiene").  Keep the dependency tables comment-free and
+# self-documenting -- in particular, never note here why a sibling
+# terok-* package is pinned a certain way, nor any transient dev-cycle
+# state: a comment-blind release script would ship such notes.
 dependencies = [
     "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.3.2a1/terok_sandbox-0.3.2a1-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.2.0/terok_util-0.2.0-py3-none-any.whl",
@@ -132,7 +134,7 @@ quote-style = "double"
 indent-style = "space"
 docstring-code-format = true
 
-# Static type checking — see `make typecheck`.
+# Static type checking -- see `make typecheck`.
 # ``resources/`` is excluded entirely: it holds container-side scripts and
 # bundled agent assets that aren't part of the host-side import graph
 # (``resources/toad-agents/`` isn't even a valid Python package name).
@@ -153,7 +155,7 @@ pretty = true
 show_error_codes = true
 
 # ``resources/`` holds container-side scripts (run inside task containers, not
-# part of the host import graph — the same reason mypy excludes it).  Tests
+# part of the host import graph -- the same reason mypy excludes it).  Tests
 # exercise them by path-loading (``SourceFileLoader``), which coverage.py can't
 # attribute, so they report 0%; omit them rather than chase phantom misses.
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,7 @@ keywords = ["podman", "containers", "agent", "ai", "coding-agent"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
-# pyproject.toml Hygiene").  Keep the dependency tables comment-free and
-# self-documenting -- in particular, never note here why a sibling
-# terok-* package is pinned a certain way, nor any transient dev-cycle
-# state: a comment-blind release script would ship such notes.
+# pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
     "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.3.2a1/terok_sandbox-0.3.2a1-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.2.0/terok_util-0.2.0-py3-none-any.whl",


### PR DESCRIPTION
Pin third-party **major-0** runtime deps to an exact patch (pre-1.0 makes no compat guarantee across minors *or* patches); major>=1 keep ranges; **sibling terok-* deps stay ranges** (we guarantee patch-level API stability). Dev/test/docs groups untouched. Documents the policy in AGENTS.md + a single sanctioned pyproject comment, and forbids all other pyproject comments — especially dev-cycle git-branch pins / PR-chain notes a merge script would leak into a release. (`agent-client-protocol==0.10.1`, `ruamel.yaml==0.19.1`). Removes a stale inline pyproject comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for dependency versioning and project file conventions.
* **Chores**
  * Updated runtime dependencies to use tighter version constraints for improved consistency and reliability.
  * Aligned related package versions with the new pinning policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->