### PR TITLE
fix(vault): stop flagging glab's settings-only config.yml as a leaked credential

### DIFF
--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -12,9 +12,9 @@ What lives here:
 
 - ``routes`` — regenerate ``routes.json`` from the YAML agent roster.
 - ``clean`` — remove leaked credential files from shared config mounts.
-- ``scan_leaked_credentials`` / ``_is_injected_credentials_file`` /
-  ``_is_injected_codex_auth_file`` — primitives the scan + clean
-  verbs share.
+- ``scan_leaked_credentials`` + the ``_BENIGN_CREDENTIAL_CHECKS``
+  registry of per-provider recognizers for credential files that are
+  legitimately non-empty — primitives the scan + clean verbs share.
 
 Both verbs operate on host-side files only.
 """
@@ -22,6 +22,7 @@ Both verbs operate on host-side files only.
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -82,6 +83,41 @@ def _is_injected_codex_auth_file(path: Path) -> bool:
     )
 
 
+def _is_tokenless_glab_config_file(path: Path) -> bool:
+    """Check whether *path* is a glab ``config.yml`` that carries no token.
+
+    glab's ``config.yml`` doubles as a settings file the tool rewrites on
+    startup (update-check metadata, ``git_protocol``, …), so its shared
+    mount is writable by design and a non-empty file is the expected
+    steady state — only a ``hosts.<host>.token`` entry makes it a leak.
+
+    Any parse error or unexpected structure → ``False`` (treat as real leak).
+    """
+    from .vendor_files import RawGlabConfigFile, load_vendor_yaml
+
+    try:
+        cred = load_vendor_yaml(RawGlabConfigFile, path)
+    except ValueError:
+        return False
+    if cred is None:
+        return False
+    return not any(block.token for block in cred.hosts.values())
+
+
+_BENIGN_CREDENTIAL_CHECKS: dict[str, Callable[[Path], bool]] = {
+    "claude": _is_injected_credentials_file,
+    "codex": _is_injected_codex_auth_file,
+    "glab": _is_tokenless_glab_config_file,
+}
+"""Per-provider recognizers for credential files that are legitimately non-empty.
+
+Maps the mount's owning agent name to a predicate that returns ``True``
+when the file holds no real secret: a terok-injected phantom (claude,
+codex) or a settings-only vendor file (glab).  Providers without an
+entry treat any non-empty credential file as a leak.
+"""
+
+
 def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     """Return ``(provider, host_path)`` for credential files found in shared mounts.
 
@@ -90,8 +126,9 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     into containers.  This function checks each routed provider's mount for
     credential files that would leak real tokens alongside phantom ones.
 
-    Files injected by `_write_claude_credentials_file`
-    are recognised by their dummy ``accessToken`` marker and skipped.
+    Non-empty files recognised as benign by the provider's
+    `_BENIGN_CREDENTIAL_CHECKS` entry — terok-injected phantoms, or
+    glab's settings-only ``config.yml`` — are skipped.
 
     Symlinks are rejected to prevent a container from tricking the scan into
     reading arbitrary host files via a crafted symlink in the shared mount.
@@ -121,9 +158,8 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
             # Ensure resolved path stays within the mounts base
             if base_resolved not in path.resolve(strict=True).parents:
                 continue
-            if st.st_size > 0 and not (
-                _is_injected_credentials_file(path) or _is_injected_codex_auth_file(path)
-            ):
+            is_benign = _BENIGN_CREDENTIAL_CHECKS.get(mount.provider)
+            if st.st_size > 0 and not (is_benign and is_benign(path)):
                 leaked.append((mount.provider, path))
         except (OSError, TypeError) as exc:
             # Silently skipping turns a real leak into a no-result: the

--- a/tests/unit/test_vault_routes.py
+++ b/tests/unit/test_vault_routes.py
@@ -247,6 +247,94 @@ class TestScanLeakedCredentials:
         assert "No leaked" in capsys.readouterr().out
 
 
+class TestGlabConfigScan:
+    """glab's ``config.yml`` mixes settings and credentials — only a token is a leak.
+
+    The shared mount is writable by design (glab rewrites the file on
+    startup), so a non-empty settings-only file is the expected steady
+    state and must not be reported as a leaked credential.
+    """
+
+    def _write_glab_config(self, tmp_path: Path, content: str) -> Path:
+        """Materialise *content* as glab's credential file in a mock mount tree."""
+        from terok_executor import AgentRoster
+
+        roster = AgentRoster.shared()
+        mount = next(m for m in roster.mounts if m.provider == "glab" and m.credential_file)
+        cred_dir = tmp_path / mount.host_dir
+        cred_dir.mkdir(parents=True)
+        cred_file = cred_dir / mount.credential_file
+        cred_file.write_text(content)
+        return cred_file
+
+    def test_settings_only_config_not_flagged(self, tmp_path: Path) -> None:
+        """A config.yml holding only glab settings is benign."""
+        from terok_executor.credentials.vault_commands import scan_leaked_credentials
+
+        self._write_glab_config(
+            tmp_path,
+            'last_seen_version: v1.107.0\nlast_update_check_timestamp: "2026-07-13T22:05:22+02:00"\n',
+        )
+
+        assert "glab" not in [p for p, _ in scan_leaked_credentials(tmp_path)]
+
+    def test_config_with_token_flagged(self, tmp_path: Path) -> None:
+        """A config.yml carrying a hosts.<host>.token entry is a real leak."""
+        from terok_executor.credentials.vault_commands import scan_leaked_credentials
+
+        cred_file = self._write_glab_config(
+            tmp_path,
+            "git_protocol: ssh\nhosts:\n  gitlab.com:\n    token: glpat-real-secret\n",
+        )
+
+        assert ("glab", cred_file) in scan_leaked_credentials(tmp_path)
+
+    def test_unparseable_config_flagged(self, tmp_path: Path) -> None:
+        """A config.yml the scanner cannot parse is treated as a leak."""
+        from terok_executor.credentials.vault_commands import scan_leaked_credentials
+
+        cred_file = self._write_glab_config(tmp_path, "hosts: [not, a, mapping]\n")
+
+        assert ("glab", cred_file) in scan_leaked_credentials(tmp_path)
+
+
+class TestTokenlessGlabConfigFile:
+    """Verify _is_tokenless_glab_config_file classifies vendor files correctly."""
+
+    def test_tokenless_config_is_benign(self, tmp_path: Path) -> None:
+        """Settings-only config (no hosts section) reads as tokenless."""
+        from terok_executor.credentials.vault_commands import _is_tokenless_glab_config_file
+
+        cred_file = tmp_path / "config.yml"
+        cred_file.write_text("check_update: true\n")
+
+        assert _is_tokenless_glab_config_file(cred_file) is True
+
+    def test_empty_host_block_is_benign(self, tmp_path: Path) -> None:
+        """A hosts entry without a token (e.g. api_protocol only) reads as tokenless."""
+        from terok_executor.credentials.vault_commands import _is_tokenless_glab_config_file
+
+        cred_file = tmp_path / "config.yml"
+        cred_file.write_text("hosts:\n  gitlab.com:\n    api_protocol: https\n")
+
+        assert _is_tokenless_glab_config_file(cred_file) is True
+
+    def test_token_is_not_benign(self, tmp_path: Path) -> None:
+        """Any non-empty hosts.<host>.token makes the file a credential."""
+        from terok_executor.credentials.vault_commands import _is_tokenless_glab_config_file
+
+        cred_file = tmp_path / "config.yml"
+        cred_file.write_text("hosts:\n  gitlab.example.com:\n    token: glpat-abc\n")
+
+        assert _is_tokenless_glab_config_file(cred_file) is False
+
+    def test_missing_file_is_not_benign(self, tmp_path: Path) -> None:
+        """A missing file cannot be vouched for."""
+        from terok_executor.credentials.vault_commands import _is_tokenless_glab_config_file
+
+        assert _is_tokenless_glab_config_file(tmp_path / "config.yml") is False
+
+
 class TestVaultCommandHandlers:
     """Verify executor's vault CLI command handlers.
 


### PR DESCRIPTION
## Problem

Since #412 made glab's config mount writable (so the tool can start), glab persists update-check metadata (`last_seen_version`, `last_update_check_timestamp`) in the shared `config.yml`. `scan_leaked_credentials` treated any non-empty credential file it didn't recognize as a leak — it only knew the claude/codex phantom markers — so every task start after the first in-container glab invocation warned:

```
Real credential in shared mount for provider glab
```

…with no credential anywhere in the file.

## Fix

- Generalize the injected-file recognizers into a per-provider `_BENIGN_CREDENTIAL_CHECKS` registry (claude → phantom `.credentials.json`, codex → phantom `auth.json`, glab → settings-only `config.yml`), keyed by the mount's owning agent, replacing the try-every-marker-on-every-file loop.
- New `_is_tokenless_glab_config_file`: parses `config.yml` with the existing `RawGlabConfigFile` vendor model and vouches for the file only when no `hosts.<host>.token` is present. Unparseable or unexpected content still counts as a leak.

A side benefit: `vault clean` no longer deletes glab's legitimate settings file.

## Tests

- Scan-level: settings-only config not flagged; config with a `hosts.gitlab.com.token` flagged; unparseable config flagged.
- Unit: `_is_tokenless_glab_config_file` classification (tokenless / host block without token / token / missing file).

Companion terok PR turns the remaining (real) findings into red errors at task start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)