### PR TITLE
fix(vault): stop warning when a never-authenticated agent has no credential file

### DIFF
--- a/src/terok_executor/credentials/vault_commands.py
+++ b/src/terok_executor/credentials/vault_commands.py
@@ -130,6 +130,11 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
     `_BENIGN_CREDENTIAL_CHECKS` entry — terok-injected phantoms, or
     glab's settings-only ``config.yml`` — are skipped.
 
+    A credential file that does not exist is a definitive clean result,
+    not a skipped check: an agent that ships in the image but was never
+    authenticated on this host has nothing to leak.  Only genuine read
+    failures (permissions, I/O errors) warrant the skip warning.
+
     Symlinks are rejected to prevent a container from tricking the scan into
     reading arbitrary host files via a crafted symlink in the shared mount.
     """
@@ -161,6 +166,10 @@ def scan_leaked_credentials(mounts_base: Path) -> list[tuple[str, Path]]:
             is_benign = _BENIGN_CREDENTIAL_CHECKS.get(mount.provider)
             if st.st_size > 0 and not (is_benign and is_benign(path)):
                 leaked.append((mount.provider, path))
+        except FileNotFoundError:
+            # No credential file at all — the agent was never authenticated
+            # on this host, so there is nothing to scan and nothing to leak.
+            continue
         except (OSError, TypeError) as exc:
             # Silently skipping turns a real leak into a no-result: the
             # operator would believe the scan was clean.  Surface a

--- a/tests/unit/test_vault_scan_warning.py
+++ b/tests/unit/test_vault_scan_warning.py
@@ -1,14 +1,19 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression for #86 — ``scan_leaked_credentials`` warns when it skips a provider.
+"""``scan_leaked_credentials`` skip semantics: warn on failures, not on absence.
 
-The scan used to ``except (OSError, TypeError): continue`` silently, so
-an operator running it on a not-yet-mounted shared dir would see an
-empty result and conclude "no leaks found" — when in fact zero
-providers had been checked.  The fix surfaces a per-provider warning
-on stderr while keeping the loop going so other providers still get
+Regression for #86 — the scan used to ``except (OSError, TypeError):
+continue`` silently, so an operator would see an empty result and
+conclude "no leaks found" when a provider's credential file existed
+but could not be read.  The fix surfaces a per-provider warning on
+stderr while keeping the loop going so other providers still get
 scanned.
+
+That warning must not fire for a credential file that simply does not
+exist: an agent that ships in the image but was never authenticated on
+the host has nothing to leak, so absence is a definitive clean result
+— not a skipped check.
 """
 
 from __future__ import annotations
@@ -21,33 +26,36 @@ import pytest
 from terok_executor.credentials.vault_commands import scan_leaked_credentials
 
 
-class TestScanLeakedCredentialsWarnsOnSkip:
-    """A non-existent provider dir surfaces a warning and doesn't break the scan."""
+def _mount(provider: str, host_dir: str, credential_file: str) -> MagicMock:
+    """Build a roster mount stub with the three fields the scan reads."""
+    mount = MagicMock()
+    mount.provider = provider
+    mount.host_dir = host_dir
+    mount.credential_file = credential_file
+    return mount
 
-    def test_missing_mount_warns_and_continues(
+
+class TestScanLeakedCredentialsSkipSemantics:
+    """Missing credential files pass silently; unreadable ones warn."""
+
+    def test_missing_mount_is_silent_and_scan_continues(
         self,
         tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """A provider whose mount dir is missing yields a warning naming it."""
-        # Two mounts: one has a credential file present, one's dir is missing.
+        """A provider whose credential file doesn't exist produces no warning."""
         roster = MagicMock()
-        mount_present = MagicMock()
-        mount_present.provider = "claude"
-        mount_present.host_dir = "_claude-config"
-        mount_present.credential_file = ".credentials.json"
-        mount_missing = MagicMock()
-        mount_missing.provider = "codex"
-        mount_missing.host_dir = "_codex-config"
-        mount_missing.credential_file = ".auth.json"
-        roster.mounts = [mount_present, mount_missing]
+        roster.mounts = [
+            _mount("claude", "_claude-config", ".credentials.json"),
+            _mount("glab", "_glab-config", "config.yml"),
+        ]
 
-        # Set up only the claude mount with a leaked-looking file.
+        # Only the claude mount exists, with a leaked-looking file; the
+        # glab agent ships in the image but was never set up on the host.
         (tmp_path / "_claude-config").mkdir()
         (tmp_path / "_claude-config" / ".credentials.json").write_text(
             '{"accessToken": "real-secret"}'
         )
-        # The codex provider's mount dir is intentionally absent → lstat raises.
 
         with (
             patch("terok_executor.roster.loader._shared_roster", return_value=roster),
@@ -55,16 +63,54 @@ class TestScanLeakedCredentialsWarnsOnSkip:
                 "terok_executor.credentials.vault_commands._is_injected_credentials_file",
                 return_value=False,
             ),
+        ):
+            leaked = scan_leaked_credentials(tmp_path)
+
+        # The present provider still gets reported; the absent one is clean.
+        assert leaked == [("claude", tmp_path / "_claude-config" / ".credentials.json")]
+        assert capsys.readouterr().err == ""
+
+    def test_unreadable_file_warns_and_scan_continues(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A credential file that exists but can't be read warns, naming the provider."""
+        roster = MagicMock()
+        roster.mounts = [
+            _mount("codex", "_codex-config", ".auth.json"),
+            _mount("claude", "_claude-config", ".credentials.json"),
+        ]
+
+        for host_dir, name in (
+            ("_codex-config", ".auth.json"),
+            ("_claude-config", ".credentials.json"),
+        ):
+            (tmp_path / host_dir).mkdir()
+            (tmp_path / host_dir / name).write_text('{"accessToken": "real-secret"}')
+
+        real_lstat = Path.lstat
+
+        def deny_codex(self: Path, *args: object, **kwargs: object) -> object:
+            if self.name == ".auth.json":
+                raise PermissionError(13, "Permission denied")
+            return real_lstat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "lstat", deny_codex)
+
+        with (
+            patch("terok_executor.roster.loader._shared_roster", return_value=roster),
             patch(
-                "terok_executor.credentials.vault_commands._is_injected_codex_auth_file",
+                "terok_executor.credentials.vault_commands._is_injected_credentials_file",
                 return_value=False,
             ),
         ):
             leaked = scan_leaked_credentials(tmp_path)
 
-        # The present provider still gets reported.
-        assert ("claude", tmp_path / "_claude-config" / ".credentials.json") in leaked
-        # The missing one produced a warning naming it; the scan kept going.
+        # The readable provider still gets reported.
+        assert leaked == [("claude", tmp_path / "_claude-config" / ".credentials.json")]
+        # The unreadable one produced a warning naming it; the scan kept going.
         err = capsys.readouterr().err
         assert "codex" in err
         assert "vault" in err.lower()


### PR DESCRIPTION
## Problem

Every task launch prints a scary vault warning when an agent ships in the image but was never authenticated on the host:

```
Warning [vault]: credential leak scan skipped 'glab': [Errno 2] No such file or directory:
'.../mounts/_glab-config/config.yml'
```

`scan_leaked_credentials()` catches `(OSError, TypeError)` and prints the skipped-provider warning introduced for #86 — but `FileNotFoundError` is an `OSError`, so the perfectly normal "agent installed, never set up" state lands in the failure branch.

## Fix

A missing credential file is a **definitive clean result** — nothing to scan, nothing to leak — not an incomplete check. The scan now silently continues on `FileNotFoundError` and keeps the warning for genuine read failures (permissions, I/O errors), which is what #86 was actually about ("credential files that can't be read").

The regression test flips accordingly: the missing-mount case now asserts silence, and a new case pins the warning to an unreadable-but-existing file (`PermissionError`), so #86's guarantee stays covered.

`make check` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing credential files are now treated as clean results without generating warnings.
  * Read or permission failures continue to display a warning while allowing scans to proceed for other providers.
* **Tests**
  * Added coverage confirming correct handling of absent and unreadable credential files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->