### PR TITLE
feat(preflight): warn when podman predates the tested 4.3 floor

### DIFF
--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -25,6 +25,14 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
+MIN_PODMAN_VERSION = (4, 3)
+"""Oldest podman the launch path is tested against.
+
+4.3 introduced the ``keep-id:uid=…`` userns mode terok prefers and
+matches the oldest distro in the test matrix (Debian 12).  Older
+clients are warned about, not blocked: terok-util downgrades the
+userns args for them, so launches degrade rather than break."""
+
 
 @dataclass(frozen=True)
 class CheckResult:
@@ -200,7 +208,13 @@ class Preflight:
     # ── Prerequisite probes ────────────────────────────────────────
 
     def check_podman(self) -> CheckResult:  # noqa: PLR6301
-        """Verify that podman is installed and responds to ``podman version``."""
+        """Verify that podman is installed, responds, and meets the tested version floor.
+
+        A podman older than [`MIN_PODMAN_VERSION`][terok_executor.preflight.MIN_PODMAN_VERSION]
+        still passes (``ok``) — launches degrade rather than break, and
+        blocking would kill unofficial use on frozen-distro hosts — but
+        the result message carries the warning instead of a bare "ok".
+        """
         if not shutil.which("podman"):
             return CheckResult("podman", False, "not found on PATH")
         try:
@@ -214,6 +228,15 @@ class Preflight:
         if result.returncode != 0:
             detail = (result.stderr or b"").decode(errors="ignore").strip() or "non-zero exit"
             return CheckResult("podman", False, f"found but not responding: {detail}")
+        version = (result.stdout or b"").decode(errors="ignore").strip()
+        if _version_below_floor(version):
+            floor = ".".join(map(str, MIN_PODMAN_VERSION))
+            return CheckResult(
+                "podman",
+                True,
+                f"version {version} is older than the tested minimum {floor} — "
+                "unsupported; expect degraded behavior",
+            )
         return CheckResult("podman", True, "ok")
 
     def check_git(self) -> CheckResult:  # noqa: PLR6301
@@ -426,6 +449,19 @@ def _fix_credentials(
 
 
 # ── Printing ───────────────────────────────────────────────────────────
+
+
+def _version_below_floor(version: str) -> bool:
+    """Whether *version* parses and sits below the tested podman floor.
+
+    Unparseable output counts as modern — the probe already proved the
+    binary responds, and a false warning helps nobody.
+    """
+    try:
+        major, minor = (int(part) for part in version.split(".")[:2])
+    except ValueError:
+        return False
+    return (major, minor) < MIN_PODMAN_VERSION
 
 
 def _print_step(result: CheckResult) -> None:

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -50,7 +50,9 @@ def test_podman_below_floor_warns_but_passes(_which: MagicMock, mock_run: MagicM
 def test_podman_floor_boundary_is_plain_ok(_which: MagicMock, mock_run: MagicMock) -> None:
     """Podman 4.3 itself is the tested floor — no warning."""
     mock_run.return_value = MagicMock(returncode=0, stdout=b"4.3.0\n", stderr=b"")
-    assert _pf().check_podman().message == "ok"
+    r = _pf().check_podman()
+    assert r.ok is True
+    assert r.message == "ok"
 
 
 @patch("terok_executor.preflight.subprocess.run")

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -29,7 +29,38 @@ def _pf(**overrides) -> Preflight:
 def test_podman_ok(_which: MagicMock, mock_run: MagicMock) -> None:
     """Podman found and responds → ok."""
     mock_run.return_value = MagicMock(returncode=0, stdout=b"5.0.0\n", stderr=b"")
-    assert _pf().check_podman().ok is True
+    r = _pf().check_podman()
+    assert r.ok is True
+    assert r.message == "ok"
+
+
+@patch("terok_executor.preflight.subprocess.run")
+@patch("terok_executor.preflight.shutil.which", return_value="/usr/bin/podman")
+def test_podman_below_floor_warns_but_passes(_which: MagicMock, mock_run: MagicMock) -> None:
+    """A pre-4.3 podman passes with a degraded-behavior warning, not a FAIL."""
+    mock_run.return_value = MagicMock(returncode=0, stdout=b"3.4.4\n", stderr=b"")
+    r = _pf().check_podman()
+    assert r.ok is True
+    assert "3.4.4" in r.message
+    assert "degraded" in r.message
+
+
+@patch("terok_executor.preflight.subprocess.run")
+@patch("terok_executor.preflight.shutil.which", return_value="/usr/bin/podman")
+def test_podman_floor_boundary_is_plain_ok(_which: MagicMock, mock_run: MagicMock) -> None:
+    """Podman 4.3 itself is the tested floor — no warning."""
+    mock_run.return_value = MagicMock(returncode=0, stdout=b"4.3.0\n", stderr=b"")
+    assert _pf().check_podman().message == "ok"
+
+
+@patch("terok_executor.preflight.subprocess.run")
+@patch("terok_executor.preflight.shutil.which", return_value="/usr/bin/podman")
+def test_podman_unparseable_version_is_plain_ok(_which: MagicMock, mock_run: MagicMock) -> None:
+    """Garbage version output counts as modern — the binary already responded."""
+    mock_run.return_value = MagicMock(returncode=0, stdout=b"weird\n", stderr=b"")
+    r = _pf().check_podman()
+    assert r.ok is True
+    assert r.message == "ok"
 
 
 @patch("terok_executor.preflight.shutil.which", return_value=None)


### PR DESCRIPTION
## Problem

`check_podman` runs `podman version --format {{.Client.Version}}` but throws the value away — only responsiveness is checked. A frozen-distro podman (Ubuntu 22.04's 3.4.4 being the live example) passes preflight cleanly and then fails at launch with `Error: unrecognized namespace mode keep-id:uid=1000,gid=1000`.

## Fix

Declare the tested floor explicitly — `MIN_PODMAN_VERSION = (4, 3)`, the release that introduced `keep-id:uid=…` and the version shipped by the oldest matrix distro (Debian 12) — and parse the probed version against it.

Below the floor the check stays **ok** but the step message carries the warning:

```
  podman                 ok (version 3.4.4 is older than the tested minimum 4.3 — unsupported; expect degraded behavior)
```

Warn-not-block is deliberate: terok-util downgrades the userns args for pre-4.3 clients (terok-ai/terok-util#73), so launches degrade rather than break, and unofficial use on frozen-distro hosts stays reachable. Unparseable version output counts as modern — the binary already proved responsive, and a false warning helps nobody.

Pairs with terok-ai/terok-util#73 but has no ordering dependency on it.

## Testing

- 4 new unit tests: below-floor warns-but-passes, 4.3.0 boundary plain ok, modern plain ok, unparseable-version plain ok.
- `make lint` clean; full suite 1132 passed + 6 pre-existing environment failures (`test_auth_capture.py` needs a real `podman` binary, absent in the dev container); docstrings 98.1%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preflight checks now recognize Podman versions below the tested minimum and keep the check non-blocking while showing an explicit “older than tested minimum…unsupported; expect degraded behavior” warning.
  * Podman versions at or above the tested minimum continue to report a standard **ok** message without warnings.
  * Unparseable `podman version` output is treated as passing with an **ok** message.
* **Tests**
  * Expanded unit coverage for below-floor, at-floor, and unparseable version scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->