### PR TITLE
chore(deps): consume the matrix-engine PR chain (sandbox + util branch tips)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3447,7 +3447,7 @@ terok-util = {git = "https://github.com/sliwowitz/terok-util.git", rev = "feat/m
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "0e26c376b8d20b18e15e3efa47edfff9d46aef13"
+resolved_reference = "734706ff3b06ebd1107a5bc1fa72de2d2e60c495"
 
 [[package]]
 name = "terok-shield"
@@ -3488,7 +3488,7 @@ platformdirs = ">=4.10,<5.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-util.git"
 reference = "feat/matrix-engine"
-resolved_reference = "3eedac137a48d7ec58147eb8e33b36497d43295d"
+resolved_reference = "686fdbfc6131bab2c481486467df29d0854f99b3"
 
 [[package]]
 name = "tomli"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3447,7 +3447,7 @@ terok-util = ">=0.2.1,<0.3.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "17e63313354f70433becd5640c88a9525ff7e76f"
+resolved_reference = "0282cfb3c9eb963d3b5c3619f731b856567d61ec"
 
 [[package]]
 name = "terok-shield"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3447,7 +3447,7 @@ terok-util = {git = "https://github.com/sliwowitz/terok-util.git", rev = "feat/m
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "734706ff3b06ebd1107a5bc1fa72de2d2e60c495"
+resolved_reference = "3c9cba485b44dd850801edba098e31c1dad3c550"
 
 [[package]]
 name = "terok-shield"
@@ -3488,7 +3488,7 @@ platformdirs = ">=4.10,<5.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-util.git"
 reference = "feat/matrix-engine"
-resolved_reference = "686fdbfc6131bab2c481486467df29d0854f99b3"
+resolved_reference = "6068c4aed440a183955d30357982376ab81c765e"
 
 [[package]]
 name = "tomli"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3420,13 +3420,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.2/tero
 
 [[package]]
 name = "terok-sandbox"
-version = "0.3.2a2"
+version = "0.3.2a3"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.3.2a3-py3-none-any.whl", hash = "sha256:deb7a7b8d6dc823694e2d3b8bfdef70aae13df033e9fb8af7f0d35de91248693"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.14.1,<3.15.0"
@@ -3441,13 +3442,11 @@ pydantic = ">=2.13,<3.0"
 sqlcipher3 = "0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.2/terok_clearance-0.7.2-py3-none-any.whl"}
 terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.7.1/terok_shield-0.7.1-py3-none-any.whl"}
-terok-util = ">=0.2.1,<0.3.0"
+terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.2.1/terok_util-0.2.1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/shared-matrix-engine"
-resolved_reference = "0282cfb3c9eb963d3b5c3619f731b856567d61ec"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.3.2a3/terok_sandbox-0.3.2a3-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3474,17 +3473,20 @@ name = "terok-util"
 version = "0.2.1"
 description = "Shared utility library for the terok-* sibling packages"
 optional = false
-python-versions = "<4.0,>=3.12"
+python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
     {file = "terok_util-0.2.1-py3-none-any.whl", hash = "sha256:51a2dd3e5d8de52cc349aa4d3fab46a05c02c190a005525bf5b21c753e421f2f"},
-    {file = "terok_util-0.2.1.tar.gz", hash = "sha256:7311147632b585c0e3764ba3092044f5d330e3515327a315866743ef90459e83"},
 ]
 
 [package.dependencies]
 jinja2 = ">=3.1,<4.0"
 platformdirs = ">=4.10,<5.0"
 "ruamel.yaml" = "0.19.1"
+
+[package.source]
+type = "url"
+url = "https://github.com/terok-ai/terok-util/releases/download/v0.2.1/terok_util-0.2.1-py3-none-any.whl"
 
 [[package]]
 name = "tomli"
@@ -3859,4 +3861,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "e4c99e76cb14ee5045d3e3438cf9b72737edbf87933d0679e927fdcf869c9fc3"
+content-hash = "032e051287f9189e07260dc3f91fa0ea853cd9f92dec62c82b756c14375d9f90"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3441,13 +3441,13 @@ pydantic = ">=2.13,<3.0"
 sqlcipher3 = "0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.2/terok_clearance-0.7.2-py3-none-any.whl"}
 terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.7.1/terok_shield-0.7.1-py3-none-any.whl"}
-terok-util = {git = "https://github.com/sliwowitz/terok-util.git", rev = "feat/matrix-engine"}
+terok-util = {git = "https://github.com/terok-ai/terok-util.git", rev = "879265e4808f1bdb8bdd7b21d71508021b9e90dd"}
 
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "c650c944e94b7a820e82717c02393c2f4debca1d"
+resolved_reference = "0cc871d5f5af0e88e65b93fdb7baa1dcb91db50a"
 
 [[package]]
 name = "terok-shield"
@@ -3486,9 +3486,9 @@ platformdirs = ">=4.10,<5.0"
 
 [package.source]
 type = "git"
-url = "https://github.com/sliwowitz/terok-util.git"
-reference = "feat/matrix-engine"
-resolved_reference = "66edd4af4f17b27d5c679cf2b81f6739e5f34ae2"
+url = "https://github.com/terok-ai/terok-util.git"
+reference = "879265e4808f1bdb8bdd7b21d71508021b9e90dd"
+resolved_reference = "879265e4808f1bdb8bdd7b21d71508021b9e90dd"
 
 [[package]]
 name = "tomli"
@@ -3863,4 +3863,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "1a21cce439e0af790c5bde9340b56bb36c73483335299ed60f9cfb07129ce90f"
+content-hash = "c10d065785613760e0ef8f17a87661800d8f4acf0475af4acd2e593d6a452568"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3447,7 +3447,7 @@ terok-util = {git = "https://github.com/sliwowitz/terok-util.git", rev = "feat/m
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "a22724cf2048f3e653fb8aaf6a98e4406d639955"
+resolved_reference = "0e26c376b8d20b18e15e3efa47edfff9d46aef13"
 
 [[package]]
 name = "terok-shield"
@@ -3480,6 +3480,7 @@ files = []
 develop = false
 
 [package.dependencies]
+jinja2 = ">=3.1,<4.0"
 platformdirs = ">=4.10,<5.0"
 "ruamel.yaml" = "0.19.1"
 
@@ -3487,7 +3488,7 @@ platformdirs = ">=4.10,<5.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-util.git"
 reference = "feat/matrix-engine"
-resolved_reference = "60fa1229b238ab4941ea1f07a34cca0f4121db89"
+resolved_reference = "3eedac137a48d7ec58147eb8e33b36497d43295d"
 
 [[package]]
 name = "tomli"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3441,13 +3441,13 @@ pydantic = ">=2.13,<3.0"
 sqlcipher3 = "0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.2/terok_clearance-0.7.2-py3-none-any.whl"}
 terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.7.1/terok_shield-0.7.1-py3-none-any.whl"}
-terok-util = {git = "https://github.com/terok-ai/terok-util.git", rev = "879265e4808f1bdb8bdd7b21d71508021b9e90dd"}
+terok-util = ">=0.2.1,<0.3.0"
 
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "0cc871d5f5af0e88e65b93fdb7baa1dcb91db50a"
+resolved_reference = "8768ac823940c515955fd0973057751b92ec4deb"
 
 [[package]]
 name = "terok-shield"
@@ -3471,24 +3471,20 @@ url = "https://github.com/terok-ai/terok-shield/releases/download/v0.7.1/terok_s
 
 [[package]]
 name = "terok-util"
-version = "0.2.0"
+version = "0.2.1"
 description = "Shared utility library for the terok-* sibling packages"
 optional = false
-python-versions = ">=3.12,<4.0"
+python-versions = "<4.0,>=3.12"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_util-0.2.1-py3-none-any.whl", hash = "sha256:51a2dd3e5d8de52cc349aa4d3fab46a05c02c190a005525bf5b21c753e421f2f"},
+    {file = "terok_util-0.2.1.tar.gz", hash = "sha256:7311147632b585c0e3764ba3092044f5d330e3515327a315866743ef90459e83"},
+]
 
 [package.dependencies]
 jinja2 = ">=3.1,<4.0"
 platformdirs = ">=4.10,<5.0"
 "ruamel.yaml" = "0.19.1"
-
-[package.source]
-type = "git"
-url = "https://github.com/terok-ai/terok-util.git"
-reference = "879265e4808f1bdb8bdd7b21d71508021b9e90dd"
-resolved_reference = "879265e4808f1bdb8bdd7b21d71508021b9e90dd"
 
 [[package]]
 name = "tomli"
@@ -3863,4 +3859,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "c10d065785613760e0ef8f17a87661800d8f4acf0475af4acd2e593d6a452568"
+content-hash = "e4c99e76cb14ee5045d3e3438cf9b72737edbf87933d0679e927fdcf869c9fc3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3447,7 +3447,7 @@ terok-util = ">=0.2.1,<0.3.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "f78fbd89f35583eb83121e374a23cac5fb755df6"
+resolved_reference = "17e63313354f70433becd5640c88a9525ff7e76f"
 
 [[package]]
 name = "terok-shield"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3447,7 +3447,7 @@ terok-util = {git = "https://github.com/sliwowitz/terok-util.git", rev = "feat/m
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "9d0fc99c459ada73d179d256735428a1ec81387c"
+resolved_reference = "c650c944e94b7a820e82717c02393c2f4debca1d"
 
 [[package]]
 name = "terok-shield"
@@ -3488,7 +3488,7 @@ platformdirs = ">=4.10,<5.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-util.git"
 reference = "feat/matrix-engine"
-resolved_reference = "b0a7b79dfd4f7557592ea05f090b36ed017904da"
+resolved_reference = "66edd4af4f17b27d5c679cf2b81f6739e5f34ae2"
 
 [[package]]
 name = "tomli"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2003,20 +2003,20 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.7.3"
+version = "0.7.1"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
 python-versions = "<4.0,>=3.12"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.7.3-py3-none-any.whl", hash = "sha256:3c628aecc2201e86c5573b0e19d412b602f2534ab49a4c745f2fdd1304b4af04"},
-    {file = "mkdocs_terok-0.7.3.tar.gz", hash = "sha256:67129d19a623dfe6c8acdcef4b2bf8485ea7a38e8de9abf0d51c8f59e9f5a2a4"},
+    {file = "mkdocs_terok-0.7.1-py3-none-any.whl", hash = "sha256:71f51c8d2d241a808e527ede731983157e817864ab6065a7e74cf84021215e2e"},
+    {file = "mkdocs_terok-0.7.1.tar.gz", hash = "sha256:cdb5715dfa82395bcd61c005603091910924a7609178c6dca26eea814cdf6667"},
 ]
 
 [package.dependencies]
-properdocs = ">=1.6.7,<1.7.0"
-PyYAML = ">=6.0,<7.0"
-squarify = "0.4.4"
+properdocs = ">=1.6.7"
+PyYAML = ">=6.0"
+squarify = ">=0.4"
 
 [[package]]
 name = "mkdocstrings"
@@ -3420,14 +3420,13 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.2/tero
 
 [[package]]
 name = "terok-sandbox"
-version = "0.3.2a2"
+version = "0.3.2a1"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.3.2a2-py3-none-any.whl", hash = "sha256:8111575c5cc0ff04e712408d467b1138f88b7976a415f057457b77b42569eb99"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.14.1,<3.15.0"
@@ -3442,11 +3441,13 @@ pydantic = ">=2.13,<3.0"
 sqlcipher3 = "0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.2/terok_clearance-0.7.2-py3-none-any.whl"}
 terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.7.1/terok_shield-0.7.1-py3-none-any.whl"}
-terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.2.0/terok_util-0.2.0-py3-none-any.whl"}
+terok-util = {git = "https://github.com/sliwowitz/terok-util.git", rev = "feat/matrix-engine"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.3.2a2/terok_sandbox-0.3.2a2-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/shared-matrix-engine"
+resolved_reference = "a22724cf2048f3e653fb8aaf6a98e4406d639955"
 
 [[package]]
 name = "terok-shield"
@@ -3475,17 +3476,18 @@ description = "Shared utility library for the terok-* sibling packages"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_util-0.2.0-py3-none-any.whl", hash = "sha256:74f047643962ff64e62e354958fe37caa91f04dc811eb61f6af41220f8311ef8"},
-]
+files = []
+develop = false
 
 [package.dependencies]
-platformdirs = ">=4.10.0"
-"ruamel.yaml" = ">=0.18"
+platformdirs = ">=4.10,<5.0"
+"ruamel.yaml" = "0.19.1"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-util/releases/download/v0.2.0/terok_util-0.2.0-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-util.git"
+reference = "feat/matrix-engine"
+resolved_reference = "60fa1229b238ab4941ea1f07a34cca0f4121db89"
 
 [[package]]
 name = "tomli"
@@ -3860,4 +3862,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "ce352a3951aa3a0c453a0325970056d785275a31f9c03eb866a40c33c2e26455"
+content-hash = "1a21cce439e0af790c5bde9340b56bb36c73483335299ed60f9cfb07129ce90f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3447,7 +3447,7 @@ terok-util = {git = "https://github.com/sliwowitz/terok-util.git", rev = "feat/m
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "3c9cba485b44dd850801edba098e31c1dad3c550"
+resolved_reference = "9d0fc99c459ada73d179d256735428a1ec81387c"
 
 [[package]]
 name = "terok-shield"
@@ -3488,7 +3488,7 @@ platformdirs = ">=4.10,<5.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-util.git"
 reference = "feat/matrix-engine"
-resolved_reference = "6068c4aed440a183955d30357982376ab81c765e"
+resolved_reference = "b0a7b79dfd4f7557592ea05f090b36ed017904da"
 
 [[package]]
 name = "tomli"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3420,7 +3420,7 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.2/tero
 
 [[package]]
 name = "terok-sandbox"
-version = "0.3.2a1"
+version = "0.3.2a2"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -3447,7 +3447,7 @@ terok-util = ">=0.2.1,<0.3.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/shared-matrix-engine"
-resolved_reference = "8768ac823940c515955fd0973057751b92ec4deb"
+resolved_reference = "f78fbd89f35583eb83121e374a23cac5fb755df6"
 
 [[package]]
 name = "terok-shield"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dynamic = ["version", "classifiers"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/shared-matrix-engine",
-    "terok-util~=0.2.1",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.3.2a3/terok_sandbox-0.3.2a3-py3-none-any.whl",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.2.1/terok_util-0.2.1-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
     "tomli-w~=1.2",
@@ -56,7 +56,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.2.2a1"
+version = "0.2.2a3"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version", "classifiers"]
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
     "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/shared-matrix-engine",
-    "terok-util @ git+https://github.com/terok-ai/terok-util.git@879265e4808f1bdb8bdd7b21d71508021b9e90dd",
+    "terok-util~=0.2.1",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
     "tomli-w~=1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version", "classifiers"]
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
     "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/shared-matrix-engine",
-    "terok-util @ git+https://github.com/sliwowitz/terok-util.git@feat/matrix-engine",
+    "terok-util @ git+https://github.com/terok-ai/terok-util.git@879265e4808f1bdb8bdd7b21d71508021b9e90dd",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
     "tomli-w~=1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dynamic = ["version", "classifiers"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.3.2a2/terok_sandbox-0.3.2a2-py3-none-any.whl",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.2.0/terok_util-0.2.0-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/shared-matrix-engine",
+    "terok-util @ git+https://github.com/sliwowitz/terok-util.git@feat/matrix-engine",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
     "tomli-w~=1.2",
@@ -56,7 +56,7 @@ classifiers = [
 packages = [
   { include = "terok_executor", from = "src" },
 ]
-version = "0.2.2a2"
+version = "0.2.2a1"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=4.0"
@@ -82,7 +82,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.26"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
-mkdocs-terok = "^0.7.3"
+mkdocs-terok = "^0.7"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Pin-only link in the matrix-engine extraction chain: **terok-ai/terok-util#31** ← terok-ai/terok-sandbox#414 ← this ← the terok PR.

Executor has no test matrix, so no code changes — `terok-sandbox` and `terok-util` move to the PR branch tips so terok (which wheel-pins executor) can resolve the whole chain. The release script repins to alpha wheel URLs bottom-up on release.

Checks: lint, tach, mypy, bandit, docstrings, vulture, reuse all green; the 6 unit-test failures in this dev container are pre-existing/environmental (no `podman` binary on PATH — byte-identical failing set on `upstream/master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to use newer, more flexible package sources and version ranges.
  * Adjusted the project version for the latest release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->