### PR TITLE
chore(dev): add make test-fast and steer agents to it during development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,17 @@
 
 ## Verification
 
+**During development, ALWAYS iterate with `make test-fast`** — it runs
+only the tests affected by your branch diff (tach impact analysis, no
+coverage) and is far cheaper than the full suite.  Running the full
+suite after every edit is the single biggest time sink in agent dev
+loops; don't do it.  Run the full `make test` exactly once, right
+before committing.  One exception: impact analysis follows the Python
+import graph only, so after changing non-Python inputs (`resources/`
+YAML rosters, jinja templates, shell scripts) `make test-fast` skips
+tests that are actually affected — run the full `make test` for those
+changes.
+
 Run `make check` before declaring work done — it covers lint, unit
 tests, module boundaries (tach), security, docstring coverage, dead
 code, and SPDX compliance.  Skip tests that need podman or docker;

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint format test test-unit ruff-report bandit-report sonar-inputs tach lint-imports security docstrings complexity deadcode reuse typecheck check install install-dev docs docs-build clean spdx
+.PHONY: all lint format test test-unit test-fast ruff-report bandit-report sonar-inputs tach lint-imports security docstrings complexity deadcode reuse typecheck check install install-dev docs docs-build clean spdx
 
 REPORTS_DIR ?= reports
 COVERAGE_XML ?= $(REPORTS_DIR)/coverage.xml
@@ -23,6 +23,13 @@ lint:
 format:
 	poetry run ruff check --fix .
 	poetry run ruff format .
+
+# Fast dev loop: run only the tests affected by the branch diff (tach
+# impact analysis), no coverage.  Impact analysis follows the Python
+# import graph only — after touching non-Python inputs (resources/,
+# YAML, templates, scripts) run the full `make test` instead.
+test-fast:
+	poetry run pytest tests/unit/ --tach
 
 # Run tests with coverage
 test-unit:


### PR DESCRIPTION
Adds a `make test-fast` target that runs only the tests affected by the branch diff (tach impact analysis, `pytest --tach`, no coverage/junit reports), and updates AGENTS.md to explicitly instruct agents to iterate with it — reserving the full `make test` for the single pre-commit run.

Rationale: agents rerunning the full coverage suite after every edit is the biggest recurring inefficiency in our dev loops. On a branch with no Python changes, `test-fast` deselects all 1090 tests in ~1.3s vs ~21s for the full run.

Caveat documented in both the Makefile comment and AGENTS.md: tach impact analysis follows the Python import graph only, so changes to non-Python inputs (`resources/` rosters, jinja templates, shell scripts) must still run the full suite. CI keeps running everything unmasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)