### PR TITLE
refactor(runner): narrow piped log stream with cast, not assert

### DIFF
--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -22,7 +22,7 @@ import sys
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, cast
 
 from terok_executor._util import detect_host_timezone
 from terok_executor.integrations.sandbox import SandboxConfig, Sharing, VolumeSpec
@@ -1214,8 +1214,8 @@ class AgentRunner:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
             )
-            assert proc.stdout is not None
-            for line in proc.stdout:
+            stdout = cast(IO[bytes], proc.stdout)
+            for line in stdout:
                 sys.stdout.buffer.write(line)
                 sys.stdout.buffer.flush()
             proc.wait(timeout=timeout)


### PR DESCRIPTION
Part of a cross-repo assert sweep (independent per repo) toward running under `python -O` for faster task startup — asserts are compiled out under `-O`, so nothing load-bearing may depend on one, and Bandit/Sonar flag production asserts regardless.

The only production assert was mypy type-narrowing on the headless `podman logs -f` stream (`stdout=PIPE`). Swapped for `typing.cast`; no behaviour change.