### PR TITLE
fix(opencode-provider): announce the model-list refresh and fail it with a reason

### DIFF
--- a/src/terok_executor/resources/scripts/opencode-provider
+++ b/src/terok_executor/resources/scripts/opencode-provider
@@ -25,7 +25,7 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Any
-from urllib import error, request
+from urllib import request
 
 # Hardcoded fallbacks for manual invocation (when env vars not set)
 _FALLBACK_PROVIDERS = {
@@ -138,7 +138,14 @@ def _load_api_key(config: dict[str, str]) -> str | None:
 
 
 def _fetch_models(base_url: str, api_key: str) -> list[str] | None:
-    """Fetch available models from the API. Returns None on failure."""
+    """Fetch available models from the API. Returns None on failure.
+
+    ``OSError`` is the whole network-failure family here — ``HTTPError``,
+    ``URLError`` and the socket-level ``TimeoutError`` a half-dead proxy
+    produces are all subclasses.  A failure is announced with its reason
+    rather than swallowed: the fetch can stall for the full timeout, and
+    a silent ``None`` would leave the user staring at a frozen launcher.
+    """
     url = base_url.rstrip("/") + "/models"
     req = request.Request(
         url,
@@ -151,7 +158,8 @@ def _fetch_models(base_url: str, api_key: str) -> list[str] | None:
     try:
         with request.urlopen(req, timeout=30) as resp:  # nosec B310
             payload = json.loads(resp.read().decode("utf-8"))
-    except (error.HTTPError, error.URLError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Warning: model-list refresh from {url} failed: {exc}", file=sys.stderr)
         return None
 
     items = []
@@ -371,7 +379,9 @@ def main() -> int:
     )
     base_url = base_url.rstrip("/")
 
-    # Fetch models from API
+    # Fetch models from API — announce first: the refresh can legitimately
+    # take up to the 30s timeout, and a silent launcher reads as frozen.
+    print(f"Updating the model list from {config['display_name']}...", file=sys.stderr)
     fetched_models = _fetch_models(base_url, api_key)
 
     if args.list_models:

--- a/tests/unit/test_native_provider.py
+++ b/tests/unit/test_native_provider.py
@@ -407,3 +407,43 @@ class TestPiProvider:
         monkeypatch.setattr(pp.os, "execvpe", lambda f, a, e: captured.update(argv=a))
         pp.main(["hi"])
         assert captured["argv"] == ["pi", "hi"]
+
+
+class TestOpencodeModelFetchFeedback:
+    """The model-list refresh announces itself and fails with a reason.
+
+    Regression: the refresh can stall for its full 30s timeout (e.g. a
+    half-dead vault bridge that accepts but never answers), and the
+    socket-level ``TimeoutError`` escaped the ``URLError``-only handler —
+    a silent freeze followed by a raw traceback.
+    """
+
+    def test_timeout_returns_none_with_reason(
+        self, ocp: ModuleType, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A socket-level timeout → ``None`` plus a stderr warning, no traceback."""
+
+        def _hang(*_a, **_k):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(ocp.request, "urlopen", _hang)
+        assert ocp._fetch_models(_LOOPBACK + "/v1", "tok") is None
+        err = capsys.readouterr().err
+        assert "model-list refresh" in err
+        assert "timed out" in err
+
+    def test_main_announces_the_refresh(
+        self, ocp: ModuleType, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """``main`` prints the update notice before fetching — no silent freeze."""
+        monkeypatch.setattr(ocp.sys, "argv", ["blablador"])
+        monkeypatch.setenv("TEROK_OC_BLABLADOR_BASE_URL", _LOOPBACK + "/v1")
+        monkeypatch.setenv("TEROK_OC_BLABLADOR_DISPLAY_NAME", "Helmholtz Blablador")
+        monkeypatch.setenv("TEROK_OC_BLABLADOR_ENV_VAR_PREFIX", "BLABLADOR")
+        monkeypatch.setenv("TEROK_PROVIDER_BLABLADOR_TOKEN", "tok")
+        monkeypatch.setattr(ocp, "_fetch_models", lambda *a: None)
+        monkeypatch.setattr(ocp, "_write_opencode_config", lambda *a: None)
+        monkeypatch.setattr(ocp.os.path, "exists", lambda _p: False)
+        monkeypatch.setattr(ocp.subprocess, "call", lambda cmd, env=None: 0)
+        assert ocp.main() == 0
+        assert "Updating the model list from Helmholtz Blablador" in capsys.readouterr().err


### PR DESCRIPTION
Observed on hal8999: `blablador` sat silent for 30s (model-list refresh stalling against a half-dead vault bridge that accepted the connection but never answered), then died with a raw `TimeoutError` traceback out of `urllib`.

Two fixes in the launcher, independent of the underlying host problem:

- **Announce the refresh** (`Updating the model list from <display name>...` on stderr) before the fetch — the fetch can legitimately take up to its 30s timeout, and a silent launcher reads as frozen.
- **Catch the whole network-failure family.** The handler listed `HTTPError`/`URLError`/`JSONDecodeError`, so the socket-level `TimeoutError` from a stalled read escaped as a traceback. `OSError` covers all three (`HTTPError` → `URLError` → `OSError`, `TimeoutError` ⊂ `OSError`); a failed fetch now degrades gracefully with its reason printed (`Warning: model-list refresh from <url> failed: ...`) and the existing cached/pinned-model fallback takes over.

Regression tests for both. Full unit suite green (1141 passed).

Independent, no pins — the script ships into containers at image build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model-list refresh error handling so connection and timeout failures display a clear warning instead of causing an unexpected traceback.
  * Added a status message when refreshing models from the selected provider.
* **Tests**
  * Added coverage for refresh failures and confirmation that refresh notifications appear before the update begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->