### PR TITLE
fix(list): named containers surface via their state dirs

### DIFF
--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -491,12 +491,27 @@ def _handle_build(
 
 
 def _handle_list() -> None:
-    """List running terok-executor containers."""
-    from terok_executor.integrations.sandbox import PodmanRuntime
+    """List executor-managed containers and their states.
 
-    states = PodmanRuntime().container_states("terok-executor")
+    Two name sources meet here: the ``terok-executor-`` default-name
+    prefix, and the per-container state dirs under
+    [`container_state_root`][terok_executor.paths.container_state_root]
+    — the latter makes ``--name`` overrides visible.  Podman stays the
+    truth for liveness: the dirs only contribute names to ask about,
+    and a name whose container is gone is skipped.
+    """
+    from terok_executor.integrations.sandbox import PodmanRuntime
+    from terok_executor.paths import container_state_root
+
+    runtime = PodmanRuntime()
+    states = runtime.container_states("terok-executor")
+    run_root = container_state_root()
+    named = (p.name for p in run_root.iterdir() if p.is_dir()) if run_root.is_dir() else ()
+    for name in named:
+        if name not in states and (state := runtime.container(name).state) is not None:
+            states[name] = state
     if not states:
-        print("No running containers.")
+        print("No containers.")
         return
     for name, state in sorted(states.items()):
         print(f"{name}  {state}")
@@ -984,7 +999,7 @@ ACP_COMMAND = CommandDef(
 )
 
 
-LIST_COMMAND = CommandDef(name="list", help="List running containers", handler=_handle_list)
+LIST_COMMAND = CommandDef(name="list", help="List containers", handler=_handle_list)
 
 SHOW_CONFIG_COMMAND = CommandDef(
     name="show-config",

--- a/src/terok_executor/paths.py
+++ b/src/terok_executor/paths.py
@@ -25,6 +25,15 @@ def state_root() -> Path:
     return namespace_state_dir(_SUBDIR, env_var="TEROK_EXECUTOR_STATE_DIR")
 
 
+def container_state_root() -> Path:
+    """Parent of every per-container state directory (``state_root()/run``).
+
+    Listing it names every container a ``run`` created on this host —
+    including ``--name`` overrides the default-name prefix can't find.
+    """
+    return state_root() / "run"
+
+
 def container_state_dir(container_name: str) -> Path:
     """Host-side state directory for one container, derived from its name.
 
@@ -47,7 +56,7 @@ def container_state_dir(container_name: str) -> Path:
         or "\\" in container_name
     ):
         raise ValueError(f"invalid container name: {container_name!r}")
-    return state_root() / "run" / container_name
+    return container_state_root() / container_name
 
 
 def mounts_dir() -> Path:

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -21,6 +21,7 @@ from terok_executor.commands import (
     _handle_agents_set,
     _handle_auth,
     _handle_build,
+    _handle_list,
     _handle_rm,
     _handle_start,
     _handle_stop,
@@ -223,3 +224,37 @@ def test_handle_rm_failure_exits_without_state_sweep(tmp_path) -> None:
         with pytest.raises(SystemExit, match="in use"):
             _handle_rm(name="ctr")
     state.assert_not_called()
+
+
+# ── list ─────────────────────────────────────────────────────
+
+
+def test_handle_list_includes_named_containers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
+) -> None:
+    """Containers with --name overrides surface via their state dirs."""
+    monkeypatch.setenv("TEROK_EXECUTOR_STATE_DIR", str(tmp_path))
+    (tmp_path / "run" / "my-named-run").mkdir(parents=True)
+    with mock.patch("terok_executor.integrations.sandbox.PodmanRuntime") as runtime_cls:
+        runtime = runtime_cls.return_value
+        runtime.container_states.return_value = {"terok-executor-abc": "running"}
+        runtime.container.return_value.state = "exited"
+        _handle_list()
+    runtime.container.assert_called_once_with("my-named-run")
+    out = capsys.readouterr().out
+    assert "terok-executor-abc  running" in out
+    assert "my-named-run  exited" in out
+
+
+def test_handle_list_skips_state_dirs_without_containers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys
+) -> None:
+    """A stale state dir (container removed out-of-band) is not listed."""
+    monkeypatch.setenv("TEROK_EXECUTOR_STATE_DIR", str(tmp_path))
+    (tmp_path / "run" / "gone").mkdir(parents=True)
+    with mock.patch("terok_executor.integrations.sandbox.PodmanRuntime") as runtime_cls:
+        runtime = runtime_cls.return_value
+        runtime.container_states.return_value = {}
+        runtime.container.return_value.state = None
+        _handle_list()
+    assert "No containers." in capsys.readouterr().out


### PR DESCRIPTION
`list` only queried the `terok-executor-` name prefix, so a `--name` override was manageable by `start`/`stop`/`rm` yet invisible to the one discovery verb. It now unions the prefix query with the per-container state dirs under `state_root()/run` (created by `run`, removed by `rm`). Podman stays the truth for liveness — stale dirs whose container is gone are skipped.

Follow-up to #421; fully contained, no release needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The container list command now shows all managed containers, including their current state, rather than only running ones.
  * The list output is sorted and uses a clearer empty-state message: `No containers.`
* **Bug Fixes**
  * Container states are now gathered more reliably from both saved state and the runtime, improving visibility when containers are stopped or partially removed.
* **Tests**
  * Added coverage for listing containers from saved state and for handling stale entries correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->