### PR TITLE
fix(credentials): openrouter joins the api-key extractors

### DIFF
--- a/src/terok_executor/credentials/extractors.py
+++ b/src/terok_executor/credentials/extractors.py
@@ -219,6 +219,7 @@ EXTRACTORS: dict[str, tuple] = {
     "glab": (extract_glab_token,),
     "blablador": (extract_json_api_key, "config.json"),
     "kisski": (extract_json_api_key, "config.json"),
+    "openrouter": (extract_json_api_key, "config.json"),
 }
 """Maps provider name → ``(extractor_fn, *extra_args)``."""
 

--- a/tests/unit/test_credential_extractors.py
+++ b/tests/unit/test_credential_extractors.py
@@ -409,6 +409,12 @@ class TestExtractCredential:
         with pytest.raises(ValueError, match="No credential extractor"):
             extract_credential("unknown-agent", tmp_path)
 
+    def test_dispatches_to_openrouter(self, tmp_path: Path) -> None:
+        """extract_credential('openrouter', ...) reads config.json like its OpenCode siblings."""
+        (tmp_path / "config.json").write_text(json.dumps({"api_key": "sk-or-test"}))
+        result = extract_credential("openrouter", tmp_path)
+        assert result["key"] == "sk-or-test"
+
 
 class TestVendorFormatDrift:
     """Verify the Pydantic schema surfaces vendor-format drift clearly.


### PR DESCRIPTION
Follow-up flagged in #427, scoped after investigation: the default vault-routed path was never affected (API keys for blablador/kisski/openrouter all go straight to the credential DB via `store_api_key`). The gap was only in **exposed mode** — `_materialize_exposed_providers` builds `TEROK_PROVIDER_*` handles by reading the credential file through `EXTRACTORS`, where blablador/kisski have `config.json` entries and openrouter had none, so an exposed OpenRouter credential was silently skipped. One-line entry restores symmetry; dispatch test added (52/52 extractor tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)