### PR TITLE
fix(scripts): terok-trust-workspace states its usage

### DIFF
--- a/src/terok_executor/resources/scripts/terok-trust-workspace.py
+++ b/src/terok_executor/resources/scripts/terok-trust-workspace.py
@@ -101,4 +101,12 @@ def _minimal_dump(data: dict) -> str:
 
 
 if __name__ == "__main__":
+    # The wrapper always passes both, but the module claims to be
+    # standalone-safe -- so say what is missing instead of an IndexError.
+    if len(sys.argv) != 3:  # noqa: PLR2004 — argv[0] + the two documented args
+        print(
+            f"usage: {pathlib.Path(sys.argv[0]).name} <workspace-path> <trusted-folders-toml>",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     sys.exit(main(sys.argv[1], pathlib.Path(sys.argv[2])))


### PR DESCRIPTION
Noticed while triaging the code-scanning alerts on this file (all of which are false positives — the script's arguments are wrapper-controlled constants, and an agent invoking it directly gains nothing it cannot already do inside its own container).

The genuine nit: the module's docstring claims standalone-safety, but a direct call with no arguments died on `IndexError` before reaching `main()`. It now prints its usage and exits 2, like every other argv entry in the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)