### PR TITLE
feat(instructions): render the bundled default per package family

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a4/terok_sandbox-0.5.0a4-py3-none-any.whl",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a5/terok_sandbox-0.5.0a5-py3-none-any.whl",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
     "tomli-w~=1.2",
@@ -91,7 +91,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.4.0a4"
+fallback-version = "0.4.0a5"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_executor"]

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
         ImageBuilder as ImageBuilder,
         ImageSet as ImageSet,
         build_project_image as build_project_image,
+        known_family as known_family,
     )
     from .container.cache import seed_workspace_from_clone_cache as seed_workspace_from_clone_cache
     from .container.env import (
@@ -157,6 +158,7 @@ _LAZY: dict[str, str] = {
     "ImageBuilder": ".container.build",
     "ImageSet": ".container.build",
     "build_project_image": ".container.build",
+    "known_family": ".container.build",
     # Container environment assembly
     "ContainerEnvSpec": ".container.env",
     "assemble_container_env": ".container.env",

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -371,8 +371,8 @@ class ImageBuilder:
 # ── Underlying free functions (now private — call via ImageBuilder) ──
 
 
-def detect_family(base_image: str, override: str | None = None) -> str:
-    """Resolve the package family (``deb`` or ``rpm``) for *base_image*.
+def known_family(base_image: str, override: str | None = None) -> str | None:
+    """The package family (``deb``/``rpm``) for *base_image*, or ``None`` if unrecognized.
 
     *override* — when set, must be ``"deb"`` or ``"rpm"`` and wins over
     detection (used to support unknown bases via project config).
@@ -381,8 +381,7 @@ def detect_family(base_image: str, override: str | None = None) -> str:
     (Ubuntu/Debian, Fedora, the official Podman container, NVIDIA CUDA/HPC
     SDK).  NVIDIA images are inspected at the tag level so UBI variants
     (e.g. ``…:13.0.0-devel-ubi9``) resolve to ``rpm`` while Ubuntu
-    variants resolve to ``deb``.  Unknown images raise [`BuildError`][terok_executor.container.build.BuildError]
-    with a hint to set ``family:`` explicitly.
+    variants resolve to ``deb``.
     """
     if override is not None:
         if override not in {"deb", "rpm"}:
@@ -393,10 +392,23 @@ def detect_family(base_image: str, override: str | None = None) -> str:
     for prefix, fam in _KNOWN_FAMILIES:
         if name_lc == prefix or name_lc.startswith(prefix + "/"):
             return fam(tag) if callable(fam) else fam
-    raise BuildError(
-        f"Cannot infer package family for base image {base_image!r}. "
-        "Set `family: deb` or `family: rpm` under image: in project.yml."
-    )
+    return None
+
+
+def detect_family(base_image: str, override: str | None = None) -> str:
+    """Resolve the package family for *base_image*, raising for unknown images.
+
+    Same detection as [`known_family`][terok_executor.container.build.known_family], except that an
+    unrecognized image raises [`BuildError`][terok_executor.container.build.BuildError] with a hint to set
+    ``family:`` explicitly — an image build cannot proceed without one.
+    """
+    family = known_family(base_image, override)
+    if family is None:
+        raise BuildError(
+            f"Cannot infer package family for base image {base_image!r}. "
+            "Set `family: deb` or `family: rpm` under image: in project.yml."
+        )
+    return family
 
 
 def build_project_image(

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -1181,11 +1181,15 @@ class AgentRunner:
         *project_root* is passed to [`resolve_instructions`][terok_executor.resolve_instructions] so that
         ``<repo>/instructions.md`` is appended when present.
         """
+        from terok_executor.container.build import known_family
         from terok_executor.provider.agents import AgentConfigSpec, prepare_agent_config_dir
         from terok_executor.provider.instructions import resolve_instructions
 
         resolved_instructions = instructions or resolve_instructions(
-            {}, agent, project_root=project_root
+            {},
+            agent,
+            project_root=project_root,
+            family=known_family(self._base_image, self._family),
         )
 
         spec = AgentConfigSpec(

--- a/src/terok_executor/provider/instructions.py
+++ b/src/terok_executor/provider/instructions.py
@@ -33,6 +33,8 @@ def resolve_instructions(
     config: dict[str, Any],
     agent_name: str,
     project_root: Path | None = None,
+    *,
+    family: str | None = None,
 ) -> str:
     """Resolve instructions from a merged config dict.
 
@@ -42,6 +44,10 @@ def resolve_instructions(
     - List (with ``_inherit``): splices bundled default at each ``_inherit`` sentinel
     - Absent/None: returns bundled default
 
+    *family* is the task image's package family (``"deb"``/``"rpm"``, or
+    ``None`` when unknown) — wherever the bundled default is used, its
+    package-manager guidance is rendered for that family.
+
     After resolving the YAML value, appends the contents of
     ``project_root/instructions.md`` (if it exists and is non-empty).
 
@@ -50,7 +56,7 @@ def resolve_instructions(
     from .providers import resolve_agent_value
 
     val = config.get("instructions")
-    default = bundled_default_instructions()
+    default = bundled_default_instructions(family)
 
     if val is None:
         base = default
@@ -93,10 +99,26 @@ def has_custom_instructions(
     return bool(project_root and (project_root / "instructions.md").is_file())
 
 
-def bundled_default_instructions() -> str:
-    """Read and return the bundled default instructions from package resources."""
+def bundled_default_instructions(family: str | None = None) -> str:
+    """Render the bundled default instructions for a package *family*.
+
+    The bundled ``default.md`` is a Jinja2 template branching on *family*,
+    like the Dockerfile templates: package-manager guidance renders as
+    ``apt`` for ``"deb"`` bases and ``dnf`` for ``"rpm"`` bases, and stays
+    deliberately generic when the family is unknown (``None``) — better no
+    tool advice than wrong tool advice.
+    """
+    from jinja2 import BaseLoader, Environment
+
     ref = importlib.resources.files("terok_executor.resources.instructions").joinpath("default.md")
-    return ref.read_text(encoding="utf-8")
+    env = Environment(  # nosec B701 — Markdown output, not HTML
+        loader=BaseLoader(),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+        autoescape=False,
+    )
+    return env.from_string(ref.read_text(encoding="utf-8")).render(family=family)
 
 
 # ── Private helpers ──────────────────────────────────────────────────────

--- a/src/terok_executor/resources/instructions/default.md
+++ b/src/terok_executor/resources/instructions/default.md
@@ -11,14 +11,20 @@ You are running inside an isolated Podman container managed by terok.
 ## Privileges
 
 - You can use `sudo` without a password to install packages, modify system config, etc.
+{% if family == "deb" %}
 - Use `sudo apt install <package>` for any tools you need.
+{% elif family == "rpm" %}
+- Use `sudo dnf install <package>` for any tools you need.
+{% else %}
+- Use the image's package manager for any tools you need.
+{% endif %}
 - The environment is disposable — feel free to install, configure, and experiment.
 
 ## Pre-installed tools
 
 git, gh (GitHub CLI), glab (GitLab CLI), rg (ripgrep), fd-find, jq, yq, ast-grep (structural code search/rewrite using AST patterns; `ast-grep run -p 'PATTERN' -l LANG` to search), toad (multi-agent TUI via ACP; `toad` to launch, `toad -a claude` to skip agent selection).
 
-Python 3 and Node.js are available. Use `sudo apt install` or `pip`/`npm` for anything else.
+Python 3 and Node.js are available. Use {% if family == "deb" %}`sudo apt install`{% elif family == "rpm" %}`sudo dnf install`{% else %}the image's package manager{% endif %} or `pip`/`npm` for anything else.
 
 ## Git workflow
 

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -20,6 +20,7 @@ from terok_executor.container.build import (
     build_base_images,
     build_sidecar_image,
     detect_family,
+    known_family,
     l0_image_tag,
     l1_image_tag,
     l1_sidecar_image_tag,
@@ -1346,6 +1347,28 @@ class TestDetectFamily:
     def test_blank_falls_back_to_default(self) -> None:
         # _normalize_base_image turns blank into fedora:44 → rpm.
         assert detect_family("") == "rpm"
+
+
+class TestKnownFamily:
+    """The lenient variant: ``None`` for unrecognized images instead of raising."""
+
+    def test_unknown_returns_none(self) -> None:
+        assert known_family("rockylinux:9") is None
+
+    @pytest.mark.parametrize(
+        ("base_image", "expected"),
+        [("ubuntu:24.04", "deb"), ("fedora:44", "rpm")],
+    )
+    def test_known_matches_detect_family(self, base_image: str, expected: str) -> None:
+        assert known_family(base_image) == expected == detect_family(base_image)
+
+    def test_override_wins_for_unknown(self) -> None:
+        assert known_family("rockylinux:9", override="rpm") == "rpm"
+
+    def test_invalid_override_still_rejected(self) -> None:
+        # A bad explicit ``family:`` is a config error, not an unknown image.
+        with pytest.raises(BuildError, match="must be 'deb' or 'rpm'"):
+            known_family("ubuntu:24.04", override="alpine")
 
 
 class TestRenderFamilyAware:

--- a/tests/unit/test_instructions.py
+++ b/tests/unit/test_instructions.py
@@ -48,6 +48,31 @@ class TestBundledDefault:
         assert "sudo" in DEFAULT_INSTRUCTIONS
         assert "git" in DEFAULT_INSTRUCTIONS.lower()
 
+    @pytest.mark.parametrize(
+        ("family", "tool", "other_tool"),
+        [("deb", "sudo apt install", "dnf"), ("rpm", "sudo dnf install", "apt")],
+    )
+    def test_family_renders_its_package_manager(
+        self, family: str, tool: str, other_tool: str
+    ) -> None:
+        """Each family sees its own package manager and never the other's."""
+        text = bundled_default_instructions(family)
+        assert tool in text
+        assert other_tool not in text
+
+    def test_unknown_family_stays_generic(self) -> None:
+        """No family → no distro-specific claims that could be untrue."""
+        assert "apt" not in DEFAULT_INSTRUCTIONS
+        assert "dnf" not in DEFAULT_INSTRUCTIONS
+        assert "package manager" in DEFAULT_INSTRUCTIONS
+
+    @pytest.mark.parametrize("family", ["deb", "rpm", None])
+    def test_no_unrendered_jinja_leaks(self, family: str | None) -> None:
+        """The template renders fully for every family value."""
+        text = bundled_default_instructions(family)
+        assert "{%" not in text
+        assert "{{" not in text
+
 
 class TestResolveInstructions:
     """Tests for resolve_instructions()."""
@@ -87,6 +112,14 @@ class TestResolveInstructions:
     ) -> None:
         """Instructions resolve correctly for various config shapes."""
         assert resolve_instructions(config, provider) == expected
+
+    def test_family_reaches_the_spliced_default(self) -> None:
+        """*family* renders the bundled default wherever ``_inherit`` splices it."""
+        text = resolve_instructions(
+            {"instructions": ["Project preamble.", "_inherit"]}, "claude", family="rpm"
+        )
+        assert text.startswith("Project preamble.")
+        assert "sudo dnf install" in text
 
 
 class TestFileAppend:

--- a/uv.lock
+++ b/uv.lock
@@ -2205,8 +2205,8 @@ wheels = [
 
 [[package]]
 name = "terok-clearance"
-version = "0.8.0a3"
-source = { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a3/terok_clearance-0.8.0a3-py3-none-any.whl" }
+version = "0.8.0a4"
+source = { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a4/terok_clearance-0.8.0a4-py3-none-any.whl" }
 dependencies = [
     { name = "asyncvarlink" },
     { name = "dbus-fast" },
@@ -2214,7 +2214,7 @@ dependencies = [
     { name = "terok-util" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a3/terok_clearance-0.8.0a3-py3-none-any.whl", hash = "sha256:5e9303a4e28e0dba624ddd0d31713cdf54ed3828d50d7edf6ef419a48295ef8a" },
+    { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a4/terok_clearance-0.8.0a4-py3-none-any.whl", hash = "sha256:323f59219887c8e754956bad917eef204066034c0c898c5217bca0f236035e07" },
 ]
 
 [package.metadata]
@@ -2222,7 +2222,7 @@ requires-dist = [
     { name = "asyncvarlink", specifier = "==0.3.2" },
     { name = "dbus-fast", specifier = "~=5.0" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -2276,8 +2276,8 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a4/terok_sandbox-0.5.0a4-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a5/terok_sandbox-0.5.0a5-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
 
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a4"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a4/terok_sandbox-0.5.0a4-py3-none-any.whl" }
+version = "0.5.0a5"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a5/terok_sandbox-0.5.0a5-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2329,7 +2329,7 @@ dependencies = [
     { name = "terok-util" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a4/terok_sandbox-0.5.0a4-py3-none-any.whl", hash = "sha256:f3dfbe48d99b2461b8e5f23a23811eba4481aa4f61b2c32dc22db55832137b0c" },
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a5/terok_sandbox-0.5.0a5-py3-none-any.whl", hash = "sha256:03ba82d422f9c98b994f44f13d6720409aba8811d2868324cee2c836e2dfe3db" },
 ]
 
 [package.metadata]
@@ -2344,42 +2344,42 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
     { name = "sqlcipher3", specifier = "==0.6.2" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a3/terok_clearance-0.8.0a3-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a3/terok_shield-0.8.0a3-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl" },
+    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a4/terok_clearance-0.8.0a4-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a4/terok_shield-0.8.0a4-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a3"
-source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a3/terok_shield-0.8.0a3-py3-none-any.whl" }
+version = "0.8.0a4"
+source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a4/terok_shield-0.8.0a4-py3-none-any.whl" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a3/terok_shield-0.8.0a3-py3-none-any.whl", hash = "sha256:1be0e315299eac88d07b935edd2256352caab9038066a46966f2a1c49e398353" },
+    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a4/terok_shield-0.8.0a4-py3-none-any.whl", hash = "sha256:08c1e4f15ca41b626ca082934815f739a2274c338e89d2aeae2acb974ca894b4" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "terok-util"
-version = "0.3.0"
-source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl" }
+version = "0.3.1a1"
+source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.0/terok_util-0.3.0-py3-none-any.whl", hash = "sha256:966c66ed4de17c18247c65ccb8dba45060e1bced804a305ec1794b30bd9a9f4e" },
+    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a1/terok_util-0.3.1a1-py3-none-any.whl", hash = "sha256:f75d4ef6db5587b5297ffe9c166103b5d6ede63a5014d8dfb6667211fd505bbd" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## Problem

The bundled `default.md` hardcodes `sudo apt install` — untrue on rpm-based task images. On a Fedora base, agents follow the instruction into `apt-get: command not found` detours at the start of nearly every session (observed repeatedly in real terok task transcripts).

## Change

- `resources/instructions/default.md` is now a Jinja2 template branching on a `family` variable — the same convention the L0/L1 Dockerfile templates and roster snippets already use. `deb` → apt, `rpm` → dnf, unknown → neutral "use the image's package manager" wording, so unknown bases never receive a potentially untrue command.
- `bundled_default_instructions(family=None)` renders the template; `resolve_instructions(..., family=None)` threads it through every place the bundled default is used (including `_inherit` splices).
- New `known_family(base_image, override)` in `container.build` — the lenient sibling of `detect_family()` that returns `None` for unrecognized images instead of raising (an invalid explicit override still raises: that's a config error, not an unknown image). `detect_family()` is now a strict wrapper over it. Exported from the package root for callers that resolve instructions outside an image build (terok will pass the project's family from its call sites).
- `AgentRunner._prepare_agent_config` passes `known_family(self._base_image, self._family)`.

## Testing

- New tests: per-family rendering (each family sees only its own tool), neutral unknown-family output, no unrendered Jinja leakage, `_inherit` splice threading, `known_family` lenient/override semantics.
- `make check` green except 6 pre-existing baseline failures in `test_auth_capture.py` that need the `podman` binary (fail identically on clean master in this environment; podman-dependent tests are run on the test machine per policy).

## Follow-up

terok wires `family` into its `resolve_instructions` call sites and drops its stale orphaned copy of `default.md` (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)