### PR TITLE
test: deep-reach integration suite + multi-distro test matrix

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-distro integration test matrix on the self-hosted runner.
+# Thin caller: the jobs live in terok-util's reusable
+# fleet-test-matrix.yml; the slot list is derived from this repo's
+# tests/containers/matrix.yml via `terok-matrix --slots-json`.
+name: Test Matrix
+
+on:
+  workflow_dispatch:
+    inputs:
+      slots:
+        description: Space-separated slot subset (default = all declared)
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    uses: terok-ai/terok-util/.github/workflows/fleet-test-matrix.yml@v0.3.0a7
+    with:
+      slots: ${{ inputs.slots }}

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: all lint format test test-unit test-fast ruff-report bandit-report sonar-inputs tach lint-imports security docstrings complexity deadcode reuse typecheck check install install-dev docs docs-build clean spdx
+.PHONY: all lint format test test-unit test-fast test-integration test-matrix ruff-report bandit-report sonar-inputs tach lint-imports security docstrings complexity deadcode reuse typecheck check install install-dev docs docs-build clean spdx
 
 REPORTS_DIR ?= reports
 COVERAGE_XML ?= $(REPORTS_DIR)/coverage.xml
 COVERAGE_JSON ?= $(REPORTS_DIR)/coverage.json
 UNIT_JUNIT_XML ?= $(REPORTS_DIR)/unit.junit.xml
+INTEGRATION_JUNIT_XML ?= $(REPORTS_DIR)/integration.junit.xml
 RUFF_REPORT ?= $(REPORTS_DIR)/ruff-report.json
 BANDIT_REPORT ?= $(REPORTS_DIR)/bandit-report.json
 
@@ -35,6 +36,34 @@ test-fast:
 test-unit:
 	mkdir -p $(REPORTS_DIR)
 	uv run pytest tests/unit/ --cov=terok_executor --cov-report=term-missing --cov-report=xml:$(COVERAGE_XML) --cov-report=json:$(COVERAGE_JSON) --junitxml=$(UNIT_JUNIT_XML) -o junit_family=legacy
+
+# Podman-backed integration tests.  Skips cleanly where podman or the
+# shield hooks are absent; the matrix is where they really run.
+test-integration:
+	mkdir -p $(REPORTS_DIR)
+	uv run pytest tests/integration/ -v --junitxml=$(INTEGRATION_JUNIT_XML) -o junit_family=legacy
+
+# Multi-distro integration test matrix — slots declared in
+# tests/containers/matrix.yml, engine provided by terok-util (terok-matrix).
+# Options (env vars):
+#   NO_CACHE=1    Rebuild images from scratch (ignore layer cache)
+#   BUILD_ONLY=1  Build images without running tests
+#   SCOPE=unit    Run only unit tests (or: integ)
+#   SLOTS="fedora43 debian13"  Run specific slots only
+#   JOBS=4        Run up to N slots concurrently (live output, [slot]-tagged lines)
+# `make -j 4 test-matrix` works too: GNU make >= 4.3 exposes -jN in MAKEFLAGS,
+# and JOBS defaults to it.  An explicit JOBS= always wins; bare -j (unlimited)
+# carries no number and falls back to serial.
+MAKE_JOBS = $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS)))
+JOBS ?= $(MAKE_JOBS)
+test-matrix:
+	uv run terok-matrix \
+		$(if $(NO_CACHE),--no-cache) \
+		$(if $(BUILD_ONLY),--build-only) \
+		$(if $(filter unit,$(SCOPE)),--unit-only) \
+		$(if $(filter integ,$(SCOPE)),--integ-only) \
+		$(if $(JOBS),--jobs $(JOBS)) \
+		$(SLOTS)
 
 # Write Ruff's JSON report without failing on findings.
 ruff-report:

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -56,3 +56,50 @@ CONTAINER_CLAUDE_MEMORY_OVERRIDE = "/home/dev/.claude/projects/${PROJECT_ID}-wor
 
 WORKSPACE_ROOT = Path("/workspace")
 """Canonical workspace root referenced in bundled instructions assertions."""
+
+# ── Integration tests: real podman containers ────────────────────────────────
+# Only the podman-backed suite under tests/integration/ reads these.  They
+# name the one image, the one container-name prefix, and the file modes the
+# credential contract is stated in — the suite hard-codes nothing itself.
+
+PODMAN_BASE_IMAGE = "docker.io/library/alpine:latest"
+"""Tiny base image the container tests launch.
+
+Alpine carries busybox ``stat``/``printenv``/``sleep``, which is the whole
+in-container vocabulary the suite needs.  Pulled once per session by the
+``podman_image`` fixture; every launch afterwards finds it locally."""
+
+PODMAN_CONTAINER_PREFIX = "terok-executor-itest"
+"""Prefix of every container the suite creates.
+
+Names are suffixed with a random token per test and removed in a ``finally``
+— an interrupted run leaves at most one identifiable stray, and the prefix
+makes it greppable in ``podman ps -a``."""
+
+CONTAINER_KEEPALIVE_COMMAND = ("sleep", "300")
+"""Entry command that keeps a test container up long enough to exec into."""
+
+CREDENTIAL_FILE_MODE = 0o600
+"""The mode every credential file executor places must land in.
+
+Owner-only, host-side *and* as seen from inside the container: glab aborts
+when its ``config.yml`` is looser than this (the 0644 bug class)."""
+
+LOOSE_FILE_MODE = 0o644
+"""World-readable mode a pre-0.3 launch left behind — the clamp's input."""
+
+PERMISSIVE_UMASK = 0o000
+"""Umask the credential-mode test runs under.
+
+A ``touch()`` without an explicit mode inherits the umask, so a 0022 umask
+masks the bug: only an all-permissive umask falsifies the claim that the
+0600 comes from executor rather than from the process environment."""
+
+INTEGRATION_VAULT_PASSPHRASE = "integration-test-passphrase"  # nosec: B105 — fixture key
+"""Passphrase for the throwaway SQLCipher vault each integration test seeds."""
+
+PODMAN_COMMAND_TIMEOUT = 60
+"""Seconds any single podman invocation in the suite may take."""
+
+PODMAN_PULL_TIMEOUT = 300
+"""Seconds the once-per-session base-image pull may take."""

--- a/tests/containers/matrix.yml
+++ b/tests/containers/matrix.yml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+#
+# Multi-distro test matrix for terok-executor — declarative input to the
+# shared engine in terok-util.  Run with `uv run terok-matrix` from the
+# repo root (or `make test-matrix`).
+#
+# Executor's integration suite launches real containers through the same
+# Sandbox.run() path a task launch uses, so every slot needs the podman +
+# shield egress stack (nft, dnsmasq) and the OCI hooks installed by the
+# first phase — Sandbox refuses to start a container it cannot shield.
+# The nested rootless-podman image family provides all of it as-is; no
+# fragments/ overlay is needed.  There is no nix slot: executor without
+# podman has nothing to test.
+
+image-prefix: terok-executor-test
+flavor: podman
+expect: [podman, nft, dnsmasq, internet]
+groups: [test]
+
+slots:
+  debian12:
+  ubuntu2404:
+  ubuntu2604:
+  debian13:
+  fedora43:
+  fedora44:
+  podman:
+    extra-packages: [slirp4netns]
+  alpine:
+  void:
+  mageia:
+
+phases:
+  - name: installing shield hooks
+    run:
+      - terok-shield setup
+    expect-add: [hooks]
+  - name: unit tests
+    scope: unit
+    pytest: tests/unit/ -v --tb=short --durations=25
+  - name: integration tests
+    scope: integ
+    pytest: tests/integration/ -v --tb=short --durations=25

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Podman-backed integration tests for terok-executor."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixtures and skip guards for the podman-backed integration suite.
+
+These tests exist for the claims a mock cannot falsify: the file modes a
+real kernel and a real podman uid mapping produce, the env a real
+``podman run`` actually delivers, and the run/exec/stop lifecycle across
+the podman version spread (4.3 → 5.8) the matrix covers.  Everything that
+can be asserted without a container already lives in ``tests/unit``, and
+nothing here mirrors it.
+
+Environment requirements are expressed as markers, not directory layout:
+
+- ``needs_podman``: podman on the host, plus shield's OCI hooks — every
+  container executor launches goes through
+  [`Sandbox.run`][terok_sandbox.Sandbox], which refuses to start a
+  container it cannot shield.
+
+**Isolation.**  ``HOME`` is deliberately *not* redirected (unlike the unit
+suite): podman's rootless image store lives under the real ``HOME``, and a
+tmp one would hide the image the session pulled.  Isolation is achieved the
+other way round — every path executor would resolve from the environment is
+passed in explicitly (``SandboxConfig(state_dir=…, vault_dir=…)``,
+``ContainerEnvSpec(envs_dir=…)``), all rooted in ``tmp_path``.  The single
+patched symbol is the ``SandboxConfig`` *class* seen by the env assembler,
+which constructs its own config from nothing; the object it hands back is a
+real config over real tmp directories, not a mock.
+"""
+
+from __future__ import annotations
+
+import shutil
+import socket
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from terok_util.matrix import binary_on_path, check_capability_contract
+
+from terok_executor.integrations.sandbox import RunSpec, Sandbox, SandboxConfig, VolumeSpec
+from terok_executor.roster import AgentRoster
+from tests.constants import (
+    CONTAINER_KEEPALIVE_COMMAND,
+    INTEGRATION_VAULT_PASSPHRASE,
+    PODMAN_BASE_IMAGE,
+    PODMAN_PULL_TIMEOUT,
+)
+
+from .helpers import podman, podman_rm, unique_container_name
+
+_INTERNET_PROBE_HOST = ("one.one.one.one", 443)
+"""Address the internet probe dials — the base-image pull needs egress."""
+
+
+# ── Host capability probes ────────────────────────────────────────────
+
+
+def _has(binary: str) -> bool:
+    """Return whether *binary* is on ``PATH``."""
+    return shutil.which(binary) is not None
+
+
+def _hooks_available() -> bool:
+    """Return whether shield's global OCI hooks are installed.
+
+    Imported lazily and defensively: shield is a transitive dependency, and
+    a host without it should skip rather than error at collection.
+    """
+    try:
+        from terok_shield.podman_info import has_global_hooks
+    except ImportError:  # pragma: no cover — shield always ships with sandbox
+        return False
+    try:
+        return bool(has_global_hooks())
+    except Exception:  # pragma: no cover — defensive; a probe never fails a run
+        return False
+
+
+def _internet_reachable() -> bool:
+    """Return whether the host can open an outbound TCP connection."""
+    try:
+        with socket.create_connection(_INTERNET_PROBE_HOST, timeout=5):
+            return True
+    except OSError:
+        return False
+
+
+# ── Skip guards (dev machines) ────────────────────────────────────────
+# On a developer laptop a missing binary is a host limitation, so the
+# suite skips.  Inside the matrix the image was built to a contract, and
+# the same absence is a failure — see the contract check below.
+
+podman_missing = pytest.mark.skipif(not _has("podman"), reason="podman not installed")
+hooks_missing = pytest.mark.skipif(
+    not _hooks_available(), reason="shield OCI hooks not installed (run `terok-shield setup`)"
+)
+
+
+# ── Matrix capability contract ────────────────────────────────────────
+
+
+_CAPABILITY_PROBES = {
+    "podman": lambda: _has("podman"),
+    "nft": lambda: binary_on_path("nft"),
+    "dnsmasq": lambda: binary_on_path("dnsmasq"),
+    "hooks": _hooks_available,
+    "internet": _internet_reachable,
+}
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Fail the session up front when the matrix capability contract is broken.
+
+    Without this, a slot whose image lost ``nft`` would dissolve into a page
+    of skips and read as green.
+    """
+    if broken := check_capability_contract(_CAPABILITY_PROBES):
+        pytest.exit(broken, returncode=3)
+
+
+# ── The container base image ──────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def podman_image() -> str:
+    """Ensure the base image is in the local store; return its reference.
+
+    Pulled at most once per session.  Container launches afterwards resolve
+    it locally, so no test is at the mercy of a registry.
+    """
+    if not _has("podman"):
+        pytest.skip("podman not installed")
+    if podman("image", "exists", PODMAN_BASE_IMAGE).returncode == 0:
+        return PODMAN_BASE_IMAGE
+    proc = podman("pull", PODMAN_BASE_IMAGE, timeout=PODMAN_PULL_TIMEOUT)
+    if proc.returncode != 0:
+        pytest.skip(f"cannot pull {PODMAN_BASE_IMAGE}: {proc.stderr.strip()}")
+    return PODMAN_BASE_IMAGE
+
+
+# ── Isolated executor environment ─────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ExecutorEnv:
+    """The tmp-rooted state an executor launch reads and writes."""
+
+    cfg: SandboxConfig
+    """Real sandbox config — real vault DB, real ports, tmp directories."""
+
+    mounts_dir: Path
+    """Base for the shared credential mounts (``ContainerEnvSpec.envs_dir``)."""
+
+    task_dir: Path
+    """Per-task state dir; shield writes its dossier here on ``pre_start``."""
+
+    def sandbox(self) -> Sandbox:
+        """Return a Sandbox bound to this config — the launcher executor uses."""
+        return Sandbox(config=self.cfg)
+
+
+@pytest.fixture
+def executor_env(tmp_path: Path) -> Iterator[ExecutorEnv]:
+    """Yield a fully tmp-rooted [`ExecutorEnv`][tests.integration.conftest.ExecutorEnv].
+
+    The vault DB is a real SQLCipher file opened with a throwaway passphrase
+    (the operator's own passphrase chain is never consulted, and their vault
+    is never opened).  ``SandboxConfig`` is patched only where the env
+    assembler constructs one implicitly — see the module docstring.
+    """
+    env = ExecutorEnv(
+        cfg=SandboxConfig(
+            state_dir=tmp_path / "state",
+            vault_dir=tmp_path / "vault",
+            config_dir=tmp_path / "config",
+            credentials_passphrase=INTEGRATION_VAULT_PASSPHRASE,
+        ),
+        mounts_dir=tmp_path / "mounts",
+        task_dir=tmp_path / "task",
+    )
+    env.mounts_dir.mkdir(parents=True, exist_ok=True)
+    env.task_dir.mkdir(parents=True, exist_ok=True)
+    env.cfg.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with patch("terok_executor.integrations.sandbox.SandboxConfig", return_value=env.cfg):
+        yield env
+
+
+@pytest.fixture
+def roster() -> AgentRoster:
+    """Return the live agent roster loaded from the bundled YAML."""
+    return AgentRoster.shared()
+
+
+# ── Launching containers ──────────────────────────────────────────────
+
+
+type Launcher = Callable[..., str]
+"""``launch(slug, env=…, volumes=…) -> container_name``."""
+
+
+@pytest.fixture
+def launch(executor_env: ExecutorEnv, podman_image: str) -> Iterator[Launcher]:
+    """Yield a launcher that starts containers exactly as executor does.
+
+    Launches go through [`Sandbox.run`][terok_sandbox.Sandbox] — the same
+    ``podman run`` assembly ``AgentRunner.launch_prepared`` performs, shield
+    args and all — with the keepalive command in place of an agent, so what
+    the matrix exercises is executor's launch path rather than a hand-rolled
+    podman command line.
+
+    Every container is named before it is created and force-removed in the
+    ``finally``, so an assertion failure (or a podman that half-created it)
+    still leaves the host clean.
+    """
+    started: list[str] = []
+
+    def _launch(
+        slug: str,
+        *,
+        env: dict[str, str] | None = None,
+        volumes: tuple[VolumeSpec, ...] = (),
+    ) -> str:
+        name = unique_container_name(slug)
+        started.append(name)
+        executor_env.sandbox().run(
+            RunSpec(
+                container_name=name,
+                image=podman_image,
+                env=dict(env or {}),
+                volumes=volumes,
+                command=CONTAINER_KEEPALIVE_COMMAND,
+                task_dir=executor_env.task_dir,
+            )
+        )
+        return name
+
+    try:
+        yield _launch
+    finally:
+        for name in started:
+            podman_rm(name)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Podman helpers shared by the integration suite.
+
+Every function here shells out to the real ``podman`` binary.  Two rules
+hold throughout, and callers must not break them:
+
+- **Scoped mutation.**  The only operator state a test may touch is one
+  container named ``terok-executor-itest-<slug>-<token>``, created and
+  removed by the test itself.  Nothing else on the host is written.
+- **No registry traffic at launch time.**  The base image is pulled once
+  per session by the ``podman_image`` fixture; container launches find it
+  in the local store and never reach out.
+"""
+
+from __future__ import annotations
+
+import subprocess  # nosec B404 — driving the real podman CLI is the point
+import uuid
+
+from tests.constants import PODMAN_COMMAND_TIMEOUT, PODMAN_CONTAINER_PREFIX
+
+
+def unique_container_name(slug: str) -> str:
+    """Return a collision-free container name for the test called *slug*."""
+    return f"{PODMAN_CONTAINER_PREFIX}-{slug}-{uuid.uuid4().hex[:8]}"
+
+
+def podman(*args: str, timeout: int = PODMAN_COMMAND_TIMEOUT) -> subprocess.CompletedProcess[str]:
+    """Run ``podman *args`` and return the completed process (never raises on exit code)."""
+    return subprocess.run(  # nosec B603 B607 — fixed binary, test-controlled args
+        ["podman", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def podman_checked(*args: str, timeout: int = PODMAN_COMMAND_TIMEOUT) -> str:
+    """Run ``podman *args``, assert it succeeded, and return its stdout.
+
+    Failures surface podman's own stderr — a bare ``CalledProcessError`` in a
+    matrix log tells you nothing about *which* podman disagreed.
+    """
+    proc = podman(*args, timeout=timeout)
+    if proc.returncode != 0:
+        raise AssertionError(f"podman {' '.join(args)} failed ({proc.returncode}): {proc.stderr}")
+    return proc.stdout
+
+
+def podman_rm(name: str) -> None:
+    """Force-remove container *name*, tolerating its absence.
+
+    Called from the ``finally`` of every launching test, so it must never
+    raise: a cleanup failure would mask the real assertion error.
+    """
+    try:
+        podman("rm", "-f", "-t", "0", name)
+    except (subprocess.TimeoutExpired, OSError):  # pragma: no cover — cleanup fallback
+        pass
+
+
+def container_exists(name: str) -> bool:
+    """Return whether podman still knows a container called *name*."""
+    return podman("container", "exists", name).returncode == 0
+
+
+def container_state(name: str) -> str:
+    """Return the podman lifecycle state of *name* (``running``, ``exited``, …)."""
+    return podman_checked("inspect", "-f", "{{.State.Status}}", name).strip()
+
+
+def exec_in(name: str, *command: str) -> str:
+    """Exec *command* inside running container *name* and return its stdout."""
+    return podman_checked("exec", name, *command)
+
+
+def file_mode_in(name: str, container_path: str) -> int:
+    """Return the permission bits of *container_path* as seen from inside *name*.
+
+    Reading the mode through the container — rather than off the host — is
+    the whole point: it is the view the agent's tooling gets after podman's
+    uid mapping and mount handling have had their say.
+    """
+    return int(exec_in(name, "stat", "-c", "%a", container_path).strip(), 8)

--- a/tests/integration/test_container_lifecycle.py
+++ b/tests/integration/test_container_lifecycle.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Executor can run a container, exec into it, and stop and remove it.
+
+The assertions are deliberately unremarkable — a container that starts,
+answers an exec, stops on request, and leaves nothing behind.  Their value
+is not in what they claim but in *where they run*: the matrix replays this
+across the podman version spread (4.3 → 5.8) and the distro spread, which
+is where the launch path actually breaks — a userns flag podman 4.x spells
+differently, a stop that leaves the container in ``stopping``, a runtime
+default that changed under us.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import ExecutorEnv, Launcher, hooks_missing, podman_missing
+from .helpers import container_exists, container_state, exec_in
+
+pytestmark = [pytest.mark.needs_podman, podman_missing, hooks_missing]
+
+MARKER = "executor-lifecycle-ok"
+"""Payload echoed from inside the container — proof the exec really ran there."""
+
+
+def test_run_exec_stop_removes_every_trace(
+    executor_env: ExecutorEnv,
+    launch: Launcher,
+) -> None:
+    """A launched container is exec-able, stoppable, and removable."""
+    sandbox = executor_env.sandbox()
+
+    name = launch("lifecycle")
+    assert container_state(name) == "running"
+
+    assert exec_in(name, "echo", MARKER).strip() == MARKER
+
+    sandbox.stop([name])
+    assert container_state(name) == "exited"
+
+    sandbox.rm([name])
+    assert not container_exists(name)

--- a/tests/integration/test_credential_modes.py
+++ b/tests/integration/test_credential_modes.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Every credential file executor places must reach the agent as 0600.
+
+The claim under test is a *filesystem* claim, and only a real launch can
+falsify it.  Two failure modes have bitten this code:
+
+- a ``touch()`` without an explicit mode inherits the process umask, so on
+  a permissive umask the file lands 0644 — glab then refuses to start,
+  because it aborts on a ``config.yml`` looser than owner-only;
+- files written by an *older* executor persist in the shared mounts across
+  upgrades, so assembly must re-clamp what it finds, not just what it
+  creates.  The glab mount is writable (its config doubles as a settings
+  file), which means the clamp is the *only* thing standing between a
+  legacy 0644 file and the agent.
+
+A unit test can assert what ``os.stat`` says on the host.  It cannot say
+what the file looks like from inside the container, after podman's uid
+mapping and mount handling — which is the view glab actually gets.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from terok_executor.container.env import ContainerEnvSpec, assemble_container_env
+from terok_executor.roster import AgentRoster
+from tests.constants import CREDENTIAL_FILE_MODE, LOOSE_FILE_MODE, PERMISSIVE_UMASK
+
+from .conftest import ExecutorEnv, Launcher, hooks_missing, podman_missing
+from .helpers import file_mode_in
+
+pytestmark = [pytest.mark.needs_podman, podman_missing, hooks_missing]
+
+
+def _credential_mounts(roster: AgentRoster) -> list:
+    """Return every roster mount that carries a credential file."""
+    return [m for m in roster.mounts if m.credential_file]
+
+
+def _seed_legacy_loose_files(roster: AgentRoster, mounts_dir: Path) -> list[Path]:
+    """Pre-create every credential file world-readable, as a pre-0.3 launch left it.
+
+    This is the clamp's input.  It also puts a file where the writable
+    mounts (glab) would otherwise have none — assembly never creates those,
+    so without seeding, the one mount the 0644 bug was reported against
+    would not be under test at all.
+    """
+    seeded = []
+    for mount in _credential_mounts(roster):
+        host_file = mounts_dir / mount.host_dir / mount.credential_file
+        host_file.parent.mkdir(parents=True, exist_ok=True)
+        host_file.touch()
+        host_file.chmod(LOOSE_FILE_MODE)
+        seeded.append(host_file)
+    return seeded
+
+
+def test_credential_files_are_owner_only_in_the_container(
+    executor_env: ExecutorEnv,
+    roster: AgentRoster,
+    launch: Launcher,
+) -> None:
+    """Assembled credential files land 0600 on the host and inside the container."""
+    seeded = _seed_legacy_loose_files(roster, executor_env.mounts_dir)
+    assert seeded, "roster declares no credential files — the test would assert nothing"
+
+    spec = ContainerEnvSpec(
+        task_id="cred-modes",
+        agent_name="claude",
+        envs_dir=executor_env.mounts_dir,
+    )
+
+    # Assemble under an all-permissive umask: a mode that survives *this*
+    # came from executor, not from the environment it happened to run in.
+    previous_umask = os.umask(PERMISSIVE_UMASK)
+    try:
+        result = assemble_container_env(spec, roster)
+    finally:
+        os.umask(previous_umask)
+
+    for host_file in seeded:
+        mode = host_file.stat().st_mode & 0o777
+        assert mode == CREDENTIAL_FILE_MODE, f"{host_file} is {mode:o} on the host"
+
+    name = launch("cred-modes", env=result.env, volumes=result.volumes)
+
+    for mount in _credential_mounts(roster):
+        container_file = f"{mount.container_path}/{mount.credential_file}"
+        mode = file_mode_in(name, container_file)
+        assert mode == CREDENTIAL_FILE_MODE, (
+            f"{mount.provider}: {container_file} is {mode:o} inside the container"
+        )

--- a/tests/integration/test_vault_route_env.py
+++ b/tests/integration/test_vault_route_env.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""A configured provider's vault route must reach the container as env.
+
+One provider, one route: a credential stored for ``anthropic`` becomes a
+phantom token in the vault DB, the route names the env var that carries it
+(``ANTHROPIC_API_KEY``) and the var that points the SDK at the vault proxy
+(``ANTHROPIC_BASE_URL``), and ``podman run -e`` has to deliver both intact.
+
+What a mock cannot check, and this does:
+
+- the token in the container is the *phantom*, and the real secret never
+  crosses the boundary — asserted against the container's whole env, not
+  against the dict executor built;
+- the phantom resolves back through the real SQLCipher vault to exactly the
+  provider that was configured, so the route is wired to one credential and
+  not another.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from terok_executor.container.env import ContainerEnvSpec, assemble_container_env
+from terok_executor.roster import AgentRoster
+
+from .conftest import ExecutorEnv, Launcher, hooks_missing, podman_missing
+from .helpers import exec_in
+
+pytestmark = [pytest.mark.needs_podman, podman_missing, hooks_missing]
+
+PROVIDER = "anthropic"
+"""The provider under test — claude's default, and the roster's richest route."""
+
+REAL_SECRET = "sk-integration-not-for-the-container"  # nosec B105 — fixture, not a real key
+"""The credential stored in the vault.  It must never appear in a container."""
+
+CREDENTIAL_SCOPE = "integration-scope"
+CREDENTIAL_SET = "default"
+TASK_ID = "vault-route"
+
+
+def test_provider_credential_reaches_the_container_as_a_phantom_token(
+    executor_env: ExecutorEnv,
+    roster: AgentRoster,
+    launch: Launcher,
+) -> None:
+    """The anthropic route delivers a vault phantom token — never the secret."""
+    route = roster.vault_routes[PROVIDER]
+    token_var = route.token_env["_default"]
+
+    db = executor_env.cfg.open_credential_db()
+    try:
+        db.store_credential(CREDENTIAL_SET, PROVIDER, {"type": "api_key", "key": REAL_SECRET})
+    finally:
+        db.close()
+
+    spec = ContainerEnvSpec(
+        task_id=TASK_ID,
+        agent_name="claude",
+        envs_dir=executor_env.mounts_dir,
+        credential_scope=CREDENTIAL_SCOPE,
+        credential_set=CREDENTIAL_SET,
+        vault_required=True,
+    )
+    result = assemble_container_env(spec, roster, caller_manages_vault=False)
+
+    phantom = result.env[token_var]
+    assert phantom != REAL_SECRET
+
+    name = launch("vault-route", env=result.env, volumes=result.volumes)
+
+    assert exec_in(name, "printenv", token_var).strip() == phantom
+    assert exec_in(name, "printenv", route.base_url_env).strip(), "route left the SDK unpointed"
+
+    container_env = exec_in(name, "env")
+    assert REAL_SECRET not in container_env, "the real credential leaked into the container"
+
+    # The phantom the container holds resolves — through the real vault DB —
+    # to the one provider that was configured.  This is the route.
+    db = executor_env.cfg.open_credential_db()
+    try:
+        resolved = db.lookup_token(phantom)
+    finally:
+        db.close()
+
+    assert resolved is not None, "the container's token is unknown to the vault"
+    assert resolved["provider"] == PROVIDER
+    assert resolved["scope"] == CREDENTIAL_SCOPE
+    assert resolved["credential_set"] == CREDENTIAL_SET


### PR DESCRIPTION
Executor shipped only `tests/unit`.  This adds its first integration suite —
three tests, chosen because a real distro and a real podman can falsify them
and a mock cannot — plus the matrix config that runs them across the fleet.

## The three tests

**1. Credential file modes end-to-end** (`test_credential_modes.py`)
Assembles the container env the way `AgentRunner` does, launches it, and
asserts every credential file the roster declares is `0600` — on the host
*and* as seen from inside the container, after podman's uid mapping and mount
handling have had their say.  This is the glab-644 bug class: `touch()`
without an explicit mode inherits the umask, and glab aborts on a `config.yml`
looser than owner-only.  The test runs assembly under an all-permissive umask
(a mode that survives that came from executor, not from the environment) and
seeds the pre-0.3 world-readable files the clamp exists to fix — including on
glab's *writable* mount, where the clamp is the only thing standing between a
legacy 0644 file and the agent.

**2. Provider -> vault route wiring** (`test_vault_route_env.py`)
A credential stored for `anthropic` must reach the container through its one
route: `ANTHROPIC_API_KEY` carries the phantom, `ANTHROPIC_BASE_URL` points
the SDK at the proxy, and `podman run -e` has to deliver both intact.
Asserted against the container's whole env — the real secret never appears —
and the phantom is resolved back through the real SQLCipher vault to exactly
the provider that was configured.

**3. Run -> exec -> stop lifecycle** (`test_container_lifecycle.py`)
Deliberately unremarkable assertions; the value is *where* they run.  The
matrix replays them across the podman version spread (4.3 -> 5.8) and ten
distros, which is where the launch path actually breaks — a userns flag
podman 4.x spells differently, a stop that leaves the container `stopping`, a
runtime default that moved.

All three launch through `Sandbox.run()` — executor's own podman path, shield
args and all — rather than a hand-rolled command line.

## What is deliberately not here

No mirroring of unit coverage.  Anything assertable without a container stays
in `tests/unit` (1101 tests); nothing here duplicates it.  The suite is three
tests on purpose — the matrix is expensive, and it should only carry claims
that need it.

## Honesty and blast radius

- Skips cleanly (never errors) when podman or the shield OCI hooks are absent;
  inside the matrix the same absence is a contract violation and fails the
  session up front (`TEROK_EXPECT` / `check_capability_contract`), so a
  degraded image cannot read as green.
- `HOME` stays real — podman's rootless image store lives there — and
  isolation comes the other way round: every path executor would resolve from
  the environment is passed in explicitly, tmp-rooted (`SandboxConfig(state_dir=…,
  vault_dir=…)`, `ContainerEnvSpec(envs_dir=…)`).  The operator's vault is
  never opened; the suite seeds its own SQLCipher DB with a throwaway
  passphrase.
- Every container is uniquely named (`terok-executor-itest-<slug>-<token>`) and
  force-removed in a `finally`.  The base image (alpine) is pulled once per
  session, so launches never reach a registry.

## Matrix

`tests/containers/matrix.yml`: flavor `podman`, image-prefix
`terok-executor-test`, `expect: [podman, nft, dnsmasq, internet]`,
`groups: [test]`, the ten podman-flavor slots shield uses (no nix — executor
without podman has nothing to test), phases: install shield hooks (`expect-add:
[hooks]`) -> unit -> integration.  `.github/workflows/test-matrix.yml` is a
thin caller of `terok-util`'s `fleet-test-matrix.yml@v0.3.0a7`.  `make
test-integration` and `make test-matrix` (with the usual `JOBS`/`SLOTS`/`SCOPE`
plumbing) added.

Cost: roughly 5 minutes at `-j 4`.

Validated without running podman: `uv sync --locked && pytest tests/unit -q`
green (1101 passed); the integration tests collect cleanly and skip (3 skipped,
0 errors) both on a hookless host and with podman off `PATH`; `make lint`,
`make docstrings` (98.1%), `make reuse`, `make tach`, `make lint-imports` all
green; `matrix.yml` loads with the real terok-util engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)