### PR TITLE
ci: lint-imports rides the fleet battery; refs on the a3 tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,29 +17,6 @@ permissions:
 
 jobs:
   checks:
-    uses: terok-ai/terok-util/.github/workflows/fleet-checks.yml@v0.3.0a2
-
-  lint-imports:
-    if: github.repository == 'terok-ai/terok-executor'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: true
-
-      - name: Install project
-        run: uv sync --locked
-
-      - name: Check cross-package import boundaries
-        run: uv run --no-sync lint-imports
+    uses: terok-ai/terok-util/.github/workflows/fleet-checks.yml@v0.3.0a3
+    with:
+      run-lint-imports: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
     permissions:
       contents: read
       actions: read
-    uses: terok-ai/mkdocs-terok/.github/workflows/docs-build.yml@v0.8.0a2
+    uses: terok-ai/mkdocs-terok/.github/workflows/docs-build.yml@v0.8.0a3
     with:
       release: ${{ inputs.release == true }}
 
@@ -68,6 +68,6 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.8.0a2
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.8.0a3
     with:
       release: ${{ inputs.release == true }}

--- a/.github/workflows/inventory.yml
+++ b/.github/workflows/inventory.yml
@@ -24,6 +24,6 @@ permissions:
 jobs:
   publish:
     if: github.repository == 'terok-ai/terok-executor' && github.ref == 'refs/heads/master'
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-inventory.yml@v0.8.0a2
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-inventory.yml@v0.8.0a3
     secrets:
       INVENTORY_WRITE_TOKEN: ${{ secrets.INVENTORY_WRITE_TOKEN }}

--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -13,4 +13,4 @@ jobs:
   # the package family); this caller keeps the local triggers and the
   # release.yml gate wiring.
   scan:
-    uses: terok-ai/terok-util/.github/workflows/no-git-deps.yml@v0.3.0a2
+    uses: terok-ai/terok-util/.github/workflows/no-git-deps.yml@v0.3.0a3


### PR DESCRIPTION
Follow-up to terok-ai/terok-util#49: the local `lint-imports` job moves into `fleet-checks.yml@v0.3.0a3` behind `run-lint-imports: true`; all fleet refs bump to the current tags (docs-build `@v0.8.0a3` carries the `--no-sync` properdocs fix from terok-ai/mkdocs-terok#109).

🤖 Generated with [Claude Code](https://claude.com/claude-code)