### PR TITLE
feat(setup): expose --passphrase-tier and declare the setup invocation

### DIFF
--- a/src/terok_executor/cli.py
+++ b/src/terok_executor/cli.py
@@ -36,6 +36,13 @@ except PackageNotFoundError:
     __version__ = "0.0.0"
 
 
+#: Spelling under which sandbox setup is reachable in this front-end;
+#: declared at CLI entry so sandbox-composed re-run hints name a verb
+#: this CLI actually exposes (protocol: env var name, shared by string).
+_SETUP_INVOCATION_ENV = "TEROK_SETUP_INVOCATION"
+_SETUP_INVOCATION = "terok-executor setup"
+
+
 def main() -> None:
     """Run the terok-executor CLI.
 
@@ -44,6 +51,7 @@ def main() -> None:
     subparser convention, matching the placement used by ``docker`` and
     ``kubectl``.
     """
+    os.environ.setdefault(_SETUP_INVOCATION_ENV, _SETUP_INVOCATION)
     parser = argparse.ArgumentParser(
         prog="terok-executor",
         description="Single-agent task runner for hardened Podman containers",

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -619,6 +619,7 @@ def _handle_setup(
     no_images: bool = False,
     base: str = DEFAULT_BASE_IMAGE,
     family: str | None = None,
+    passphrase_tier: str | None = None,
     cfg: SandboxConfig | None = None,
 ) -> None:
     """Bootstrap the full terok-executor stack on a fresh host.
@@ -635,7 +636,7 @@ def _handle_setup(
     if not no_sandbox:
         from .sandbox import ensure_sandbox_ready
 
-        ensure_sandbox_ready(cfg=cfg)
+        ensure_sandbox_ready(cfg=cfg, passphrase_tier=passphrase_tier)
 
     if not no_images:
         _build_images_with_banner(base, family)
@@ -1067,6 +1068,15 @@ SETUP_COMMAND = CommandDef(
             name="--family",
             default=None,
             help="Override package family for unknown base images (deb or rpm)",
+        ),
+        ArgDef(
+            name="--passphrase-tier",
+            default=None,
+            help=(
+                "Force credentials-DB passphrase storage to a specific tier"
+                " (systemd-creds | keyring | session-file | config); required"
+                " on a non-TTY host without systemd-creds"
+            ),
         ),
     ),
 )

--- a/tests/unit/test_setup_flow.py
+++ b/tests/unit/test_setup_flow.py
@@ -62,7 +62,7 @@ class TestHandleSetup:
 
     def test_default_runs_sandbox_setup_then_image_build(self, setup_spies) -> None:
         _handle_setup()
-        setup_spies["sandbox_setup"].assert_called_once_with(cfg=None)
+        setup_spies["sandbox_setup"].assert_called_once_with(cfg=None, passphrase_tier=None)
         setup_spies["build_images"].assert_called_once()
 
     def test_no_sandbox_skips_sandbox_setup(self, setup_spies) -> None:


### PR DESCRIPTION
Companion to terok-ai/terok-sandbox#419 (user report: the first-run passphrase-tier error names a flag the invoked command didn't have). `terok-executor setup` gains `--passphrase-tier` (forwarded through `ensure_sandbox_ready`'s existing kwargs pass-through; sandbox fail-fast validates the value), and CLI entry declares `TEROK_SETUP_INVOCATION=terok-executor setup` so sandbox-composed hints name this front-end's own verb. Works with the currently pinned sandbox (the aggregator kwarg already exists); the hint spelling upgrade activates with the next sandbox release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)