### PR TITLE
fix(tests): integration launches mount the workspace

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -77,6 +77,12 @@ Names are suffixed with a random token per test and removed in a ``finally``
 makes it greppable in ``podman ps -a``."""
 
 CONTAINER_KEEPALIVE_COMMAND = ("sleep", "300")
+
+#: The sandbox hardcodes ``-w /workspace`` for every run, so a container
+#: without the workspace bind-mount cannot start at all ("workdir does not
+#: exist").  Production always mounts the task's workspace there; the
+#: integration launches must too.
+CONTAINER_WORKSPACE_DIR = "/workspace"
 """Entry command that keeps a test container up long enough to exec into."""
 
 CREDENTIAL_FILE_MODE = 0o600

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,6 +44,7 @@ from terok_executor.integrations.sandbox import RunSpec, Sandbox, SandboxConfig,
 from terok_executor.roster import AgentRoster
 from tests.constants import (
     CONTAINER_KEEPALIVE_COMMAND,
+    CONTAINER_WORKSPACE_DIR,
     INTEGRATION_VAULT_PASSPHRASE,
     PODMAN_BASE_IMAGE,
     PODMAN_PULL_TIMEOUT,
@@ -154,6 +155,10 @@ class ExecutorEnv:
     mounts_dir: Path
     """Base for the shared credential mounts (``ContainerEnvSpec.envs_dir``)."""
 
+    workspace_dir: Path
+    """Host side of the container's ``/workspace`` — the sandbox always runs
+    with that as the working directory, so every launch must mount it."""
+
     task_dir: Path
     """Per-task state dir; shield writes its dossier here on ``pre_start``."""
 
@@ -180,9 +185,11 @@ def executor_env(tmp_path: Path) -> Iterator[ExecutorEnv]:
         ),
         mounts_dir=tmp_path / "mounts",
         task_dir=tmp_path / "task",
+        workspace_dir=tmp_path / "workspace",
     )
     env.mounts_dir.mkdir(parents=True, exist_ok=True)
     env.task_dir.mkdir(parents=True, exist_ok=True)
+    env.workspace_dir.mkdir(parents=True, exist_ok=True)
     env.cfg.db_path.parent.mkdir(parents=True, exist_ok=True)
 
     with patch("terok_executor.integrations.sandbox.SandboxConfig", return_value=env.cfg):
@@ -226,12 +233,20 @@ def launch(executor_env: ExecutorEnv, podman_image: str) -> Iterator[Launcher]:
     ) -> str:
         name = unique_container_name(slug)
         started.append(name)
+        # The workspace mount is not optional: the sandbox runs every
+        # container with ``-w /workspace`` (as production does, where the
+        # task's workspace lives there), so podman refuses to start a
+        # container that lacks it.
+        workspace = VolumeSpec(
+            host_path=executor_env.workspace_dir,
+            container_path=CONTAINER_WORKSPACE_DIR,
+        )
         executor_env.sandbox().run(
             RunSpec(
                 container_name=name,
                 image=podman_image,
                 env=dict(env or {}),
-                volumes=volumes,
+                volumes=(workspace, *volumes),
                 command=CONTAINER_KEEPALIVE_COMMAND,
                 task_dir=executor_env.task_dir,
             )


### PR DESCRIPTION
First matrix run of the new suite (#453) failed on all ten slots with `Error: workdir "/workspace" does not exist on container`. The sandbox hardcodes `-w /workspace` for every run (`sandbox.py:551`) because production always bind-mounts the task's workspace there — the integration launches didn't, so podman refused to start the container.

The launch fixture now always mounts a tmp workspace at `/workspace`, which also makes the tests match how executor is genuinely used. Unit suite unchanged (1101 passed); integration collects and skips cleanly here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by ensuring every test container has the expected `/workspace` directory mounted.
  * Standardized workspace setup across test executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->