### PR TITLE
fix(container): clamp shared credential files to owner-only permissions

### DIFF
--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -488,11 +488,14 @@ def _clamp_credential_mode(host_file: Path) -> None:
 
     Opens with ``O_NOFOLLOW`` + ``fchmod`` so a symlink planted in the
     container-writable shared dir cannot redirect the chmod to an
-    arbitrary operator-owned file (CWE-59).
+    arbitrary operator-owned file (CWE-59).  The clamp is best-effort:
+    any open failure (missing file, planted symlink, permissions) leaves
+    the file as-is rather than aborting container assembly — a file we
+    cannot even open is not one the old ``touch()`` created loose.
     """
     try:
         fd = os.open(host_file, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
-    except FileNotFoundError:
+    except OSError:
         return
     try:
         st = os.fstat(fd)

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -23,6 +23,8 @@ Usage::
 from __future__ import annotations
 
 import logging
+import os
+import stat
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
@@ -438,6 +440,8 @@ def _shared_config_mounts(
     materialises the destination inside the container's userns as root
     with mode 0700, leaving the file unreadable to the agent (and breaking
     e.g. ``gh`` whose ``hosts.yml`` is normally absent on fresh installs).
+    Credential files are created — and pre-existing ones re-clamped —
+    owner-only, because glab aborts on a ``config.yml`` looser than 0600.
 
     Providers in *expose_credential_providers* keep the writable mount —
     used by terok's experimental ``expose_oauth_token`` mode where the
@@ -454,18 +458,48 @@ def _shared_config_mounts(
         host_dir.mkdir(parents=True, exist_ok=True)
         specs.append(VolumeSpec(host_dir, m.container_path))
 
-        if not m.credential_file or m.writable or m.provider in expose_credential_providers:
+        if not m.credential_file:
             continue
 
         host_file = host_dir / m.credential_file
+        _clamp_credential_mode(host_file)
+
+        if m.writable or m.provider in expose_credential_providers:
+            continue
+
         host_file.parent.mkdir(parents=True, exist_ok=True)
         if not host_file.exists():
-            host_file.touch()
+            host_file.touch(mode=0o600)
 
         container_file = f"{m.container_path}/{m.credential_file}"
         specs.append(VolumeSpec(host_file, container_file, read_only=True))
 
     return specs
+
+
+def _clamp_credential_mode(host_file: Path) -> None:
+    """Strip group/other permission bits from an existing credential file.
+
+    Releases up to 0.2.x ``touch()``-ed credential files with the umask
+    default (0644), and those files persist in the shared mounts across
+    upgrades.  glab refuses to start when its ``config.yml`` is looser
+    than 0600, so every launch re-clamps to owner-only — idempotent, and
+    never *adds* bits (a deliberately read-only 0400 file stays 0400).
+
+    Opens with ``O_NOFOLLOW`` + ``fchmod`` so a symlink planted in the
+    container-writable shared dir cannot redirect the chmod to an
+    arbitrary operator-owned file (CWE-59).
+    """
+    try:
+        fd = os.open(host_file, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    except FileNotFoundError:
+        return
+    try:
+        st = os.fstat(fd)
+        if stat.S_ISREG(st.st_mode) and stat.S_IMODE(st.st_mode) & 0o077:
+            os.fchmod(fd, stat.S_IMODE(st.st_mode) & ~0o077)
+    finally:
+        os.close(fd)
 
 
 def _set_provider_handle(

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import dataclasses
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1243,6 +1244,40 @@ class TestSharedConfigMountsUnit:
         )
         cred = [m for m in mounts if m.container_path == "/home/dev/.claude/.credentials.json"]
         assert cred == []
+
+    def test_credential_file_created_owner_only(self, roster, tmp_path):
+        """A freshly touched credential file must be 0600 — glab aborts on looser."""
+        _shared_config_mounts(roster, tmp_path)
+        cred = tmp_path / "_claude-config" / ".credentials.json"
+        assert stat.S_IMODE(cred.stat().st_mode) == 0o600
+
+    def test_existing_loose_credential_file_reclamped(self, roster, tmp_path):
+        """A 0644 credential file left behind by an older release is healed to 0600.
+
+        Releases up to 0.2.x touched credential files with the umask default;
+        the stale file persists in the shared mount across upgrades and makes
+        glab refuse to start.  Content must survive the re-clamp.
+        """
+        host_cred = tmp_path / "_glab-config" / "config.yml"
+        host_cred.parent.mkdir(parents=True)
+        host_cred.write_text("hosts:\n  gitlab.com:\n    token: t\n")
+        host_cred.chmod(0o644)
+
+        _shared_config_mounts(roster, tmp_path)
+
+        assert stat.S_IMODE(host_cred.stat().st_mode) == 0o600
+        assert "gitlab.com" in host_cred.read_text()
+
+    def test_stricter_credential_file_left_alone(self, roster, tmp_path):
+        """Re-clamping only strips group/other bits — a 0400 file stays 0400."""
+        host_cred = tmp_path / "_glab-config" / "config.yml"
+        host_cred.parent.mkdir(parents=True)
+        host_cred.write_text("hosts: {}\n")
+        host_cred.chmod(0o400)
+
+        _shared_config_mounts(roster, tmp_path)
+
+        assert stat.S_IMODE(host_cred.stat().st_mode) == 0o400
 
     def test_writable_credential_file_skips_ro_shadow(self, roster, tmp_path):
         """A ``credential_file_writable`` provider (glab) gets no ro shadow.


### PR DESCRIPTION
## Problem

On hosts that used `glab` before #412, every task container now fails to start `glab`:

```
failed to read configuration:  /home/dev/.config/glab-cli/config.yml has the permissions 644, but glab requires 600.
```

Root cause: releases up to 0.2.x `touch()`-ed the credential shadow file with the umask default (0644) in `_shared_config_mounts`. Since #412 glab's mount is writable and the touch is skipped, but the stale 0644 `config.yml` persists in the `_glab-config` shared mount across upgrades — and recent glab releases refuse any `config.yml` looser than 0600. One `chmod` inside any container "fixes" all of them because it is a single shared host file.

## Fix

- Freshly touched credential files are created with mode 0600.
- Every launch re-clamps pre-existing credential files to owner-only, healing upgraded hosts on the next task start. The clamp only strips group/other bits (a deliberate 0400 stays 0400) and uses `O_NOFOLLOW` + `fchmod` so a symlink planted in the container-writable shared dir cannot redirect the chmod (CWE-59).

## Tests

- new: created credential file is 0600
- new: stale 0644 `config.yml` is re-clamped to 0600 with content preserved
- new: stricter 0400 file left untouched
- `make check` green locally except pre-existing podman-dependent failures (`test_auth_capture`, `test_preflight`) that run on the test machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for container credential files by enforcing owner-only permissions.
  * Existing credential files with overly broad permissions are now tightened without changing their contents.
  * Missing credential files are created with secure permissions by default.
  * Symlink-aware handling helps prevent unintended permission changes to other files.
* **Tests**
  * Added coverage for newly created, existing, and already restricted credential files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->