### PR TITLE
fix(acp): migrate to agent-client-protocol 0.11 (ACP schema 1.16)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "prompt-toolkit~=3.0",
     "pydantic~=2.13",
     "rich~=15.0",
-    "agent-client-protocol==0.10.1",
+    "agent-client-protocol==0.11.0",
 ]
 
 [project.urls]

--- a/src/terok_executor/acp/model_options.py
+++ b/src/terok_executor/acp/model_options.py
@@ -12,14 +12,20 @@ models:
   — the pre-bind ``session/new`` reply that advertises the union of
   every authenticated agent's models under one selector.
 - [`build_model_option`][terok_executor.acp.model_options.build_model_option]
-  — the ``configOptions[category=model]`` entry that mirrors the
-  aggregate selector for clients that read it instead of ``models``.
+  — the ``configOptions[category=model]`` entry carrying that aggregate
+  selector.  Since ACP 1.16 retired the dedicated ``models`` block, this
+  is the only channel on which models are advertised.
+- [`find_model_option`][terok_executor.acp.model_options.find_model_option]
+  — the mirror image: which of a *backend's* config options is its model
+  selector, so the probe can read its ids and the proxy can write a pick
+  into it.
 - [`namespace_model_options_in_place`][terok_executor.acp.model_options.namespace_model_options_in_place]
   — the post-bind rewrite that puts the ``agent:`` prefix back on the
   bare model ids a bound backend emits in its own config options.
 
 Plus the small vocabulary helpers ([`split_namespaced`][terok_executor.acp.model_options.split_namespaced],
-[`humanise_model_id`][terok_executor.acp.model_options.humanise_model_id])
+[`humanise_model_id`][terok_executor.acp.model_options.humanise_model_id],
+[`model_ids_in_option`][terok_executor.acp.model_options.model_ids_in_option])
 that callers across the proxy share.
 """
 
@@ -27,12 +33,10 @@ from __future__ import annotations
 
 from acp import NewSessionResponse
 from acp.schema import (
-    ModelInfo,
     SessionConfigOptionBoolean,
     SessionConfigOptionSelect,
     SessionConfigSelectGroup,
     SessionConfigSelectOption,
-    SessionModelState,
 )
 
 MODEL_OPTION_CATEGORY = "model"
@@ -53,22 +57,23 @@ OpenRouter-style ids like ``anthropic/claude-opus-4``."""
 def build_aggregated_session_new(session_id: str, models: list[str]) -> NewSessionResponse:
     """Build the pre-bind ``session/new`` reply for *models*.
 
-    Empty *models* yields a schema-valid response with no ``models`` or
-    ``configOptions`` block — both have non-nullable required fields the
-    proxy can't fill in for an empty list, and modelling "no models" as
-    an empty selector trips client validation.
+    ACP 1.16 retired the dedicated ``models`` block (``SessionModelState``
+    / ``ModelInfo``) that used to ride alongside ``configOptions``; the
+    ``category="model"`` selector is now the only channel through which an
+    agent advertises what it can run.  So the aggregate selector this
+    builds is no longer a mirror of the real thing — it *is* the real
+    thing.
+
+    Empty *models* yields a schema-valid response with no ``configOptions``
+    block — a select has non-nullable required fields the proxy can't fill
+    in for an empty list, and modelling "no models" as an empty selector
+    trips client validation.
     """
     if not models:
         return NewSessionResponse(session_id=session_id)
     current = models[0]
     return NewSessionResponse(
         session_id=session_id,
-        models=SessionModelState(
-            available_models=[
-                ModelInfo(model_id=ident, name=humanise_model_id(ident)) for ident in models
-            ],
-            current_model_id=current,
-        ),
         config_options=[build_model_option(models, current=current)],
     )
 
@@ -87,6 +92,48 @@ def build_model_option(namespaced_models: list[str], *, current: str) -> Session
             for ident in namespaced_models
         ],
     )
+
+
+def find_model_option(
+    config_options: list[SessionConfigOptionSelect | SessionConfigOptionBoolean] | None,
+) -> SessionConfigOptionSelect | None:
+    """Pick the model selector out of an agent's ``configOptions``.
+
+    Since ACP 1.16 dropped the dedicated ``models`` block, the model
+    selector is just one select among the agent's config options and has
+    to be recognised by convention.  ``category`` is the semantic marker
+    the spec provides, but it is optional ("UX only"), so a wrapper that
+    omits it is matched on the well-known ``id`` instead.  Returns
+    ``None`` when the agent exposes no model choice at all — a
+    single-model wrapper, which callers must treat as legitimate rather
+    than as an error.
+
+    The one place this rule lives: the probe reads models *out* of the
+    option, the proxy writes a pick *into* it, and both must agree on
+    which option they mean.
+    """
+    for opt in config_options or ():
+        if not isinstance(opt, SessionConfigOptionSelect):
+            continue
+        if opt.category == MODEL_OPTION_CATEGORY or opt.id == MODEL_OPTION_CATEGORY:
+            return opt
+    return None
+
+
+def model_ids_in_option(opt: SessionConfigOptionSelect) -> list[str]:
+    """List the model ids a selector offers, flattening any groups.
+
+    ACP lets a select present its options either flat or bucketed into
+    named groups (providers, tiers, …).  The roster only cares about the
+    ids, so both shapes collapse to one ordered list.
+    """
+    ids: list[str] = []
+    for entry in opt.options:
+        if isinstance(entry, SessionConfigSelectGroup):
+            ids.extend(sub.value for sub in entry.options)
+        else:
+            ids.append(entry.value)
+    return ids
 
 
 def namespace_model_options_in_place(

--- a/src/terok_executor/acp/probe.py
+++ b/src/terok_executor/acp/probe.py
@@ -8,7 +8,10 @@ that exposes the agent over JSON-RPC on stdio.  To learn which models
 the wrapper currently advertises, drive a minimal handshake:
 
 1. ``initialize`` — version negotiation
-2. ``session/new`` — receive the ``models`` block
+2. ``session/new`` — receive the ``configOptions`` block and read the
+   model selector out of it (ACP 1.16 retired the dedicated ``models``
+   block; a wrapper that offers no model selector reports no models,
+   which is legitimate rather than a failure)
 3. close stdin — agent exits cleanly
 
 The handshake is cheap but non-trivial to repeat; the result is cached
@@ -29,6 +32,8 @@ from typing import Any, NoReturn
 
 from acp import CLIENT_METHODS, PROTOCOL_VERSION, RequestError, spawn_agent_process
 from acp.schema import ClientCapabilities
+
+from .model_options import find_model_option, model_ids_in_option
 
 _logger = logging.getLogger(__name__)
 
@@ -53,8 +58,9 @@ async def probe_agent_models(
 
     Spawns the wrapper via `acp.spawn_agent_process`
     (which owns the asyncio stdio bridging and the graceful subprocess
-    shutdown dance), sends ``initialize`` and ``session/new``, reads
-    the ``models`` block, and returns the bare model ids.
+    shutdown dance), sends ``initialize`` and ``session/new``, reads the
+    model selector out of the returned ``configOptions``, and returns the
+    bare model ids.
 
     Raises [`ProbeError`][terok_executor.acp.probe.ProbeError] on
     timeout, transport failure, or any handshake error.  Callers (the
@@ -76,9 +82,10 @@ async def probe_agent_models(
     except Exception as exc:
         raise ProbeError(f"probe failed for agent {agent_id!r}: {exc}") from exc
 
-    if resp.models is None:
+    model_option = find_model_option(resp.config_options)
+    if model_option is None:
         return ()
-    return tuple(m.model_id for m in resp.models.available_models)
+    return tuple(model_ids_in_option(model_option))
 
 
 class _ProbeClient:
@@ -131,6 +138,14 @@ class _ProbeClient:
     async def kill_terminal(self, *_: object, **__: object) -> NoReturn:
         """Fast-fail — probe owns no terminals."""
         _not_supported_during_probe(CLIENT_METHODS["terminal_kill"])
+
+    async def create_elicitation(self, *_: object, **__: object) -> NoReturn:
+        """Fast-fail — probe has no user to elicit anything from."""
+        _not_supported_during_probe(CLIENT_METHODS["elicitation_create"])
+
+    async def complete_elicitation(self, *_: object, **__: object) -> None:
+        """Swallow — the probe never opened an elicitation to complete."""
+        return None
 
     async def ext_method(self, _name: str, _payload: dict[str, Any]) -> NoReturn:
         """Fast-fail — probe doesn't carry extension surfaces."""

--- a/src/terok_executor/acp/proxy.py
+++ b/src/terok_executor/acp/proxy.py
@@ -23,18 +23,23 @@ implements **both** sides of the ACP protocol on the same object:
 Two phases drive the lifecycle:
 
 - **Pre-bind**: ``initialize`` and ``session/new`` answer locally,
-  advertising the aggregated ``agent:model`` list in
-  `acp.schema.SessionModelState` plus a mirroring
-  ``configOptions[category=model]``.  No backend process exists yet.
-- **Bound**: on the first model-picking client request — modern ACP's
-  ``session/set_model`` or older Zed's ``session/set_config_option(category=model)``,
-  or lazily on the first backend-needing method like ``session/prompt``
-  — the proxy spawns the in-container wrapper through
-  `acp.spawn_agent_process`, replays
-  ``initialize`` + ``session/new`` + ``session/set_model`` against it,
-  and from then on forwards typed calls in both directions.  Backend
-  responses and notifications carrying model ids are re-namespaced on
-  the way out so the client always sees ``agent:model`` ids.
+  advertising the aggregated ``agent:model`` list as a
+  ``configOptions[category=model]`` selector.  No backend process exists
+  yet.
+- **Bound**: on the first model-picking client request —
+  ``session/set_config_option(category=model)``, or lazily on the first
+  backend-needing method like ``session/prompt`` — the proxy spawns the
+  in-container wrapper through `acp.spawn_agent_process`, replays
+  ``initialize`` + ``session/new`` + ``session/set_config_option``
+  against it, and from then on forwards typed calls in both directions.
+  Backend responses and notifications carrying model ids are re-namespaced
+  on the way out so the client always sees ``agent:model`` ids.
+
+ACP 1.16 (SDK 0.11) retired the dedicated model channel —
+``session/set_model``, ``SessionModelState``, ``ModelInfo`` are all gone —
+and model selection now rides the generic config-option mechanism that
+older Zed already used.  That collapsed two code paths into one: the
+proxy speaks config options to the client *and* to the backend.
 
 V1 takes shortcuts where the design is still settling: one session per
 connection (Zed reconnects on every chat — fix on the roadmap), one
@@ -53,15 +58,21 @@ from acp import PROTOCOL_VERSION, RequestError, spawn_agent_process
 from acp.agent.connection import AgentSideConnection
 from acp.client.connection import ClientSideConnection
 from acp.schema import (
+    AcpMcpServer,
     AgentMessageChunk,
+    AgentPlanContentUpdate,
+    AgentPlanRemovedUpdate,
     AgentPlanUpdate,
     AgentThoughtChunk,
     AuthenticateResponse,
     AvailableCommandsUpdate,
     ClientCapabilities,
     ConfigOptionUpdate,
+    CreateElicitationResponse,
     CreateTerminalResponse,
     CurrentModeUpdate,
+    ElicitationMode,
+    ElicitationSessionScope,
     EnvVariable,
     ForkSessionResponse,
     HttpMcpServer,
@@ -80,7 +91,6 @@ from acp.schema import (
     ResumeSessionResponse,
     SessionInfoUpdate,
     SetSessionConfigOptionResponse,
-    SetSessionModelResponse,
     SetSessionModeResponse,
     SseMcpServer,
     TerminalOutputResponse,
@@ -97,6 +107,7 @@ from .model_options import (
     MODEL_OPTION_CATEGORY,
     build_aggregated_session_new,
     build_model_option,
+    find_model_option,
     namespace_model_options_in_place,
     split_namespaced,
 )
@@ -135,12 +146,24 @@ SessionUpdatePayload = (
     | ToolCallStart
     | ToolCallProgress
     | AgentPlanUpdate
+    | AgentPlanContentUpdate
+    | AgentPlanRemovedUpdate
     | AvailableCommandsUpdate
     | CurrentModeUpdate
     | ConfigOptionUpdate
     | SessionInfoUpdate
     | UsageUpdate
 )
+
+McpServerConfig = HttpMcpServer | SseMcpServer | AcpMcpServer | McpServerStdio
+"""Every MCP server shape ``session/new`` and friends accept.
+
+Spelled once because the proxy forwards the client's ``mcpServers`` list
+verbatim through four session-opening methods, and the union must stay
+identical to the SDK's — ``list`` is invariant, so a member missing here
+(``AcpMcpServer`` was, before ACP 1.16 added it) makes every forward a
+type error rather than silently dropping a server.
+"""
 
 
 class ACPProxy:
@@ -159,10 +182,18 @@ class ACPProxy:
         self._bind_lock = asyncio.Lock()
         self._bound_agent: str | None = None
         self._backend_session_id: str | None = None
-        self._client_mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None
+        self._client_mcp_servers: list[McpServerConfig] | None = None
         self._client_additional_directories: list[str] | None = None
         self._client_capabilities: ClientCapabilities | None = None
         self._aggregated_models: list[str] = []
+        # Id of the *backend's* own model selector, learned from its
+        # ``session/new`` reply at bind time.  ACP 1.16 removed the
+        # dedicated ``session/set_model`` call, so re-picks now go through
+        # ``session/set_config_option`` and need the backend's option id —
+        # which is its to choose, not ours to assume.  ``None`` means the
+        # backend offers no model choice; a pick is then a no-op rather
+        # than an error.
+        self._backend_model_config_id: str | None = None
         # Namespaced ``agent:model`` advertised as ``currentModelId`` in
         # ``session/new``.  Lazy-bind target for clients that go straight
         # from ``session/new`` to ``session/prompt`` without an explicit
@@ -216,7 +247,7 @@ class ACPProxy:
         self,
         cwd: str,
         additional_directories: list[str] | None = None,
-        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        mcp_servers: list[McpServerConfig] | None = None,
         **_kw: Any,
     ) -> NewSessionResponse:
         """Answer ``session/new`` with the aggregated model list.
@@ -238,24 +269,16 @@ class ACPProxy:
         self._default_namespaced = self._aggregated_models[0] if self._aggregated_models else None
         return build_aggregated_session_new(CLIENT_SESSION_ID, self._aggregated_models)
 
-    async def set_session_model(
-        self, model_id: str, session_id: str, **_kw: Any
-    ) -> SetSessionModelResponse | None:
-        """Bind on first call; same-agent re-pick forwards through."""
-        self._require_client_session(session_id)
-        await self._select_model(model_id)
-        return SetSessionModelResponse()
-
     async def set_config_option(
         self, config_id: str, session_id: str, value: str | bool, **_kw: Any
     ) -> SetSessionConfigOptionResponse | None:
         """Bind on ``category=model``; otherwise forward to the bound backend.
 
-        Older ACP clients (Zed v1.0.x at the time of writing) pick the
-        model through ``session/set_config_option(category="model")``;
-        modern clients use the dedicated ``session/set_model``.  Accept
-        both.  Non-model categories pass through to the bound backend;
-        a non-model option pre-bind is rejected.
+        This is now the *only* way a client picks a model: ACP 1.16
+        retired the dedicated ``session/set_model`` request, folding model
+        selection into the generic config-option channel that older Zed
+        already used.  Non-model options pass through to the bound
+        backend; a non-model option pre-bind is rejected.
         """
         self._require_client_session(session_id)
         if config_id == MODEL_OPTION_CATEGORY and isinstance(value, str):
@@ -272,18 +295,20 @@ class ACPProxy:
 
     async def prompt(
         self,
-        prompt: list,
         session_id: str,
-        message_id: str | None = None,
+        prompt: list,
         **_kw: Any,
     ) -> PromptResponse:
-        """Lazy-bind to the default model if needed, then forward."""
+        """Lazy-bind to the default model if needed, then forward.
+
+        ACP 1.16 dropped ``message_id`` from ``PromptRequest`` — message
+        ids now ride on the streamed content chunks instead — so there is
+        nothing left to relay but the prompt itself.
+        """
         self._require_client_session(session_id)
         await self._ensure_bound_for_default()
         backend, backend_session = self._require_bound()
-        return await backend.prompt(
-            prompt=prompt, session_id=backend_session, message_id=message_id
-        )
+        return await backend.prompt(prompt=prompt, session_id=backend_session)
 
     async def cancel(self, session_id: str, **_kw: Any) -> None:
         """Fire-and-forget cancel to the backend (no-op if not bound)."""
@@ -297,7 +322,7 @@ class ACPProxy:
         return await backend.authenticate(method_id=method_id)
 
     async def set_session_mode(
-        self, mode_id: str, session_id: str, **_kw: Any
+        self, session_id: str, mode_id: str, **_kw: Any
     ) -> SetSessionModeResponse | None:
         """Forward to bound backend."""
         self._require_client_session(session_id)
@@ -308,8 +333,8 @@ class ACPProxy:
         self,
         cwd: str,
         session_id: str,
+        mcp_servers: list[McpServerConfig] | None = None,
         additional_directories: list[str] | None = None,
-        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
         **_kw: Any,
     ) -> LoadSessionResponse | None:
         """Forward to bound backend (v1 advertises no session-load capability)."""
@@ -324,23 +349,24 @@ class ACPProxy:
 
     async def list_sessions(
         self,
-        additional_directories: list[str] | None = None,
-        cursor: str | None = None,
         cwd: str | None = None,
+        cursor: str | None = None,
         **_kw: Any,
     ) -> ListSessionsResponse:
-        """Forward to bound backend."""
+        """Forward to bound backend.
+
+        ``ListSessionsRequest`` lost ``additionalDirectories`` in ACP
+        1.16 — listing is scoped by ``cwd`` alone now.
+        """
         backend, _ = self._require_bound()
-        return await backend.list_sessions(
-            additional_directories=additional_directories, cursor=cursor, cwd=cwd
-        )
+        return await backend.list_sessions(cursor=cursor, cwd=cwd)
 
     async def fork_session(
         self,
-        cwd: str,
         session_id: str,
+        cwd: str,
         additional_directories: list[str] | None = None,
-        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        mcp_servers: list[McpServerConfig] | None = None,
         **_kw: Any,
     ) -> ForkSessionResponse:
         """Forward to bound backend."""
@@ -355,10 +381,10 @@ class ACPProxy:
 
     async def resume_session(
         self,
-        cwd: str,
         session_id: str,
+        cwd: str,
         additional_directories: list[str] | None = None,
-        mcp_servers: list[HttpMcpServer | SseMcpServer | McpServerStdio] | None = None,
+        mcp_servers: list[McpServerConfig] | None = None,
         **_kw: Any,
     ) -> ResumeSessionResponse:
         """Forward to bound backend."""
@@ -413,9 +439,9 @@ class ACPProxy:
 
     async def request_permission(
         self,
-        options: list[PermissionOption],
         session_id: str,
         tool_call: ToolCallUpdate,
+        options: list[PermissionOption],
         **_kw: Any,
     ) -> RequestPermissionResponse:
         """Forward permission request to the connected client."""
@@ -426,10 +452,10 @@ class ACPProxy:
 
     async def read_text_file(
         self,
-        path: str,
         session_id: str,
-        limit: int | None = None,
+        path: str,
         line: int | None = None,
+        limit: int | None = None,
         **_kw: Any,
     ) -> ReadTextFileResponse:
         """Forward fs read to the connected client."""
@@ -439,7 +465,7 @@ class ACPProxy:
         )
 
     async def write_text_file(
-        self, content: str, path: str, session_id: str, **_kw: Any
+        self, session_id: str, path: str, content: str, **_kw: Any
     ) -> WriteTextFileResponse | None:
         """Forward fs write to the connected client."""
         del session_id
@@ -449,11 +475,11 @@ class ACPProxy:
 
     async def create_terminal(
         self,
-        command: str,
         session_id: str,
+        command: str,
         args: list[str] | None = None,
-        cwd: str | None = None,
         env: list[EnvVariable] | None = None,
+        cwd: str | None = None,
         output_byte_limit: int | None = None,
         **_kw: Any,
     ) -> CreateTerminalResponse:
@@ -504,6 +530,25 @@ class ACPProxy:
             session_id=CLIENT_SESSION_ID, terminal_id=terminal_id
         )
 
+    async def create_elicitation(
+        self, message: str, mode: ElicitationMode, **_kw: Any
+    ) -> CreateElicitationResponse:
+        """Forward an elicitation request to the connected client.
+
+        The backend addresses the elicitation to *its* session; the client
+        only knows [`CLIENT_SESSION_ID`][terok_executor.acp.proxy.CLIENT_SESSION_ID],
+        so session-scoped modes get the same id rewrite every other
+        backend → client frame gets.  Request-scoped modes carry no
+        session and pass through untouched.
+        """
+        if isinstance(mode, ElicitationSessionScope):
+            mode = mode.model_copy(update={"session_id": CLIENT_SESSION_ID})
+        return await self._require_client().create_elicitation(message=message, mode=mode)
+
+    async def complete_elicitation(self, elicitation_id: str, **_kw: Any) -> None:
+        """Forward the completion of an out-of-band elicitation to the client."""
+        await self._require_client().complete_elicitation(elicitation_id=elicitation_id)
+
     # ── Bind ──────────────────────────────────────────────────────────
 
     async def _select_model(self, namespaced: str) -> None:
@@ -533,8 +578,25 @@ class ACPProxy:
                         )
                     }
                 )
+        await self._set_backend_model(model_id)
+
+    async def _set_backend_model(self, model_id: str) -> None:
+        """Tell the bound backend to switch to *model_id*.
+
+        ACP 1.16 removed ``session/set_model``; a model is now just one
+        more config option, addressed by the id the backend gave its own
+        selector.  A backend that advertises no model selector has nothing
+        to switch — one model, always in use — so the pick is a no-op
+        rather than an error.
+        """
+        if self._backend_model_config_id is None:
+            return
         backend, backend_session = self._require_bound()
-        await backend.set_session_model(model_id=model_id, session_id=backend_session)
+        await backend.set_config_option(
+            config_id=self._backend_model_config_id,
+            session_id=backend_session,
+            value=model_id,
+        )
 
     async def _ensure_bound_for_default(self) -> None:
         """Bind to the advertised default model if no backend is bound yet."""
@@ -555,7 +617,12 @@ class ACPProxy:
 
         Callers hold [`_bind_lock`][terok_executor.acp.proxy.ACPProxy._bind_lock]
         — concurrent bind attempts from a racing ``prompt`` and
-        ``set_session_model`` collapse to one.
+        ``set_config_option`` collapse to one.
+
+        The backend's ``session/new`` reply is where we learn the id of its
+        model selector: the proxy namespaces model ids for the client, but
+        the option they live in belongs to the backend and is only named in
+        that reply.
         """
         command, *args = self._roster.wrapper_argv(agent_id)
         try:
@@ -573,7 +640,9 @@ class ACPProxy:
                 additional_directories=self._client_additional_directories,
             )
             self._backend_session_id = new_resp.session_id
-            await backend.set_session_model(model_id=model_id, session_id=self._backend_session_id)
+            model_option = find_model_option(new_resp.config_options)
+            self._backend_model_config_id = None if model_option is None else model_option.id
+            await self._set_backend_model(model_id)
         except Exception as exc:
             await self._teardown_backend()
             raise AgentBindError(f"bind {agent_id!r}: {exc}") from exc
@@ -589,6 +658,7 @@ class ACPProxy:
         self._backend_stack = AsyncExitStack()
         self._backend = None
         self._backend_session_id = None
+        self._backend_model_config_id = None
         # Keep _bound_agent set if we've already declared one — clearing
         # it would let a misbehaving client switch agents mid-session
         # past the v1 guard.  On clean disconnect the proxy is discarded

--- a/tests/unit/test_acp_probe.py
+++ b/tests/unit/test_acp_probe.py
@@ -197,8 +197,11 @@ class TestProbeClient:
 
         from terok_executor.acp.probe import _ProbeClient
 
+        # Build the coroutine outside the block so the only call that can
+        # raise inside it is the one under test.
+        elicit = _ProbeClient().create_elicitation(message="pick", mode=None)
         with pytest.raises(RequestError):
-            asyncio.run(_ProbeClient().create_elicitation(message="pick", mode=None))
+            asyncio.run(elicit)
 
     def test_complete_elicitation_swallowed(self) -> None:
         """The probe never opened an elicitation, so completing one is a no-op."""

--- a/tests/unit/test_acp_probe.py
+++ b/tests/unit/test_acp_probe.py
@@ -20,9 +20,9 @@ from typing import Any
 import pytest
 from acp.schema import (
     InitializeResponse,
-    ModelInfo,
     NewSessionResponse,
-    SessionModelState,
+    SessionConfigOptionSelect,
+    SessionConfigSelectOption,
 )
 
 from terok_executor.acp import probe as probe_module
@@ -68,12 +68,21 @@ class _CannedBackend:
             raise self._raise_on_new_session
         if not self._models:
             return NewSessionResponse(session_id="be-1")
+        # ACP 1.16 retired the dedicated ``models`` block: a wrapper now
+        # advertises what it can run as a ``category="model"`` selector
+        # among its config options.
         return NewSessionResponse(
             session_id="be-1",
-            models=SessionModelState(
-                available_models=[ModelInfo(model_id=m, name=m) for m in self._models],
-                current_model_id=self._models[0],
-            ),
+            config_options=[
+                SessionConfigOptionSelect(
+                    id="model",
+                    name="Model",
+                    type="select",
+                    category="model",
+                    current_value=self._models[0],
+                    options=[SessionConfigSelectOption(value=m, name=m) for m in self._models],
+                )
+            ],
         )
 
 
@@ -101,7 +110,7 @@ class TestProbeAgentModels:
     """End-to-end probe with a patched ``spawn_agent_process``."""
 
     def test_happy_path_returns_models(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A normal handshake yields the model tuple from ``models.available_models``."""
+        """A normal handshake yields the model tuple from the config-option selector."""
         _patch_spawn(monkeypatch, _CannedBackend(models=["opus-4.6", "haiku-4.5"]))
         models = asyncio.run(
             probe_agent_models(
@@ -113,7 +122,7 @@ class TestProbeAgentModels:
         assert models == ("opus-4.6", "haiku-4.5")
 
     def test_no_models_block_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A wrapper that supports sessions but has no model picker → empty."""
+        """A wrapper that supports sessions but advertises no model selector → empty."""
         _patch_spawn(monkeypatch, _CannedBackend(models=None))
         models = asyncio.run(
             probe_agent_models(

--- a/tests/unit/test_acp_probe.py
+++ b/tests/unit/test_acp_probe.py
@@ -191,6 +191,21 @@ class TestProbeClient:
 
         asyncio.run(_ProbeClient().ext_notification("evt", {}))
 
+    def test_create_elicitation_fast_fails(self) -> None:
+        """The probe has no user to elicit from — don't hang the handshake waiting."""
+        from acp import RequestError
+
+        from terok_executor.acp.probe import _ProbeClient
+
+        with pytest.raises(RequestError):
+            asyncio.run(_ProbeClient().create_elicitation(message="pick", mode=None))
+
+    def test_complete_elicitation_swallowed(self) -> None:
+        """The probe never opened an elicitation, so completing one is a no-op."""
+        from terok_executor.acp.probe import _ProbeClient
+
+        asyncio.run(_ProbeClient().complete_elicitation(elicitation_id="e-1"))
+
     def test_on_connect_is_noop(self) -> None:
         """``on_connect`` is a protocol hook the probe doesn't use."""
         from terok_executor.acp.probe import _ProbeClient

--- a/tests/unit/test_acp_proxy.py
+++ b/tests/unit/test_acp_proxy.py
@@ -27,11 +27,11 @@ from acp.schema import (
     SessionConfigOptionSelect,
     SessionConfigSelectOption,
     SetSessionConfigOptionResponse,
-    SetSessionModelResponse,
 )
 
 from terok_executor.acp import proxy as proxy_module
 from terok_executor.acp.model_options import (
+    MODEL_OPTION_CATEGORY,
     build_aggregated_session_new,
     build_model_option,
     humanise_model_id,
@@ -46,6 +46,11 @@ from terok_executor.acp.proxy import (
 # JSON-RPC error codes the proxy maps onto via `RequestError.invalid_*`.
 _JSONRPC_INVALID_REQUEST = -32600
 _JSONRPC_INVALID_PARAMS = -32602
+
+# The id a backend gives its *own* model selector.  Deliberately not the
+# proxy's ``"model"``: the proxy must address the backend by the id that
+# backend advertised, not by assuming its own convention holds downstream.
+_BACKEND_MODEL_CONFIG_ID = "llm"
 
 
 class _StubRoster:
@@ -79,12 +84,26 @@ class _FakeBackend:
         return InitializeResponse(protocol_version=kw["protocol_version"])
 
     async def new_session(self, **kw: Any) -> NewSessionResponse:
+        # A real 0.11 wrapper advertises its models as a select among its
+        # config options — the dedicated ``models`` block is gone.  The
+        # proxy reads this to learn which option a model pick addresses.
         self.calls.append(("new_session", kw))
-        return NewSessionResponse(session_id=self.session_id)
-
-    async def set_session_model(self, **kw: Any) -> SetSessionModelResponse:
-        self.calls.append(("set_session_model", kw))
-        return SetSessionModelResponse()
+        return NewSessionResponse(
+            session_id=self.session_id,
+            config_options=[
+                SessionConfigOptionSelect(
+                    id=_BACKEND_MODEL_CONFIG_ID,
+                    name="Model",
+                    type="select",
+                    category="model",
+                    current_value="opus-4.6",
+                    options=[
+                        SessionConfigSelectOption(value="opus-4.6", name="Opus"),
+                        SessionConfigSelectOption(value="haiku-4.5", name="Haiku"),
+                    ],
+                )
+            ],
+        )
 
     async def prompt(self, **kw: Any) -> PromptResponse:
         self.calls.append(("prompt", kw))
@@ -164,6 +183,29 @@ def _new_proxy(available: list[str]) -> ACPProxy:
     return ACPProxy(roster=_StubRoster(available))  # type: ignore[arg-type]
 
 
+async def _pick_model(
+    proxy: ACPProxy, namespaced: str, *, session_id: str = CLIENT_SESSION_ID
+) -> SetSessionConfigOptionResponse | None:
+    """Pick *namespaced* the way a client does.
+
+    Since ACP 1.16 the config-option channel is the *only* way to select a
+    model — ``session/set_model`` no longer exists — so this is what every
+    bind-driving test goes through.
+    """
+    return await proxy.set_config_option(
+        config_id=MODEL_OPTION_CATEGORY, session_id=session_id, value=namespaced
+    )
+
+
+def _backend_model_picks(backend: _FakeBackend) -> list[str]:
+    """Model values the proxy pushed onto *backend*'s own model selector."""
+    return [
+        kw["value"]
+        for name, kw in backend.calls
+        if name == "set_config_option" and kw["config_id"] == _BACKEND_MODEL_CONFIG_ID
+    ]
+
+
 class TestInitialize:
     """Pre-bind ``initialize`` is answered locally."""
 
@@ -194,15 +236,9 @@ class TestSessionNew:
         assert resp.session_id == CLIENT_SESSION_ID
 
     def test_aggregates_namespaced_model_options(self) -> None:
-        """Every available ``agent:model`` appears in both ``models`` and ``configOptions``."""
+        """Every available ``agent:model`` appears in the ``configOptions`` selector."""
         proxy = _new_proxy(["claude:opus-4.6", "codex:gpt-5.5"])
         resp = asyncio.run(proxy.new_session(cwd="/x", mcp_servers=[]))
-        assert resp.models is not None
-        assert [m.model_id for m in resp.models.available_models] == [
-            "claude:opus-4.6",
-            "codex:gpt-5.5",
-        ]
-        assert resp.models.current_model_id == "claude:opus-4.6"
         assert resp.config_options is not None
         model_opt = next(opt for opt in resp.config_options if opt.category == "model")
         assert isinstance(model_opt, SessionConfigOptionSelect)
@@ -226,22 +262,8 @@ class TestSessionNew:
         assert proxy._default_namespaced == "claude:opus-4.6"
 
 
-class TestSetModelPreBind:
-    """``session/set_model`` parsing before any bind."""
-
-    def test_unnamespaced_model_id_raises_invalid_params(self) -> None:
-        """Non ``agent:model`` values are rejected with -32602."""
-        proxy = _new_proxy(["claude:opus-4.6"])
-        asyncio.run(proxy.new_session(cwd="/x", mcp_servers=[]))
-        with pytest.raises(RequestError) as exc:
-            asyncio.run(
-                proxy.set_session_model(model_id="no-namespace", session_id=CLIENT_SESSION_ID)
-            )
-        assert exc.value.code == _JSONRPC_INVALID_PARAMS
-
-
 class TestSetConfigOptionPreBind:
-    """Older Zed sends model selection via ``set_config_option``."""
+    """Clients send model selection via ``set_config_option``."""
 
     def test_model_with_bad_namespace_raises(self) -> None:
         """Malformed ``agent:model`` short-circuits before any spawn."""
@@ -287,13 +309,11 @@ class TestPromptLazyBindGate:
 class TestSessionIdValidation:
     """Session-scoped handlers reject stale or pre-``session/new`` ids."""
 
-    def test_set_session_model_pre_new_session_rejected(self) -> None:
-        """Calling ``set_session_model`` before ``session/new`` errors."""
+    def test_model_pick_pre_new_session_rejected(self) -> None:
+        """Picking a model before ``session/new`` errors."""
         proxy = _new_proxy(["claude:opus-4.6"])
         with pytest.raises(RequestError) as exc:
-            asyncio.run(
-                proxy.set_session_model(model_id="claude:opus-4.6", session_id=CLIENT_SESSION_ID)
-            )
+            asyncio.run(_pick_model(proxy, "claude:opus-4.6"))
         assert exc.value.code == _JSONRPC_INVALID_REQUEST
 
     def test_prompt_with_unknown_session_id_rejected(self) -> None:
@@ -308,15 +328,14 @@ class TestSessionIdValidation:
 class TestBind:
     """End-to-end bind flow with a patched ``spawn_agent_process``."""
 
-    def test_set_session_model_drives_backend_handshake(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """First ``set_session_model`` spawns backend + replays the three frames.
+    def test_model_pick_drives_backend_handshake(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The first model pick spawns the backend + replays the three frames.
 
         The patched backend captures the exact arguments so we can pin
         the handshake shape: namespace stripped on the way down, client
         ``cwd`` overridden to the container workspace, ``mcp_servers``
-        defaulted to the empty list when the client didn't supply any.
+        defaulted to the empty list when the client didn't supply any,
+        and the pick addressed to the backend's *own* selector id.
         """
         backend = _FakeBackend()
         _patch_spawn(monkeypatch, backend)
@@ -325,21 +344,43 @@ class TestBind:
         async def _drive() -> None:
             await proxy.initialize(protocol_version=1)
             await proxy.new_session(cwd="/host/proj", mcp_servers=None)
-            resp = await proxy.set_session_model(
-                model_id="claude:opus-4.6", session_id=CLIENT_SESSION_ID
-            )
-            assert isinstance(resp, SetSessionModelResponse)
+            resp = await _pick_model(proxy, "claude:opus-4.6")
+            assert isinstance(resp, SetSessionConfigOptionResponse)
 
         asyncio.run(_drive())
 
         method_order = [name for name, _ in backend.calls]
-        assert method_order == ["initialize", "new_session", "set_session_model"]
+        assert method_order == ["initialize", "new_session", "set_config_option"]
         new_session_call = backend.calls[1][1]
         assert new_session_call["cwd"] == proxy_module.CONTAINER_WORKSPACE
         assert new_session_call["mcp_servers"] == []
         set_model_call = backend.calls[2][1]
-        assert set_model_call["model_id"] == "opus-4.6"  # namespace stripped
+        assert set_model_call["config_id"] == _BACKEND_MODEL_CONFIG_ID
+        assert set_model_call["value"] == "opus-4.6"  # namespace stripped
         assert set_model_call["session_id"] == backend.session_id
+
+    def test_backend_without_model_selector_binds_anyway(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A single-model wrapper advertises no selector — the pick is a no-op, not an error."""
+
+        class _NoModelsBackend(_FakeBackend):
+            async def new_session(self, **kw: Any) -> NewSessionResponse:
+                self.calls.append(("new_session", kw))
+                return NewSessionResponse(session_id=self.session_id)
+
+        backend = _NoModelsBackend()
+        _patch_spawn(monkeypatch, backend)
+        proxy = _new_proxy(["claude:opus-4.6"])
+
+        async def _drive() -> None:
+            await proxy.initialize(protocol_version=1)
+            await proxy.new_session(cwd="/x", mcp_servers=[])
+            await _pick_model(proxy, "claude:opus-4.6")
+
+        asyncio.run(_drive())
+        assert [name for name, _ in backend.calls] == ["initialize", "new_session"]
+        assert proxy._bound_agent == "claude"
 
     def test_additional_directories_forwarded_on_bind(
         self, monkeypatch: pytest.MonkeyPatch
@@ -354,7 +395,7 @@ class TestBind:
             await proxy.new_session(
                 cwd="/host/proj", mcp_servers=[], additional_directories=["/extra"]
             )
-            await proxy.set_session_model(model_id="claude:opus-4.6", session_id=CLIENT_SESSION_ID)
+            await _pick_model(proxy, "claude:opus-4.6")
 
         asyncio.run(_drive())
         new_session_call = backend.calls[1][1]
@@ -369,11 +410,9 @@ class TestBind:
         async def _drive() -> None:
             await proxy.initialize(protocol_version=1)
             await proxy.new_session(cwd="/x", mcp_servers=[])
-            await proxy.set_session_model(model_id="claude:opus-4.6", session_id=CLIENT_SESSION_ID)
+            await _pick_model(proxy, "claude:opus-4.6")
             with pytest.raises(RequestError) as exc:
-                await proxy.set_session_model(
-                    model_id="codex:gpt-5.5", session_id=CLIENT_SESSION_ID
-                )
+                await _pick_model(proxy, "codex:gpt-5.5")
             assert exc.value.code == _JSONRPC_INVALID_PARAMS
 
         asyncio.run(_drive())
@@ -387,14 +426,13 @@ class TestBind:
         async def _drive() -> None:
             await proxy.initialize(protocol_version=1)
             await proxy.new_session(cwd="/x", mcp_servers=[])
-            await proxy.set_session_model(model_id="claude:opus-4.6", session_id=CLIENT_SESSION_ID)
-            await proxy.set_session_model(model_id="claude:haiku-4.5", session_id=CLIENT_SESSION_ID)
+            await _pick_model(proxy, "claude:opus-4.6")
+            await _pick_model(proxy, "claude:haiku-4.5")
 
         asyncio.run(_drive())
 
-        set_model_calls = [kw for name, kw in backend.calls if name == "set_session_model"]
-        # First call is part of bind handshake, second is the re-pick.
-        assert [c["model_id"] for c in set_model_calls] == ["opus-4.6", "haiku-4.5"]
+        # First push is part of the bind handshake, second is the re-pick.
+        assert _backend_model_picks(backend) == ["opus-4.6", "haiku-4.5"]
 
     def test_bind_failure_propagates_as_agent_bind_error(
         self, monkeypatch: pytest.MonkeyPatch
@@ -412,9 +450,7 @@ class TestBind:
             await proxy.initialize(protocol_version=1)
             await proxy.new_session(cwd="/x", mcp_servers=[])
             with pytest.raises(AgentBindError):
-                await proxy.set_session_model(
-                    model_id="claude:opus-4.6", session_id=CLIENT_SESSION_ID
-                )
+                await _pick_model(proxy, "claude:opus-4.6")
             # State reset — a retry should be possible.
             assert proxy._backend is None
             assert proxy._bound_agent is None
@@ -434,7 +470,7 @@ class TestBackendForwarding:
         async def _drive() -> SetSessionConfigOptionResponse | None:
             await proxy.initialize(protocol_version=1)
             await proxy.new_session(cwd="/x", mcp_servers=[])
-            await proxy.set_session_model(model_id="claude:opus-4.6", session_id=CLIENT_SESSION_ID)
+            await _pick_model(proxy, "claude:opus-4.6")
             return await proxy.set_config_option(
                 config_id="theme",
                 session_id=CLIENT_SESSION_ID,
@@ -480,7 +516,7 @@ class TestBackendForwarding:
         assert [e.value for e in opt.options] == ["claude:opus-4.6", "claude:haiku-4.5"]
 
     def test_prompt_lazy_binds_to_default_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A client that skips ``set_session_model`` binds lazily on first ``prompt``."""
+        """A client that never picks a model binds lazily on first ``prompt``."""
         backend = _FakeBackend()
         _patch_spawn(monkeypatch, backend)
         proxy = _new_proxy(["claude:opus-4.6"])
@@ -492,9 +528,8 @@ class TestBackendForwarding:
 
         asyncio.run(_drive())
         method_order = [name for name, _ in backend.calls]
-        assert method_order == ["initialize", "new_session", "set_session_model", "prompt"]
-        set_model_call = backend.calls[2][1]
-        assert set_model_call["model_id"] == "opus-4.6"
+        assert method_order == ["initialize", "new_session", "set_config_option", "prompt"]
+        assert _backend_model_picks(backend) == ["opus-4.6"]
 
     def test_close_session_tears_backend_down(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``close_session`` reaps the wrapper; the proxy can rebind afterwards."""
@@ -505,7 +540,7 @@ class TestBackendForwarding:
         async def _drive() -> None:
             await proxy.initialize(protocol_version=1)
             await proxy.new_session(cwd="/x", mcp_servers=[])
-            await proxy.set_session_model(model_id="claude:opus-4.6", session_id=CLIENT_SESSION_ID)
+            await _pick_model(proxy, "claude:opus-4.6")
             await proxy.close_session(session_id=CLIENT_SESSION_ID)
 
         asyncio.run(_drive())
@@ -633,7 +668,7 @@ class TestSessionUpdateForwarding:
         async def _drive() -> None:
             await proxy.initialize(protocol_version=1)
             await proxy.new_session(cwd="/x", mcp_servers=[])
-            await proxy.set_session_model(model_id="claude:opus-4.6", session_id=CLIENT_SESSION_ID)
+            await _pick_model(proxy, "claude:opus-4.6")
             # Inject the recorder *after* bind so the proxy's normal
             # initialise path isn't disturbed.
             proxy._client = _RecordingClient()  # type: ignore[assignment]
@@ -669,10 +704,9 @@ class TestBuildHelpers:
     """The pre-bind aggregate builders."""
 
     def test_build_aggregated_session_new_empty_models(self) -> None:
-        """Empty list yields a schema-valid response with no models block."""
+        """Empty list yields a schema-valid response with no selector at all."""
         resp = build_aggregated_session_new("sess-x", [])
         assert resp.session_id == "sess-x"
-        assert resp.models is None
         assert resp.config_options is None
 
     def test_humanise_model_id_round_trip(self) -> None:
@@ -753,7 +787,7 @@ def _bound_proxy(
     async def _bind() -> None:
         await proxy.initialize(protocol_version=1)
         await proxy.new_session(cwd="/x", mcp_servers=[])
-        await proxy.set_session_model(model_id=available[0], session_id=CLIENT_SESSION_ID)
+        await _pick_model(proxy, available[0])
 
     asyncio.run(_bind())
     client = _RecordingClient()
@@ -788,12 +822,11 @@ class TestPostBindAgentForwarders:
         assert backend.calls[-1][1]["session_id"] == backend.session_id
 
     def test_list_sessions_forwards(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # ACP 1.16 scopes listing by ``cwd`` alone — ``additionalDirectories``
+        # is no longer part of the request.
         proxy, backend, _ = _bound_proxy(monkeypatch)
         asyncio.run(proxy.list_sessions(cursor="abc"))
-        assert backend.calls[-1] == (
-            "list_sessions",
-            {"additional_directories": None, "cursor": "abc", "cwd": None},
-        )
+        assert backend.calls[-1] == ("list_sessions", {"cursor": "abc", "cwd": None})
 
     def test_fork_session_forwards(self, monkeypatch: pytest.MonkeyPatch) -> None:
         proxy, backend, _ = _bound_proxy(monkeypatch)
@@ -835,11 +868,22 @@ class TestPostBindAgentForwarders:
 
     def test_prompt_post_bind_forwards(self, monkeypatch: pytest.MonkeyPatch) -> None:
         proxy, backend, _ = _bound_proxy(monkeypatch)
-        resp = asyncio.run(proxy.prompt(prompt=[], session_id=CLIENT_SESSION_ID, message_id="m1"))
+        resp = asyncio.run(proxy.prompt(prompt=[], session_id=CLIENT_SESSION_ID))
         assert isinstance(resp, PromptResponse)
         assert backend.calls[-1][0] == "prompt"
         assert backend.calls[-1][1]["session_id"] == backend.session_id
-        assert backend.calls[-1][1]["message_id"] == "m1"
+
+    def test_prompt_does_not_relay_retired_message_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A client still sending ``message_id`` gets it dropped, not forwarded.
+
+        ACP 1.16 removed the field from ``PromptRequest``; relaying it to a
+        0.11 backend would be a protocol violation.
+        """
+        proxy, backend, _ = _bound_proxy(monkeypatch)
+        asyncio.run(proxy.prompt(prompt=[], session_id=CLIENT_SESSION_ID, message_id="m1"))
+        assert "message_id" not in backend.calls[-1][1]
 
 
 class TestClientSideForwarders:

--- a/tests/unit/test_acp_proxy.py
+++ b/tests/unit/test_acp_proxy.py
@@ -34,7 +34,9 @@ from terok_executor.acp.model_options import (
     MODEL_OPTION_CATEGORY,
     build_aggregated_session_new,
     build_model_option,
+    find_model_option,
     humanise_model_id,
+    model_ids_in_option,
     namespace_model_options_in_place,
 )
 from terok_executor.acp.proxy import (
@@ -700,6 +702,66 @@ class TestSessionUpdateForwarding:
         assert model_opt.options[0].value == "claude:opus-4.6"
 
 
+class TestFindModelOption:
+    """Locating a backend's model selector among its config options."""
+
+    def test_skips_non_select_options_and_matches_category(self) -> None:
+        """A boolean knob is not a model selector; the ``category="model"`` select is."""
+        from acp.schema import SessionConfigOptionBoolean
+
+        toggle = SessionConfigOptionBoolean(
+            id="verbose", name="Verbose", type="boolean", current_value=True
+        )
+        models = SessionConfigOptionSelect(
+            id="llm",
+            name="Model",
+            type="select",
+            category="model",
+            current_value="opus-4.6",
+            options=[SessionConfigSelectOption(value="opus-4.6", name="Opus")],
+        )
+        assert find_model_option([toggle, models]) is models
+
+    def test_matches_well_known_id_when_category_absent(self) -> None:
+        """``category`` is optional in the spec — fall back to the well-known id."""
+        opt = SessionConfigOptionSelect(
+            id="model",
+            name="Model",
+            type="select",
+            current_value="opus-4.6",
+            options=[SessionConfigSelectOption(value="opus-4.6", name="Opus")],
+        )
+        assert find_model_option([opt]) is opt
+
+    def test_returns_none_when_no_model_selector(self) -> None:
+        """A single-model wrapper offers no selector at all."""
+        assert find_model_option(None) is None
+        assert find_model_option([]) is None
+
+    def test_model_ids_flattens_groups(self) -> None:
+        """Grouped selects (by provider/tier) collapse to one ordered id list."""
+        from acp.schema import SessionConfigSelectGroup
+
+        opt = SessionConfigOptionSelect(
+            id="model",
+            name="Model",
+            type="select",
+            category="model",
+            current_value="opus-4.6",
+            options=[
+                SessionConfigSelectGroup(
+                    group="anthropic",
+                    name="Anthropic",
+                    options=[
+                        SessionConfigSelectOption(value="opus-4.6", name="Opus"),
+                        SessionConfigSelectOption(value="haiku-4.5", name="Haiku"),
+                    ],
+                )
+            ],
+        )
+        assert model_ids_in_option(opt) == ["opus-4.6", "haiku-4.5"]
+
+
 class TestBuildHelpers:
     """The pre-bind aggregate builders."""
 
@@ -767,6 +829,14 @@ class _RecordingClient:
 
     async def kill_terminal(self, **kw: Any) -> Any:
         self.calls.append(("kill_terminal", kw))
+        return None
+
+    async def create_elicitation(self, **kw: Any) -> Any:
+        self.calls.append(("create_elicitation", kw))
+        return None
+
+    async def complete_elicitation(self, **kw: Any) -> None:
+        self.calls.append(("complete_elicitation", kw))
         return None
 
 
@@ -953,3 +1023,43 @@ class TestClientSideForwarders:
         name, kw = client.calls[-1]
         assert name == method
         assert kw == {"session_id": CLIENT_SESSION_ID, "terminal_id": "term-1"}
+
+
+class TestElicitationForwarding:
+    """The elicitation pair ACP 1.16 added to the ``Client`` protocol."""
+
+    def test_session_scoped_elicitation_gets_session_id_rewritten(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The backend's session id never leaks to the client — same rule as every other frame."""
+        from acp.schema import ElicitationFormSessionMode, ElicitationSchema
+
+        proxy, _backend, client = _bound_proxy(monkeypatch)
+        mode = ElicitationFormSessionMode(
+            session_id="be-1",
+            requested_schema=ElicitationSchema(properties={}, required=[]),
+        )
+        asyncio.run(proxy.create_elicitation(message="pick one", mode=mode))
+        name, kw = client.calls[-1]
+        assert name == "create_elicitation"
+        assert kw["message"] == "pick one"
+        assert kw["mode"].session_id == CLIENT_SESSION_ID
+
+    def test_request_scoped_elicitation_passes_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A request-scoped mode carries no session, so there is nothing to rewrite."""
+        from acp.schema import ElicitationFormRequestMode, ElicitationSchema
+
+        proxy, _backend, client = _bound_proxy(monkeypatch)
+        mode = ElicitationFormRequestMode(
+            request_id="req-9",
+            requested_schema=ElicitationSchema(properties={}, required=[]),
+        )
+        asyncio.run(proxy.create_elicitation(message="auth", mode=mode))
+        assert client.calls[-1][1]["mode"] is mode
+
+    def test_complete_elicitation_forwards(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        proxy, _backend, client = _bound_proxy(monkeypatch)
+        asyncio.run(proxy.complete_elicitation(elicitation_id="e-1"))
+        assert client.calls[-1] == ("complete_elicitation", {"elicitation_id": "e-1"})

--- a/uv.lock
+++ b/uv.lock
@@ -4,14 +4,14 @@ requires-python = ">=3.12, <3.15"
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.10.1"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/a0/3b96cd8374725c69bc3dae9fcc2082f3f6cafec1be35d24d7af0f8c3265f/agent_client_protocol-0.10.1.tar.gz", hash = "sha256:355c65ca19f0568344aafc2c1552b7066a8fc491df23ab28e7e253c6c9a85a25", size = 81924, upload-time = "2026-05-24T18:46:44.444Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/93/396d02c91b387b2678f23081869ca47bd495fc6c78789022c683180cf5f1/agent_client_protocol-0.11.0.tar.gz", hash = "sha256:8920a3b27bdcc852fd7c73066f47ab53257dbfbe57b505e20a40c69f80a5391c", size = 87402, upload-time = "2026-07-05T17:07:56.803Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/18/d8c7ff337cf621ea79a84006a7252ff057bfb5767549bb102cc6649f4ec2/agent_client_protocol-0.10.1-py3-none-any.whl", hash = "sha256:a03d3198f4d772f2e0ec012c00ac1cce131b4710220a3dc9fae3c991d047c750", size = 65401, upload-time = "2026-05-24T18:46:43.202Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/48/a1367dded7765f5489f9840389949d5aeac53a73aeb1b4e6c0ab61e1617a/agent_client_protocol-0.11.0-py3-none-any.whl", hash = "sha256:2d8570cd4911f8af9fbab4808f7b05f09204a756f346c7409ecdcae3f37cdb2f", size = 68089, upload-time = "2026-07-05T17:07:55.518Z" },
 ]
 
 [[package]]
@@ -2276,7 +2276,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", specifier = "==0.10.1" },
+    { name = "agent-client-protocol", specifier = "==0.11.0" },
     { name = "jinja2", specifier = "~=3.1" },
     { name = "prompt-toolkit", specifier = "~=3.0" },
     { name = "pydantic", specifier = "~=2.13" },


### PR DESCRIPTION
Supersedes #450 — carries dependabot's bump commit plus the code migration it needs.

Dependabot's branch lives in this repo's `dependabot/*` namespace and can't be pushed to from a fork, so the fix ships here instead. Merging this closes out the bump; #450 can be closed.

## Why #450 is red

`agent-client-protocol` 0.11.0 is a breaking API change (ACP schema v1.16.0), not a drop-in. On #450 as it stands:

- **Unit tests** — collection error, 2 modules:
  - `ImportError: cannot import name 'ModelInfo' from 'acp.schema'`
  - `ImportError: cannot import name 'SetSessionModelResponse' from 'acp.schema'`
- **typecheck** — `Found 13 errors in 3 files`

The lockfile itself was fine; only the code needed adapting.

## Root cause

ACP 1.16 **retires the dedicated model channel**. `session/set_model`, `SessionModelState` and `ModelInfo` are gone, and model selection folds into the generic config-option mechanism (`session/set_config_option`) that older Zed clients already used. The proxy used to speak both dialects; now there is only one, so the two paths collapse into one.

That removal also broke model **discovery** silently: `probe.py` read `NewSessionResponse.models`, a field that no longer exists. Nothing in CI caught it — it would have raised `AttributeError` against a real 0.11 wrapper at runtime. Models now come from the `category="model"` selector among the session's config options.

Which option is "the model one" is a rule two callers must agree on — the probe reads ids out of it, the proxy writes a pick into it — so it lives in one place (`find_model_option`). The proxy learns the *backend's* selector id from the backend's own `session/new` reply rather than assuming its own `"model"` convention holds downstream; a backend advertising no selector is a legitimate single-model wrapper, so a pick against it is a no-op rather than an error.

## The rest, mechanical

Per the SDK's [0.11 migration guide](https://github.com/agentclientprotocol/python-sdk/blob/main/docs/migration-guide-0.11.md):

- signatures realigned to the 0.11 argument order (`session_id` first on the client-side methods; `fork_session` / `resume_session` / `set_session_mode`)
- `message_id` dropped from `prompt`, `additionalDirectories` from `list_sessions` — both retired from their request models
- `create_elicitation` / `complete_elicitation` implemented (the two new `Client` protocol members), with the session-id rewrite every other backend → client frame already gets
- `AcpMcpServer` added to the mcp-server union, spelled once as `McpServerConfig` — `list` is invariant, so a missing member makes every forward a type error
- the two new plan-update variants added to the session-update payload

## Validation

`uv sync --locked` clean; **1102 unit tests pass**; integration tests collect and skip cleanly (no podman run). All CI gates green locally: `lint`, `tach`, `lint-imports`, `typecheck`, `security`, `docstrings`, `deadcode`, `reuse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated model discovery and selection to follow ACP 1.16 using configuration options.
  * Added support for forwarding elicitation requests and completions.

* **Bug Fixes**
  * Correctly handles backends that do not advertise model choices.
  * Fails fast when an elicitation can’t be created due to missing user context, and safely no-ops completion when none was opened.
  * Ensures retired prompt fields are not forwarded, and improves session-scoped update/forwarding behavior.

* **Chores**
  * Updated a pinned protocol dependency to `0.11.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->