### PR TITLE
fix(docs): re-lock mkdocs-terok 0.7.4 lost in the matrix-chain merge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -176,6 +176,6 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.7.3
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.7.4
     with:
       release: ${{ inputs.release == true }}

--- a/poetry.lock
+++ b/poetry.lock
@@ -2003,20 +2003,20 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.7.1"
+version = "0.7.4"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
 python-versions = "<4.0,>=3.12"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.7.1-py3-none-any.whl", hash = "sha256:71f51c8d2d241a808e527ede731983157e817864ab6065a7e74cf84021215e2e"},
-    {file = "mkdocs_terok-0.7.1.tar.gz", hash = "sha256:cdb5715dfa82395bcd61c005603091910924a7609178c6dca26eea814cdf6667"},
+    {file = "mkdocs_terok-0.7.4-py3-none-any.whl", hash = "sha256:5bf8624f49c2e7d7354d1ac92f91ce8d5a487e2c1d7bb022808ca31bac4c6d7f"},
+    {file = "mkdocs_terok-0.7.4.tar.gz", hash = "sha256:27b9bb0f7a09960083722bff8b2f9098be91c61824ac0ed22848fe94e553178d"},
 ]
 
 [package.dependencies]
-properdocs = ">=1.6.7"
-PyYAML = ">=6.0"
-squarify = ">=0.4"
+properdocs = ">=1.6.7,<1.7.0"
+PyYAML = ">=6.0,<7.0"
+squarify = "0.4.4"
 
 [[package]]
 name = "mkdocstrings"


### PR DESCRIPTION
## Problem

Master docs deploys have failed since #425 merged:

```
poetry run python -m mkdocs_terok.versions plan ...
.venv/bin/python: No module named mkdocs_terok.versions
```

The site builds; the publish job dies at the version-plan step.

## Cause

#424 locked mkdocs-terok 0.7.3. #425 then merged a `poetry.lock` regenerated from a pre-#424 base, silently downgrading mkdocs-terok back to 0.7.1 — which predates the `mkdocs_terok.versions` module (added in 0.7.2) that the reusable publish workflow invokes.

## Fix

- Re-lock mkdocs-terok at 0.7.4 (`poetry update mkdocs-terok --lock`); the `^0.7` range in pyproject already admits it. The remaining diff lines are mkdocs-terok's own tightened dependency constraints inside its lock block — the locked versions already satisfy them.
- Bump the reusable workflow ref `publish-versioned-docs.yml@v0.7.3` → `@v0.7.4` to match, picking up the root-assets assembler terok already deploys with (terok-ai/terok#1125).

Same regression pattern hit terok via terok-ai/terok#1118; fixed there in terok-ai/terok#1127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing workflow to use the latest supported version of the shared docs publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->