### PR TITLE
ci: release build rides the fleet reusables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   checks:
-    uses: terok-ai/terok-util/.github/workflows/fleet-checks.yml@v0.3.0a4
+    uses: terok-ai/terok-util/.github/workflows/fleet-checks.yml@v0.3.0a5
     with:
       run-lint-imports: true

--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -13,4 +13,4 @@ jobs:
   # the package family); this caller keeps the local triggers and the
   # release.yml gate wiring.
   scan:
-    uses: terok-ai/terok-util/.github/workflows/no-git-deps.yml@v0.3.0a4
+    uses: terok-ai/terok-util/.github/workflows/no-git-deps.yml@v0.3.0a5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,30 +27,13 @@ jobs:
     permissions:
       contents: read
 
+  # The build job is the fleet-wide reusable hosted in terok-util
+  # (fleet-release-build.yml), pinned by that repo's release tag.
   build:
     needs: no-git-deps
-    runs-on: ubuntu-latest
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0    # hatch-vcs needs full history
-
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-
-      - name: Build distributions
-        run: uv build
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: dist
-          path: dist/
-          retention-days: 90    # cover any realistic re-run window
+    uses: terok-ai/terok-util/.github/workflows/fleet-release-build.yml@v0.3.0a5
 
   github-release:
     needs: build

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   sonar:
-    uses: terok-ai/terok-util/.github/workflows/fleet-sonar.yml@v0.3.0a4
+    uses: terok-ai/terok-util/.github/workflows/fleet-sonar.yml@v0.3.0a5
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   sonar:
-    uses: terok-ai/terok-util/.github/workflows/fleet-sonar-pr.yml@v0.3.0a4
+    uses: terok-ai/terok-util/.github/workflows/fleet-sonar-pr.yml@v0.3.0a5
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Final consumer sweep for terok-ai/terok-util#51: the inline release build job becomes a thin caller of the reusable `fleet-release-build.yml`, and every terok-util workflow ref is bumped to `v0.3.0a5`. terok-executor has no container matrix, so unlike its siblings it gains no `fleet-test-matrix.yml` shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)