### PR TITLE
feat(scripts): providers surfaces locked providers and the host-side unlock

### DIFF
--- a/src/terok_executor/resources/scripts/hilfe
+++ b/src/terok_executor/resources/scripts/hilfe
@@ -81,7 +81,9 @@ _terok_providers() {
         done
     fi
     printf '\n'
-    [ -n "$_byproto" ] && printf '%s\n' "$_byproto"
+    # Blank line between the authenticated-providers sentence and the
+    # wire-protocol table — without it the two dense lines read as one.
+    [ -n "$_byproto" ] && printf '\n%s\n' "$_byproto"
     printf '  Point any agent at a provider it speaks to: \033[36m<agent> --provider <name>\033[0m\n'
     printf '  (e.g. \033[36mopencode --provider openrouter\033[0m).  \033[36mopencode\033[0m reaches any of them;\n'
     printf '  native CLIs default to their own.  Ready pairs: \033[36mproviders\033[0m\n'

--- a/src/terok_executor/resources/scripts/hilfe
+++ b/src/terok_executor/resources/scripts/hilfe
@@ -69,7 +69,7 @@ _terok_providers() {
     # Nothing authenticated and nothing to suggest → skip the section entirely.
     [ -n "$_list" ] || [ -n "$_byproto" ] || return 0
 
-    printf '\n\033[1mProviders (LLM endpoints):\033[0m'
+    printf '\n\033[1mReady providers (LLM endpoints):\033[0m'
     if [ -n "$_list" ]; then
         # Authenticated providers in magenta, joined so the line reads as a sentence.
         local _first=1 _p

--- a/src/terok_executor/resources/scripts/providers
+++ b/src/terok_executor/resources/scripts/providers
@@ -8,7 +8,11 @@
 A friendlier view of ``~/.terok/agents.json`` (written per task by
 ``terok-agents``) — grouped by agent, coloured, ready pairs only.  ``--all``
 also lists the pairs that aren't ready (and why-not is implicit: the provider
-doesn't serve the agent's wire protocol, or isn't authenticated).
+doesn't serve the agent's wire protocol, or isn't authenticated), plus the
+locked providers — candidates no one has authenticated yet, which the user
+can unlock by running ``terok auth <provider>`` on the host.  The default
+view compresses that into a one-line hint so the unlock path is never more
+than one command away.
 
 Agents are the CLI tools (cyan, matching ``hilfe``); providers are the LLM
 endpoints (magenta).  Self-contained (stdlib only): it runs inside task
@@ -46,9 +50,11 @@ def main(argv: list[str]) -> int:
     for pair in manifest.get("pairs", []):
         bucket = ready if pair.get("ready") else blocked
         bucket[pair["agent"]].append(pair["provider"])
+    locked = _locked_providers(manifest)
 
     if not ready and not blocked:
         print("No (agent, provider) pairs — authenticate a provider on the host.", file=sys.stderr)
+        _print_locked(locked)
         return 0
 
     agents = sorted(ready if not show_all else {**ready, **blocked})
@@ -62,9 +68,59 @@ def main(argv: list[str]) -> int:
         for agent in sorted(blocked):
             names = ", ".join(sorted(set(blocked[agent])))
             print(f"  {_DIM}{agent:<{width}}  {names}{_RESET}")
+        _print_locked(locked)
     else:
         print(f"\n{_DIM}Use: <agent> --provider <name>   ·   not-ready too: providers --all{_RESET}")
+        _print_locked_hint(locked)
     return 0
+
+
+def _locked_providers(manifest: dict) -> list[tuple[str, list[str]]]:
+    """Return ``(protocol, providers)`` rows for the not-yet-authenticated candidates.
+
+    Derived from the manifest's ``protocols`` view: per wire protocol in play,
+    the candidate providers minus the authenticated ones.  Protocols whose
+    candidates are all authenticated drop out — there is nothing to unlock.
+    """
+    rows: list[tuple[str, list[str]]] = []
+    for row in manifest.get("protocols", []):
+        if not isinstance(row, dict):
+            continue
+        authed = set(row.get("authenticated") or [])
+        candidates = [p for p in row.get("candidates") or [] if p not in authed]
+        if candidates:
+            rows.append((str(row.get("protocol")), candidates))
+    return rows
+
+
+def _print_locked(locked: list[tuple[str, list[str]]]) -> None:
+    """Print the locked-providers section: what to authenticate on the host.
+
+    One row per wire protocol (matching the ``hilfe`` providers section, so the
+    protocol column links a dimmed agent to the providers that would enable
+    it), headed by the unlock command.  Prints nothing when nothing is locked.
+    """
+    if not locked:
+        return
+    print(
+        f"\n{_BOLD}Locked providers{_RESET}"
+        f"{_DIM} — unlock on the host:{_RESET} terok auth {_MAGENTA}<provider>{_RESET}"
+    )
+    width = max(len(protocol) for protocol, _ in locked)
+    for protocol, providers in locked:
+        print(f"  {_DIM}{protocol:<{width}}  {', '.join(providers)}{_RESET}")
+
+
+def _print_locked_hint(locked: list[tuple[str, list[str]]]) -> None:
+    """Print the default view's one-line pointer at the locked providers."""
+    if not locked:
+        return
+    count = len({provider for _, providers in locked for provider in providers})
+    noun = "provider" if count == 1 else "providers"
+    print(
+        f"{_DIM}{count} locked {noun} — unlock on the host: "
+        f"terok auth <provider>   ·   list: providers --all{_RESET}"
+    )
 
 
 if __name__ == "__main__":

--- a/src/terok_executor/resources/scripts/providers
+++ b/src/terok_executor/resources/scripts/providers
@@ -70,8 +70,9 @@ def main(argv: list[str]) -> int:
             print(f"  {_DIM}{agent:<{width}}  {names}{_RESET}")
         _print_locked(locked)
     else:
-        print(f"\n{_DIM}Use: <agent> --provider <name>   ·   not-ready too: providers --all{_RESET}")
+        print(f"\n{_DIM}Also list non-ready providers:{_RESET} providers --all")
         _print_locked_hint(locked)
+        print(f"\n{_DIM}Use:{_RESET} {_CYAN}<agent>{_RESET} --provider {_MAGENTA}<name>{_RESET}")
     return 0
 
 
@@ -118,8 +119,8 @@ def _print_locked_hint(locked: list[tuple[str, list[str]]]) -> None:
     count = len({provider for _, providers in locked for provider in providers})
     noun = "provider" if count == 1 else "providers"
     print(
-        f"{_DIM}{count} locked {noun} — unlock on the host: "
-        f"terok auth <provider>   ·   list: providers --all{_RESET}"
+        f"{_DIM}{count} locked {noun} — unlock on the host:{_RESET} "
+        f"terok auth {_MAGENTA}<provider>{_RESET}"
     )
 
 

--- a/src/terok_executor/resources/scripts/providers
+++ b/src/terok_executor/resources/scripts/providers
@@ -42,7 +42,7 @@ def main(argv: list[str]) -> int:
     try:
         manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        print(f"No readiness manifest at {MANIFEST} — run inside a terok task.", file=sys.stderr)
+        print(f"No readiness manifest at {MANIFEST} - run inside a terok task.", file=sys.stderr)
         return 1
 
     ready: dict[str, list[str]] = defaultdict(list)
@@ -53,7 +53,7 @@ def main(argv: list[str]) -> int:
     locked = _locked_providers(manifest)
 
     if not ready and not blocked:
-        print("No (agent, provider) pairs — authenticate a provider on the host.", file=sys.stderr)
+        print("No (agent, provider) pairs - authenticate a provider on the host.", file=sys.stderr)
         _print_locked(locked)
         return 0
 
@@ -105,7 +105,7 @@ def _print_locked(locked: list[tuple[str, list[str]]]) -> None:
         return
     print(
         f"\n{_BOLD}Locked providers{_RESET}"
-        f"{_DIM} — unlock on the host:{_RESET} terok auth {_MAGENTA}<provider>{_RESET}"
+        f"{_DIM} - unlock on the host:{_RESET} terok auth {_MAGENTA}<provider>{_RESET}"
     )
     width = max(len(protocol) for protocol, _ in locked)
     for protocol, providers in locked:
@@ -119,7 +119,7 @@ def _print_locked_hint(locked: list[tuple[str, list[str]]]) -> None:
     count = len({provider for _, providers in locked for provider in providers})
     noun = "provider" if count == 1 else "providers"
     print(
-        f"{_DIM}{count} locked {noun} — unlock on the host:{_RESET} "
+        f"{_DIM}{count} locked {noun} - unlock on the host:{_RESET} "
         f"terok auth {_MAGENTA}<provider>{_RESET}"
     )
 

--- a/src/terok_executor/resources/scripts/terok-agents.py
+++ b/src/terok_executor/resources/scripts/terok-agents.py
@@ -250,14 +250,14 @@ def render_provider_protocols(protocols: object) -> str:
     if not rows:
         return ""
     width = max(len(str(r["protocol"])) for r in rows)
-    lines = [f"  {_DIM}Providers by wire protocol (authenticate one to enable its agents):{_RESET}"]
+    lines = [f"{_DIM}Providers by wire protocol (authenticate one to enable its agents):{_RESET}"]
     for row in rows:
         authed = set(row.get("authenticated") or [])
         names = ", ".join(
             f"{_MAGENTA}{p}{_RESET}" if p in authed else f"{_DIM}{p}{_RESET}"
             for p in row["candidates"]
         )
-        lines.append(f"    {str(row['protocol']):<{width}}  {names}")
+        lines.append(f"  {str(row['protocol']):<{width}}  {names}")
     return "\n".join(lines)
 
 

--- a/tests/unit/test_providers_command.py
+++ b/tests/unit/test_providers_command.py
@@ -131,7 +131,7 @@ class TestLockedProviders:
         out, _ = _run(command, monkeypatch, tmp_path, capsys, ANTHROPIC_ONLY_MANIFEST)
         plain = _plain(out)
         # openrouter, blablador, kisski, mistral, openai — distinct across protocols.
-        assert "5 locked providers — unlock on the host: terok auth <provider>" in plain
+        assert "5 locked providers - unlock on the host: terok auth <provider>" in plain
         assert "Also list non-ready providers: providers --all" in plain
         assert "Use: <agent> --provider <name>" in plain
         # The full per-protocol breakdown stays behind --all.

--- a/tests/unit/test_providers_command.py
+++ b/tests/unit/test_providers_command.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from types import ModuleType
@@ -20,6 +21,13 @@ from types import ModuleType
 import pytest
 
 import terok_executor.resources.scripts as _scripts_pkg
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    """Strip SGR escapes so assertions read the text a user actually sees."""
+    return _ANSI_RE.sub("", text)
 
 
 def _load_command() -> ModuleType:
@@ -121,10 +129,11 @@ class TestLockedProviders:
     ) -> None:
         """The default view compresses the locked list into a one-line pointer."""
         out, _ = _run(command, monkeypatch, tmp_path, capsys, ANTHROPIC_ONLY_MANIFEST)
+        plain = _plain(out)
         # openrouter, blablador, kisski, mistral, openai — distinct across protocols.
-        assert "5 locked providers" in out
-        assert "terok auth <provider>" in out
-        assert "providers --all" in out
+        assert "5 locked providers — unlock on the host: terok auth <provider>" in plain
+        assert "Also list non-ready providers: providers --all" in plain
+        assert "Use: <agent> --provider <name>" in plain
         # The full per-protocol breakdown stays behind --all.
         assert "Locked providers" not in out
 

--- a/tests/unit/test_providers_command.py
+++ b/tests/unit/test_providers_command.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the in-container ``providers`` command.
+
+Exercises the ``providers`` script that renders the readiness manifest inside
+task containers.  Like ``terok-agents`` it is staged into the image (not
+importable by module name), so it is loaded from its source path and driven
+against synthetic manifests, with output captured via ``capsys``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+import terok_executor.resources.scripts as _scripts_pkg
+
+
+def _load_command() -> ModuleType:
+    """Load the staged ``providers`` script as an importable module.
+
+    Loading by path (rather than by package name) is required because the
+    file is shipped into the container image, not exposed as a Python module.
+    """
+    script_path = Path(_scripts_pkg.__file__).parent / "providers"
+    loader = SourceFileLoader("providers_command", str(script_path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def command() -> ModuleType:
+    """The loaded ``providers`` command module."""
+    return _load_command()
+
+
+def _pair(agent: str, provider: str, protocol: str, *, ready: bool) -> dict:
+    """One manifest pair in the shape ``terok-agents`` writes."""
+    return {"agent": agent, "provider": provider, "protocol": protocol, "ready": ready}
+
+
+# A container where only anthropic is authenticated: claude is ready, the
+# openai-protocol agents are blocked, and every other candidate provider in
+# the baked universe is waiting to be authenticated on the host.
+ANTHROPIC_ONLY_MANIFEST = {
+    "version": 2,
+    "pairs": [
+        _pair("claude", "anthropic", "anthropic-messages", ready=True),
+        _pair("codex", "anthropic", "openai-responses", ready=False),
+        _pair("vibe", "anthropic", "openai-chat", ready=False),
+    ],
+    "protocols": [
+        {
+            "protocol": "anthropic-messages",
+            "candidates": ["anthropic", "openrouter"],
+            "authenticated": ["anthropic"],
+        },
+        {
+            "protocol": "openai-chat",
+            "candidates": ["blablador", "kisski", "mistral", "openai", "openrouter"],
+            "authenticated": [],
+        },
+        {"protocol": "openai-responses", "candidates": ["openai"], "authenticated": []},
+    ],
+}
+
+
+def _run(
+    command: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    manifest: dict,
+    *argv: str,
+) -> tuple[str, str]:
+    """Run the command against *manifest* and return ``(stdout, stderr)``."""
+    manifest_path = tmp_path / "agents.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setattr(command, "MANIFEST", manifest_path)
+    assert command.main(["providers", *argv]) == 0
+    captured = capsys.readouterr()
+    return captured.out, captured.err
+
+
+class TestLockedProviders:
+    """Unauthenticated candidates surface with the host-side unlock command."""
+
+    def test_all_lists_locked_candidates_per_protocol(
+        self,
+        command: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--all`` renders one locked row per protocol, headed by the command."""
+        out, _ = _run(command, monkeypatch, tmp_path, capsys, ANTHROPIC_ONLY_MANIFEST, "--all")
+        assert "Locked providers" in out
+        assert "unlock on the host:" in out
+        assert "terok auth" in out
+        assert "openai-chat" in out
+        assert "blablador, kisski, mistral, openai, openrouter" in out
+        # The authenticated candidate is not offered for unlocking again.
+        assert "anthropic-messages" in out
+        assert "anthropic, openrouter" not in out
+
+    def test_default_view_hints_with_a_count(
+        self,
+        command: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The default view compresses the locked list into a one-line pointer."""
+        out, _ = _run(command, monkeypatch, tmp_path, capsys, ANTHROPIC_ONLY_MANIFEST)
+        # openrouter, blablador, kisski, mistral, openai — distinct across protocols.
+        assert "5 locked providers" in out
+        assert "terok auth <provider>" in out
+        assert "providers --all" in out
+        # The full per-protocol breakdown stays behind --all.
+        assert "Locked providers" not in out
+
+    def test_nothing_authenticated_still_lists_locked(
+        self,
+        command: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """With zero pairs the locked section is the actionable part of the output."""
+        manifest = {
+            "version": 2,
+            "pairs": [],
+            "protocols": [
+                {"protocol": "openai-chat", "candidates": ["openrouter"], "authenticated": []}
+            ],
+        }
+        out, err = _run(command, monkeypatch, tmp_path, capsys, manifest)
+        assert "authenticate a provider on the host" in err
+        assert "Locked providers" in out
+        assert "openrouter" in out
+
+    def test_no_hint_when_everything_is_authenticated(
+        self,
+        command: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Fully-authenticated protocols leave nothing to unlock — no hint, no section."""
+        manifest = {
+            "version": 2,
+            "pairs": [_pair("claude", "anthropic", "anthropic-messages", ready=True)],
+            "protocols": [
+                {
+                    "protocol": "anthropic-messages",
+                    "candidates": ["anthropic"],
+                    "authenticated": ["anthropic"],
+                }
+            ],
+        }
+        for argv in ([], ["--all"]):
+            out, _ = _run(command, monkeypatch, tmp_path, capsys, manifest, *argv)
+            assert "locked" not in out.lower()
+
+    def test_manifest_without_protocols_view_stays_quiet(
+        self,
+        command: ModuleType,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A manifest lacking the ``protocols`` view renders as before, hint-free."""
+        manifest = {
+            "version": 2,
+            "pairs": [_pair("claude", "anthropic", "anthropic-messages", ready=True)],
+        }
+        out, _ = _run(command, monkeypatch, tmp_path, capsys, manifest, "--all")
+        assert "Ready agent" in out
+        assert "locked" not in out.lower()


### PR DESCRIPTION
## Problem

Inside a task container, `providers` / `providers --all` only render (agent × authenticated-provider) pairs. When an agent shows up under *Not ready (protocol mismatch or unauthenticated)*, nothing tells the user that more providers exist for its protocol, or that the fix is to authenticate one **on the host**. (`hilfe` at least dims the unauthenticated candidates by color; `providers` gave no signal at all.)

## Change

The manifest's `protocols` view (candidate providers per wire protocol + authenticated subset, baked from the roster) already carries the answer — `providers` just never read it. Now:

- **`providers --all`** gains a section, one row per wire protocol (mirroring the `hilfe` providers section so the protocol column links a blocked agent to its enabling providers), listing only the not-yet-authenticated candidates:

  ```
  Locked providers — unlock on the host: terok auth <provider>
    anthropic-messages  openrouter
    openai-chat         blablador, kisski, mistral, openai, openrouter
    openai-responses    openai
  ```

- **default view** compresses that into a one-line dim hint:

  ```
  5 locked providers — unlock on the host: terok auth <provider>   ·   list: providers --all
  ```

- **zero pairs** (nothing authenticated): the locked section now prints alongside the existing stderr nudge, so the first thing a fresh user sees is the concrete list of providers to authenticate.

`terok auth` accepts every candidate name shown (harness providers under their own names; `openai`/`anthropic`/`mistral` resolve via the auth-entry aliases).

Also in `hilfe`: a blank line now separates the authenticated-providers sentence (`Providers (LLM endpoints): anthropic, blablador`) from the `Providers by wire protocol` table — without it the two dense blocks read as one.

## Tests

New `tests/unit/test_providers_command.py` loads the staged script by path (same pattern as `test_readiness.py`) and covers: the `--all` per-protocol section, the default-view count hint, the zero-pairs case, the everything-authenticated case (no hint at all), and a manifest without the `protocols` view (stays quiet).

`make check` green except 6 pre-existing `test_auth_capture.py` failures that need `podman` (absent in the dev container, to be run on the test machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `providers` command now identifies providers that require host-side authentication.
  * The default view displays a concise unlock hint with the provider count.
  * Use `--all` to view locked providers by protocol, including available unlock instructions.
  * Locked-provider details are omitted when all providers are authenticated or no protocol data is available.

* **Tests**
  * Added coverage for locked-provider detection, output formatting, authentication states, and manifests without protocol information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
