### PR TITLE
docs: accuracy pass against the current source

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Python when you want library-grade control.
 
 ```bash
 pip install terok-executor
-terok-executor run claude ~/my-workspace
+terok-executor run claude ~/my-workspace -p "Fix the bug"
 ```
 
 The first `run` interactively offers any missing prerequisites — sandbox
@@ -70,16 +70,18 @@ hardening guarantees.
 | Claude Code | OAuth*, API key | Anthropic Claude Code |
 | Codex | OAuth*, API key | OpenAI Codex CLI |
 | Vibe | API key | Mistral Vibe |
-| OpenCode | API key | Generic LLM endpoint driver — bundled defaults for Helmholtz Blablador, KISSKI AcademicCloud, and your own endpoint |
+| Copilot | — | GitHub Copilot (no vault route yet) |
+| OpenCode | — (uses provider keys) | Harness that drives any OpenAI-compatible provider — curated configs for Helmholtz Blablador, KISSKI AcademicCloud, and OpenRouter (each authenticated with its own API key) |
+| Pi | — (uses provider keys) | Multi-provider harness; routes through the phantom tokens of co-installed providers |
 | gh | OAuth, API key | GitHub CLI |
 | glab | API key | GitLab CLI |
+| SonarCloud | API key | SonarCloud scanner |
 | CodeRabbit | API key | CodeRabbit (sidecar tool) |
-| SonarCloud | API key | SonarCloud scanner (sidecar tool) |
 
-\* Claude and Codex OAuth are experimental, and support must be explicitly allowed in the config file. 
+\* Claude and Codex OAuth are experimental.
 
-`terok-executor agents` lists the live roster (add `--all` to
-include the tool entries).
+`terok-executor agents list` lists the live roster (add `--all` to
+include tools and harness-driven providers).
 
 ## Where it sits in the stack
 
@@ -100,15 +102,16 @@ hooks).
 | `setup` | Bootstrap sandbox services + container images |
 | `uninstall` | Remove sandbox services + container images |
 | `auth` | Authenticate a provider |
-| `agents` | List the agent roster |
+| `agents` | Inspect the agent roster (`list`) and set the build-time default selection (`set`) |
 | `build` | Build base + agent images explicitly |
-| `run-tool` | Run a sidecar tool (CodeRabbit, SonarCloud) |
+| `run-tool` | Run a sidecar tool (CodeRabbit) |
 | `list` | List containers |
 | `start` | Start a stopped container |
 | `stop` | Stop a container (kept for a later `start`) |
 | `rm` | Remove a container and its host-side state |
 | `show-config` | Print the effective `SandboxConfig` as YAML (diffable across orchestrators) |
-| `vault` | Vault management (start, stop, status, install, routes) |
+| `vault` | Vault management (status, unlock, lock, list, passphrase, routes, clean) |
+| `sandbox` | Full terok-sandbox command tree (shield, vault, ssh, doctor, …) |
 
 ### Config override
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -5,14 +5,25 @@
 | Agent | Auth | Description |
 |-------|------|-------------|
 | Claude | OAuth\*, API key | Anthropic Claude Code |
-| Codex | OAuth\*, API key | OpenAI Codex CLI |
+| Codex | OAuth\* (browser or device code), API key | OpenAI Codex CLI |
 | Vibe | API key | Mistral Vibe |
-| Copilot | — | GitHub Copilot (not proxied yet) |
-| Blablador | API key | Helmholtz Blablador via OpenCode |
-| Pi | — (reuses co-installed providers) | [Pi](https://pi.dev/) multi-provider harness; routes through the phantom tokens of co-installed agents |
-| KISSKI | API key | KISSKI AcademicCloud via OpenCode |
+| Copilot | — | GitHub Copilot (no vault route yet) |
+| OpenCode | — (uses provider keys) | OpenCode harness; drives any authenticated OpenAI-compatible provider |
+| Pi | — (uses provider keys) | [Pi](https://pi.dev/) multi-provider harness; routes through the phantom tokens of co-installed providers |
 
 \* OAuth support for Claude and Codex is experimental.
+
+### Harness-driven providers
+
+Curated OpenAI-compatible endpoints driven through the OpenCode
+harness — authenticated with their own API key, launched with a
+one-word command (`blablador`, `kisski`, `openrouter`):
+
+| Provider | Auth | Description |
+|----------|------|-------------|
+| Blablador | API key | Helmholtz Blablador |
+| KISSKI | API key | KISSKI AcademicCloud (GWDG) |
+| OpenRouter | API key | OpenRouter model aggregator |
 
 ### Tools
 
@@ -22,7 +33,7 @@ Optionally available in the container:
 |------|------|-------------|
 | gh | OAuth, API key | GitHub CLI |
 | glab | API key | GitLab CLI |
-| SonarCloud | API key | SonarCloud scanner |
+| SonarCloud (`sonar`) | API key | SonarCloud scanner (`sonar-scanner`) |
 
 ### Sidecar tools
 
@@ -37,7 +48,7 @@ Tools run in a separate container:
 
 ```bash
 terok-executor agents list           # coding agents only
-terok-executor agents list --all     # include tools (gh, glab, coderabbit, sonarcloud)
+terok-executor agents list --all     # include tools (gh, glab, coderabbit, sonar) and harness-driven providers
 ```
 
 ## Setting the global default
@@ -71,14 +82,19 @@ to the host-side credential database.
 terok-executor auth claude
 ```
 
-**Interactive API key prompt** (Vibe, Blablador, KISSKI, glab) — prompts
-for a key on the terminal. No container needed.
+Codex also has a headless device-code variant for hosts without a
+browser callback: `terok-executor auth codex --device-auth`.
+
+**Interactive API key prompt** (Vibe, Blablador, KISSKI, OpenRouter,
+glab, CodeRabbit, SonarCloud) — prompts for a key on the terminal.
+No container needed.
 
 ```bash
 terok-executor auth vibe
 ```
 
-**Non-interactive** (all providers) — pass the key directly:
+**Non-interactive** (any provider with an auth flow) — pass the key
+directly:
 
 ```bash
 terok-executor auth gh --api-key ghp_…
@@ -103,17 +119,21 @@ user definitions with bundled ones using deep merge for dicts and
 `_inherit` splicing for lists.
 
 See the bundled definitions in `resources/agents/` for the schema:
-binary, headless flags, vault routing, auth modes, and git
-identity.
+binary, headless flags, provider binding, auth modes, and git
+identity.  Endpoint definitions (upstream URL, wire auth) live
+separately in `resources/providers/`, with user overrides in
+`~/.config/terok/agent/providers/`.
 
 ## Git identity
 
-By default, agents commit under a built-in AI identity. To use the
-host machine's git config instead:
+By default, agents commit under a built-in AI identity. To record the
+host machine's git identity as the human committer alongside the agent
+author:
 
 ```bash
 terok-executor run claude . --git-identity-from-host -p "…"
 ```
 
-This injects `user.name` and `user.email` from the host's git config
-into the container.
+This reads `user.name` and `user.email` from the host's global git
+config and injects them as the human committer identity
+(`HUMAN_GIT_NAME` / `HUMAN_GIT_EMAIL`); the agent remains the author.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,11 +45,13 @@ terok-executor auth claude  # OAuth or API key
 terok-executor run claude . -p "..."
 ```
 
-`setup` is idempotent — safe to re-run after upgrades.  Only the
-image build can be run on its own: `terok-executor build` rebuilds
-the L0+L1 images without touching the sandbox services.  The other
-setup steps (shield hooks, gate, credentials-DB provisioning) are
-only available through `setup`.
+`setup` is idempotent — safe to re-run after upgrades.
+`terok-executor build` rebuilds the L0+L1 images without touching
+the sandbox services; the service side (supervisor + shield OCI
+hooks, credentials-DB provisioning) is installed by `setup`
+(individual steps are also reachable under the `terok-executor
+sandbox` subtree).  There is no host-side gate or vault service —
+both run inside each container's supervisor, spawned on demand.
 
 ## Authenticate
 

--- a/docs/launch-modes.md
+++ b/docs/launch-modes.md
@@ -1,13 +1,13 @@
 # Launch modes
 
-terok-executor supports four ways to run an agent, plus a separate tool
-runner for sidecars.
+terok-executor supports three ways to run an agent — headless,
+interactive, and web — plus a separate tool runner for sidecars.
 
 ## Headless
 
 ```bash
 terok-executor run claude . -p "Fix the failing test"
-terok-executor run claude . -p "Refactor auth" --model sonnet --max-turns 10
+terok-executor run claude . -p "Refactor auth" -m sonnet --max-turns 10
 ```
 
 Fire-and-forget. The agent runs autonomously and streams output to the
@@ -20,9 +20,10 @@ terminal. Exits when the agent finishes, hits `--max-turns`, or reaches
 terok-executor run claude . --interactive
 ```
 
-Opens a shell session inside the container. The agent CLI is installed
-and ready; credentials and the repository are pre-configured. Use this
-to drive the agent manually.
+Starts the container and keeps it running; once it is ready, the CLI
+prints the login command (e.g. `podman exec -it <name> bash -l`). The
+agent CLI is installed and ready; credentials and the repository are
+pre-configured. Use this to drive the agent manually.
 
 ## Web
 
@@ -32,18 +33,20 @@ terok-executor run claude . --web --port 8080
 ```
 
 Launches [toad](https://github.com/terok-ai/toad), a multi-agent TUI
-served over HTTP. Access it in a browser at the printed URL.
+served over HTTP on `127.0.0.1` (auto-allocated port unless `--port`
+is given). Access it in a browser at the printed URL.
 
 ## Tool mode
 
 ```bash
 terok-executor run-tool coderabbit . -- --pr 42
-terok-executor run-tool sonarcloud . --timeout 300
+terok-executor run-tool coderabbit . --timeout 300
 ```
 
-Runs a sidecar tool in its own container. Arguments after `--` are
-passed to the tool binary. See [Agents](agents.md#sidecar-tools) for
-the list of supported tools.
+Runs a sidecar tool in its own container (default timeout: 600 s).
+Arguments after `--` are passed to the tool binary. CodeRabbit is
+currently the only sidecar tool — see
+[Agents](agents.md#sidecar-tools).
 
 ## Container lifecycle
 
@@ -69,15 +72,16 @@ even `rm`).
 
 | Flag | Description |
 |------|-------------|
-| `--gate` / `--no-gate` | Route git clone through the host-side gate mirror, or skip it and let the container clone upstream directly (default: on — the gate is faster and offers staleness comparison; the shield firewall is unaffected) |
+| `--gate` / `--no-gate` | Route the git clone through the per-container gate mirror (default: on; the shield firewall is unaffected).  `--no-gate` makes the container clone the upstream URL directly — a local directory repo is unreachable without the gate and is refused |
 | `--restricted` | No auto-approve, no-new-privileges |
 | `--branch <ref>` | Check out a specific git branch |
 | `--name <name>` | Container name override |
 | `--gpu` | Enable GPU passthrough |
+| `--memory <limit>` / `--cpus <n>` | Container memory / CPU limits (e.g. `4g`, `2.0`) |
 | `--workspace <dir>` | Mount a host directory at `/workspace` (default: the workspace lives in the container) |
 | `--rm` | Remove the container when it exits (podman `--rm`) |
-| `--git-identity-from-host` | Use the host's git user.name and user.email |
-| `--shared-dir` / `--shared-mount` | Mount a host directory into the container |
+| `--git-identity-from-host` | Use the host's git user.name/email as the human committer identity |
+| `--shared-dir <dir>` | Mount a host directory as shared IPC space (at `--shared-mount`, default `/shared`) |
 | `--timeout <seconds>` | Override the default timeout |
-| `--model <name>` | Model override (headless mode) |
+| `-m <name>` | Model override (headless mode) |
 | `--max-turns <n>` | Limit agent turns (headless mode) |

--- a/docs/security.md
+++ b/docs/security.md
@@ -12,9 +12,10 @@ API endpoint, package registries, and git hosts.  Everything else is
 blocked at the nftables level.
 
 The firewall is attached via OCI hooks at install time (``terok-executor
-setup`` / ``terok-sandbox setup``); there is no per-run opt-out.  To
-loosen it for development, edit the shield profile or run
-``terok-executor uninstall`` + reinstall without the hooks.
+setup`` / ``terok-sandbox setup``); ``run`` has no per-run opt-out flag.
+To loosen it for development, use the live shield verbs — per container:
+``terok-executor sandbox shield allow|deny|down|up`` — or remove the
+hooks entirely with ``terok-executor sandbox shield uninstall-hooks``.
 
 The git gate mirror (``--gate`` / ``--no-gate``) is a separate concern
 from the firewall — see [Launch modes](launch-modes.md) for that flag.
@@ -42,14 +43,17 @@ architecture, per-agent routing table, and YAML configuration.
 
 The vault is served per container: the supervisor spawns on container
 start via the terok-sandbox OCI hook and reads the per-container
-sidecar to bind its proxy.  The vault verbs are passphrase-tier CRUD
-on the DB plus two executor-only file-level helpers:
+sidecar to bind its proxy.  The vault verbs are DB inspection and
+passphrase-tier management (owned by terok-sandbox) plus two
+executor-only file-level helpers:
 
 ```bash
-terok-executor vault unlock      # unlock the credential DB
-terok-executor vault lock        # lock the credential DB
-terok-executor vault passphrase  # passphrase-tier CRUD subgroup
-terok-executor vault routes      # regenerate routes.json from YAML roster
+terok-executor vault status      # lock state, passphrase chain, stored secrets
+terok-executor vault unlock      # provision the credential-DB passphrase for this session
+terok-executor vault lock        # clear every stored copy of the passphrase
+terok-executor vault list        # inventory stored credentials
+terok-executor vault passphrase  # manage where the passphrase lives (seal, to-keyring, …)
+terok-executor vault routes      # regenerate routes.json from the YAML roster
 terok-executor vault clean       # remove leaked credential files from mounts
 ```
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -6,51 +6,62 @@ terok bind-mounts vendor config directories into task containers. A
 prompt-injected or supply-chain-compromised agent can read and exfiltrate
 API keys, OAuth tokens, or SSH private keys from these shared mounts.
 
-## Solution: TCP Token Broker
+## Solution: Token Broker
 
 No real secret enters a task container. Instead:
 
 1. **Credential DB** (host-side) stores API keys and OAuth tokens
 2. **Token broker** ([terok-sandbox](https://terok-ai.github.io/terok-sandbox/))
-   resolves phantom tokens to real credentials and forwards requests upstream
+   resolves phantom tokens to real credentials and forwards requests upstream.
+   It runs inside each container's supervisor (spawned by the terok-sandbox
+   OCI hook) and listens on a Unix socket (default) or a per-container host
+   TCP port (legacy)
 3. **Per-provider phantom tokens** (per-task, per-provider) are what containers see
 4. **SSH signer** ([terok-sandbox](https://terok-ai.github.io/terok-sandbox/))
    lets containers sign with host-side SSH keys without the private keys
-   entering the container. A socat bridge inside the container relays
-   SSH signer requests over TCP to the host-side proxy.
+   entering the container — via the bind-mounted signer socket
+   (`TEROK_SSH_SIGNER_SOCKET`) or, in TCP mode, a per-container port
+   (`TEROK_SSH_SIGNER_PORT`)
 
 ## Architecture
 
 ```text
 HOST                                      CONTAINER
 -------------------------------           -----------------------------------
-Credential DB (sqlite3)                   Per-provider phantom tokens (env vars)
-  credentials table                         ANTHROPIC_API_KEY=<claude-phantom>
-  proxy_tokens table                        MISTRAL_API_KEY=<vibe-phantom>
-    (token, project, task,                  GH_TOKEN=<gh-phantom>
-     credential_set, provider)              GITLAB_TOKEN=<glab-phantom>
-
-Token Broker (terok-sandbox)              Agent / tool makes API request
-  TCP + Unix socket listeners                with phantom token in auth header
-  Resolves phantom → real credential
-  Injects auth header, forwards             Routing is by token, not URL path.
-  to upstream over TLS                       Token encodes which provider it's for.
+Credential DB (encrypted SQLite,          Per-provider phantom tokens (env vars)
+SQLCipher)                                  ANTHROPIC_API_KEY=<anthropic-phantom>
+  credentials table                         MISTRAL_API_KEY=<mistral-phantom>
+  proxy_tokens table                        GH_TOKEN=<github-phantom>
+    (token, scope, subject,                 GITLAB_TOKEN=<gitlab-phantom>
+     credential_set, provider)
+                                          Agent / tool makes API request
+Token Broker (terok-sandbox,                with phantom token in auth header
+per-container supervisor)
+  Unix socket (default) or TCP listener   Routing is by token, not URL path.
+  Resolves phantom → real credential       Token encodes which provider it's for.
+  Injects auth header, forwards
+  to upstream over TLS
 ```
 
 ### SELinux considerations
 
 SELinux blocks `connect()` on host Unix sockets mounted into rootless
-Podman containers (`container_t -> unconfined_t` denied). If a custom SELinux rule 
-cannot be installed, the containers reach the token broker via TCP (`host.containers.internal:<port>`) instead. [terok-shield](https://terok-ai.github.io/terok-shield/) allows the
-token broker port through the nftables firewall via `loopback_ports`.
+Podman containers (`container_t -> unconfined_t` denied).  terok-sandbox
+ships a policy module (`terok_socket.te`, installed by `setup`) that
+allows exactly this connect.  Where the module cannot be installed, the
+containers reach the token broker via TCP
+(`host.containers.internal:<port>`) instead; [terok-shield](https://terok-ai.github.io/terok-shield/)
+allows the broker port through the nftables firewall via its per-container
+`loopback_ports` state.
 
 ### Per-provider phantom token routing
 
-Each provider gets its own phantom token, created at container launch:
+Each routed provider gets its own phantom token, minted at container
+launch:
 
 ```python
 tokens = {
-    name: db.create_proxy_token(project, task, credential_set, name)
+    name: db.create_token(scope, task_id, credential_set, name)
     for name in routed_providers
 }
 ```
@@ -61,28 +72,36 @@ gh CLI) strip or ignore URL path components.
 
 ## Per-Agent Traffic Routing
 
-Different agents reach the token broker in different ways, depending on what
-their SDK supports:
+Inside the container, HTTP clients always reach the vault at
+`http://localhost:9419` — an in-container loopback bridge that runs in
+both transports and forwards to the host socket (socket mode) or the
+per-container broker port (TCP mode).  Different agents are pointed at
+it in different ways, depending on what their SDK supports:
 
 | Agent | How it reaches the token broker | Notes |
 |-------|-------------------------|-------|
-| **Claude** | `ANTHROPIC_BASE_URL=http://host.containers.internal:<port>` | Anthropic SDK respects this env var (default port: 18731) |
-| **Codex** | Shared `~/.codex/config.toml` rewrite (`openai_base_url`, `chatgpt_base_url`) | Codex's built-in first-party auth is file/config based, so terok patches the shared Codex config instead of relying on env vars |
-| **Vibe** | `config.toml` with `api_base` in shared `~/.vibe` mount | Mistral SDK ignores URL path in api_base, only uses host:port. Written by `shared_config_patch` in YAML |
-| **KISSKI** | `TEROK_OC_KISSKI_BASE_URL` env var override | OpenCode reads this; overridden from the real upstream to token broker |
-| **Blablador** | `TEROK_OC_BLABLADOR_BASE_URL` env var override | Same pattern as KISSKI |
-| **gh** | `http_unix_socket` in `~/.config/gh/config.yml` + socat bridge | gh routes ALL API traffic through a Unix socket. socat bridges it to TCP. See below. |
-| **glab** | `GITLAB_API_HOST` + `API_PROTOCOL=http` env vars | glab sends to `http://<api_host>/api/v4/...` |
-| **CodeRabbit** | Real API key via sidecar `env_map` | CLI has no base URL override, so token broker routing is not possible. Sidecar receives the real key directly from the credential DB. |
-| **SonarCloud** | `SONAR_HOST_URL` + `SONAR_TOKEN` phantom env | Tool agent; scanner uses host URL override |
+| **Claude** | `ANTHROPIC_BASE_URL=http://localhost:9419` (+ `ANTHROPIC_UNIX_SOCKET` pointing at the vault socket) | Anthropic SDK respects these env vars |
+| **Codex** | Shared `~/.codex/config.toml` rewrite (`openai_base_url`, `chatgpt_base_url`) | Codex's built-in first-party auth is file/config based, so terok patches the shared Codex config instead of relying on env vars.  `openai_base_url` is keyed by stored credential type: OAuth → `{vault_url}/backend-api/codex`, API key → `{vault_url}/v1` |
+| **Vibe** | `config.toml` with `api_base` (+ `api_key_env_var`) in shared `~/.vibe` mount | Mistral SDK ignores the URL path in api_base, only uses host:port. Written by the `provider.config_patch` in YAML |
+| **Blablador / KISSKI / OpenRouter** | `TEROK_OC_<NAME>_BASE_URL` env var override | The OpenCode wrapper reads this; computed at launch as the vault URL plus the provider's served path (e.g. `/v1`, `/api/v1` for OpenRouter) |
+| **gh** | `http_unix_socket` in `~/.config/gh/config.yml` | gh routes ALL API traffic through a Unix socket. See below. |
+| **glab** | `GITLAB_API_HOST` + `API_PROTOCOL=http` env vars | glab sends to `http://<api_host>/api/v4/...`; the host is `localhost:9419` in socket mode, `host.containers.internal:<port>` in TCP mode |
+| **CodeRabbit** | Real API key via sidecar `env_map` | CLI has no base URL override, so token broker routing is not possible. The sidecar receives the real key directly from the credential DB. |
+| **SonarCloud** | `SONAR_HOST_URL` + `SONAR_TOKEN` phantom env | Tool; scanner uses the host URL override |
 
-### gh: socat bridge pattern
+In addition, every routed provider with a `serves:` protocol map is
+materialized as a generic handle — `TEROK_PROVIDER_<NAME>_TOKEN` plus
+`TEROK_PROVIDER_<NAME>_BASE_<PROTOCOL>` — so harnesses (OpenCode, Pi)
+can select any authenticated, protocol-compatible provider at runtime
+via `--provider`.
+
+### gh: Unix-socket pattern
 
 gh has no env var for base URL. It supports `http_unix_socket` in its
 config file, which routes all API traffic through a Unix socket.
 
-The `shared_config_patch` mechanism writes the vault socket path into
-`~/.config/gh/config.yml` during `terok-executor auth gh` — the
+The config-patch mechanism writes the vault socket path into
+`~/.config/gh/config.yml` after `terok-executor auth gh` — the
 `{vault_socket}` template token, resolved per transport mode:
 
 - **socket mode**: `/run/terok/vault.sock` — the supervisor's vault
@@ -94,23 +113,27 @@ The `shared_config_patch` mechanism writes the vault socket path into
 Either way gh's API traffic reaches the vault token broker, which
 substitutes the phantom token before forwarding upstream.
 
-### YAML-driven shared_config_patch
+### YAML-driven config patches
 
-Providers that need config file changes (not just env vars) declare a
-`shared_config_patch` in their YAML:
+Agents that need config file changes (not just env vars) declare a
+`config_patch` under their `provider:` binding:
 
 ```yaml
 # Vibe: TOML patch
-shared_config_patch:
-  file: config.toml
-  toml_table: providers
-  toml_match: {name: mistral}
-  toml_set: {api_base: "{vault_url}/v1"}
+provider:
+  config_patch:
+    file: config.toml
+    toml_table: providers
+    toml_match: {name: mistral}
+    toml_set:
+      api_base: "{vault_url}/v1"
+      api_key_env_var: MISTRAL_API_KEY
 
 # gh: YAML patch
-shared_config_patch:
-  file: config.yml
-  yaml_set: {http_unix_socket: "{vault_socket}"}
+provider:
+  config_patch:
+    file: config.yml
+    yaml_set: {http_unix_socket: "{vault_socket}"}
 ```
 
 The patch is applied after auth and reconciled on every task launch.  Only
@@ -119,93 +142,135 @@ patcher also writes a `.terok-managed-config.json` sidecar beside the config
 file so callers can later disable a provider and remove only values still
 owned by terok; user-edited values are preserved.
 
-## Agent YAML Registry
+## YAML Registry: Providers and Bindings
 
-Each agent declares its vault integration in `resources/agents/<name>.yaml`:
+Vault integration is split across two YAML files.  The **endpoint**
+half lives in `resources/providers/<name>.yaml` — where requests go
+and how the real credential is attached:
 
 ```yaml
-vault:
-  route_prefix: claude           # kept for routes.json generation
-  upstream: https://api.anthropic.com
-  auth_header: dynamic           # OAuth -> Bearer, API key -> x-api-key
-  credential_type: oauth
-  credential_file: .credentials.json
+# resources/providers/anthropic.yaml
+upstream: https://api.anthropic.com
+auth:                            # wire auth per credential type
+  oauth:
+    header: Authorization
+    prefix: "Bearer "
+    extra_headers: {anthropic-beta: oauth-2025-04-20}
+  api_key:
+    header: x-api-key
+    prefix: ""
+oauth_refresh: {token_url: ..., client_id: ...}   # optional
+serves:                          # protocol → served path (harness selection)
+  anthropic-messages: ""
+```
+
+The **delivery** half is the agent's `provider:` binding in
+`resources/agents/<name>.yaml`:
+
+```yaml
+# resources/agents/claude.yaml
+provider:
+  default: anthropic             # binds the agent to one provider
   token_env:                     # phantom-token env var, keyed by credential type
     oauth: CLAUDE_CODE_OAUTH_TOKEN
     _default: ANTHROPIC_API_KEY  # fallback for any non-OAuth credential
-  base_url_env: ANTHROPIC_BASE_URL  # optional: env var for token broker URL
-  shared_config_patch: ...       # optional: file patch for token broker URL
+  base_url_env: ANTHROPIC_BASE_URL   # optional: env var for the vault URL
+  socket_env: ANTHROPIC_UNIX_SOCKET  # optional: env var for the vault socket
+  credential_file: .credentials.json
+  credential_type: oauth
+  config_patch: ...              # optional: file patch for the vault address
 ```
+
+A provider maps to exactly one vault route: the roster loader rejects
+a provider bound by more than one agent.  `routes.json` (regenerated
+by `terok-executor vault routes` and by `setup`) carries one entry per
+provider, keyed by its clean name — which is also what keeps a
+provider routable for harnesses even when no agent binds it (the
+curated OpenCode providers declare their endpoint plus an `opencode:`
+block and have no agent YAML at all).
 
 ### Agent-specific settings not in YAML
 
-- **OpenCode base URL override**: For KISSKI and Blablador, the environment
-  builder overrides `TEROK_OC_<NAME>_BASE_URL` when the vault is active.
-  This is computed at container launch, not declared in YAML.
+- **OpenCode base URL override**: For Blablador, KISSKI, and OpenRouter,
+  the environment builder sets `TEROK_OC_<NAME>_BASE_URL` when the vault
+  is active. This is computed at container launch, not declared in YAML.
 
 - **glab env vars**: `GITLAB_API_HOST` and `API_PROTOCOL=http` are injected
   by the environment builder for glab specifically. glab has no YAML field
   for this because it's a routing concern, not a credential concern.
 
-- **socat bridge**: In TCP mode, terok-sandbox's `ensure-bridges.sh`
-  exposes the broker as `/tmp/terok-vault.sock` for socket-only clients
-  (gh, claude). In socket mode no bridge is needed — the broker socket is
-  bind-mounted at `/run/terok/vault.sock`.
+- **socat bridges**: terok-sandbox's `ensure-bridges.sh` runs in-container.
+  In socket mode the broker socket is bind-mounted at
+  `/run/terok/vault.sock` and the bridge fronts it as TCP on
+  `localhost:9419` for HTTP-only clients.  In TCP mode the bridge is
+  reversed: it presents `/tmp/terok-vault.sock` for socket-only clients
+  and forwards `localhost:9419` to the per-container host port.
 
 ## Auth Flow
 
 ### Three auth paths
 
 **1. OAuth / interactive login** (Claude, Codex, gh):
-Launches a container with the vendor CLI and an empty config directory.
-After exit, the extractor captures the OAuth token to the DB.
+Launches a container with the vendor CLI and a temporary config
+directory.  After exit, the extractor captures the OAuth token to the
+DB.  Codex additionally offers a headless device-code variant
+(`--device-auth`).
 
-**2. API key -- interactive prompt** (Vibe, Blablador, KISSKI, glab):
-Prompts for an API key on the terminal. No container needed.
+**2. API key -- interactive prompt** (Vibe, Blablador, KISSKI,
+OpenRouter, glab, CodeRabbit, SonarCloud): Prompts for an API key on
+the terminal. No container needed.
 
-**3. API key -- non-interactive** (all providers):
+**3. API key -- non-interactive** (any provider with an auth flow):
 `terok-executor auth <provider> --api-key <key>`
+
+Credentials are stored keyed by the entry's *provider* (`claude` →
+`anthropic`, `gh` → `github`), matching the vault route names.
 
 ### Post-auth config patching
 
 After storing credentials, `write_vault_config()` applies any
-`shared_config_patch` from the YAML registry. This writes token broker URLs
-(not secrets) to the provider's shared config mount.  Task launch re-applies
-enabled patches and removes disabled provider patches using the managed
-sidecar, which keeps global shared config directories from retaining stale
-vault routing after a feature mode changes.
+`provider.config_patch` from the YAML registry. This writes vault
+addresses (not secrets) to the entry's shared config mount.  Task launch
+re-applies enabled patches and removes disabled provider patches using
+the managed sidecar (`.terok-managed-config.json`), which keeps global
+shared config directories from retaining stale vault routing after a
+feature mode changes.
 
 ## Per-Provider Credential Extractors
 
-| Provider   | File                | Key fields                    |
+| Entry      | File                | Key fields                    |
 |------------|---------------------|-------------------------------|
-| Claude     | `.credentials.json` | access_token, refresh_token   |
-| Codex      | `auth.json`         | access_token, refresh_token   |
+| Claude     | `.credentials.json` (fallback: `config.json`) | access_token, refresh_token (fallback: api_key) |
+| Codex      | `auth.json`         | access_token, refresh_token, id_token, account_id |
 | Vibe       | `.env`              | key (MISTRAL_API_KEY)         |
 | Blablador  | `config.json`       | key (api_key)                 |
 | KISSKI     | `config.json`       | key (api_key)                 |
 | gh         | `hosts.yml`         | token (oauth_token)           |
 | glab       | `config.yml`        | token (per-host)              |
-| CodeRabbit | —                   | API key via `--api-key`       |
-| SonarCloud | —                   | API key via `--api-key`       |
+| OpenRouter | —                   | API key via prompt/`--api-key` |
+| CodeRabbit | —                   | API key via prompt/`--api-key` |
+| SonarCloud | —                   | API key via prompt/`--api-key` |
 
 ## Limitations
 
-- **Claude**: OAuth logins do not support full routing. You can either expose th
-  real token to the agent to get full Claude CLI user experience, or route
+- **Claude**: OAuth logins do not support full routing. You can either expose the
+  real token to the agent to get the full Claude CLI user experience, or route
   what's officially routable, but miss out on some subscription features.
 - **Codex**: ChatGPT/backend-api and realtime websocket traffic are routed
   through the token broker, but any newly added Codex-specific upstream
   surfaces still need explicit vault route coverage.
-- **Copilot**: Not proxied yet. No `vault` section in YAML.
+- **Copilot**: Not proxied yet — no `provider:` binding in its YAML, so no
+  vault route and no `auth` flow.
 
 ## Package Boundaries
 
 - **[terok-sandbox](https://terok-ai.github.io/terok-sandbox/)**: Credential
-  DB, token broker (HTTP forwarding, phantom token resolution, OAuth token
-  refresh, SSH signer), TCP+Unix listeners, lifecycle management
-- **terok-executor** (this package): YAML agent registry, credential extractors,
-  auth CLI, container environment wiring (phantom env vars, base URL overrides,
-  socat bridges, `shared_config_patch`)
-- **[terok](https://terok-ai.github.io/terok/)**: Environment builder, phantom
-  token injection for full-stack multi-agent tasks
+  DB, token broker (HTTP/WebSocket forwarding, phantom token resolution,
+  OAuth token refresh, SSH signer), socket/TCP listeners, per-container
+  supervisor lifecycle
+- **terok-executor** (this package): YAML agent + provider registry,
+  credential extractors, auth CLI, canonical container environment assembly
+  (phantom env vars, base URL overrides, config patches)
+- **[terok](https://terok-ai.github.io/terok/)**: Multi-task orchestration on
+  top — delegates env assembly here and layers per-project credential sets
+  and OAuth exposure tiers


### PR DESCRIPTION
Docs verified against the live roster and command tree (editable-install venv, `roster/loader.py` + `_tree.py` dumps) plus direct source reads. Highlights:

- **vault.md (heaviest drift)**: `db.create_proxy_token(project, task, …)` doesn't exist (actual: `db.create_token(scope, task_id, credential_set, name)`); the routing table's `host.containers.internal:<port>` / "default port 18731" was wrong on both counts — the in-container endpoint is always the loopback bridge `http://localhost:9419`, and the broker port is auto-allocated (socket transport is the default, TCP legacy); `shared_config_patch:` is long gone (`provider.config_patch`); the old `vault:` agent-YAML block rewritten to the current two-file model (provider YAML endpoint + agent `provider:` binding, enforced 1:1); extractor table completed; "sqlite3" → SQLCipher.
- **Agent/provider tables (README + agents.md)** rebuilt from the live roster: OpenCode, Pi, Copilot added; Blablador/KISSKI are provider YAMLs (harness-driven), not agents, and OpenRouter was missing everywhere; SonarCloud is not a sidecar (`sonar` installs `sonar-scanner` into L1; the only sidecar is CodeRabbit); roster name is `sonar`, not `sonarcloud`.
- **Broken examples**: README quick-start `run claude ~/ws` exits with "Specify --prompt…" (now passes `-p`); `run-tool sonarcloud` would `SystemExit` (removed); `--model` → the real `-m`; `terok-executor agents` → `agents list`; the README's `vault` verb list was fictional (start/stop/install) — replaced with the real tree, and the missing `sandbox` command group added.
- **Semantics**: interactive mode prints a `podman exec` login command (doesn't "open a shell"); `--git-identity-from-host` sets the human *committer*, the agent stays author; OAuth config-gating is terok's, not standalone executor's; security.md gains the real per-container firewall controls (`sandbox shield allow|deny|down|up`) instead of claiming profile-edit/uninstall is the only path; index.md's "setup-only" claim corrected (steps reachable via the `sandbox` subtree; no host-side gate install exists).

**Follow-up flag (code, not docs):** `EXTRACTORS` has no `openrouter` entry, so `_materialize_exposed_providers` silently skips an exposed OpenRouter credential — looks like a real gap worth a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)