### PR TITLE
fix(cli): list command reports a failed runtime query instead of "No containers."

### DIFF
--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -505,6 +505,8 @@ def _handle_list() -> None:
 
     runtime = PodmanRuntime()
     states = runtime.container_states("terok-executor")
+    if states is None:
+        raise SystemExit("Container runtime unavailable — cannot query container states.")
     run_root = container_state_root()
     named = (p.name for p in run_root.iterdir() if p.is_dir()) if run_root.is_dir() else ()
     for name in named:

--- a/tests/unit/test_handlers.py
+++ b/tests/unit/test_handlers.py
@@ -258,3 +258,11 @@ def test_handle_list_skips_state_dirs_without_containers(
         runtime.container.return_value.state = None
         _handle_list()
     assert "No containers." in capsys.readouterr().out
+
+
+def test_handle_list_reports_runtime_query_failure() -> None:
+    """A failed batch query (``None``) exits with a message, not "No containers."."""
+    with mock.patch("terok_executor.integrations.sandbox.PodmanRuntime") as runtime_cls:
+        runtime_cls.return_value.container_states.return_value = None
+        with pytest.raises(SystemExit, match="runtime unavailable"):
+            _handle_list()


### PR DESCRIPTION
## What

`_handle_list` (the `list` CLI verb) now exits with *"Container runtime unavailable — cannot query container states."* when the batch state query fails, instead of treating the failure as an empty container set.

## Why

Middle link of the terok-ai/terok#1134 chain: terok-sandbox#428 changes `PodmanRuntime.container_states()` to return `None` when `podman ps` itself fails (podman missing, or erroring on storage-lock contention with a concurrent build), so failure is distinguishable from "no containers". This is the only `container_states` call site in terok-executor; without this guard it would crash on `None` — and before the chain, it printed a misleading "No containers." whenever podman was merely busy.

Compatible with both sandbox behaviours (pre-#428 `{}` and post-#428 `None`), so no pin change is needed and merge order relative to sandbox#428 doesn't matter.

## Chain

- terok-sandbox#428 — `container_states` signals query failure as `None`
- **this PR** (terok-executor)
- terok: TUI keeps last-known states on a failed poll

## Testing

- New unit test: `container_states() is None` → `SystemExit` with the message; existing empty-dict test still asserts "No containers.".
- Unit suite: 1081 passed; the 10 failures are env-only (`terok_shield`/`nft` missing on this box) and fail identically on unmodified master.
- ruff and docstr-coverage (98.1%) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)