### PR TITLE
fix(build): version-aware force-pull flag — podman 3.x spells it --pull-always

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a7/terok_sandbox-0.5.0a7-py3-none-any.whl",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox@feat/pull-always-podman3",
+    "terok-util @ git+https://github.com/sliwowitz/terok-util@feat/pull-always-podman3",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
     "tomli-w~=1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox@feat/pull-always-podman3",
-    "terok-util @ git+https://github.com/sliwowitz/terok-util@feat/pull-always-podman3",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a8/terok_sandbox-0.5.0a8-py3-none-any.whl",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
     "tomli-w~=1.2",
@@ -91,7 +91,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.4.0a7"
+fallback-version = "0.4.0a8"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_executor"]

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -984,7 +984,11 @@ BUILD_COMMAND = CommandDef(
             help='Comma-separated roster entries to install, or "all" (default).',
         ),
         ArgDef(name="--rebuild", action="store_true", help="Force rebuild (cache bust)"),
-        ArgDef(name="--full-rebuild", action="store_true", help="Force --no-cache --pull=always"),
+        ArgDef(
+            name="--full-rebuild",
+            action="store_true",
+            help="Force --no-cache and re-pull of base images",
+        ),
         ArgDef(name="--sidecar", action="store_true", help="Also build sidecar L1 (CodeRabbit)"),
     ),
 )

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -58,6 +58,7 @@ from pathlib import Path
 from typing import Any
 
 from jinja2 import BaseLoader, Environment
+from terok_util import podman_pull_always_args
 
 # ── Vocabulary ──
 
@@ -456,7 +457,7 @@ def build_project_image(
     if no_cache:
         cmd.append("--no-cache")
     if pull_always:
-        cmd.append("--pull=always")
+        cmd += podman_pull_always_args()
     cmd.append(str(context_dir))
 
     print("$", shlex.join(cmd))
@@ -494,7 +495,7 @@ def build_base_images(
             ``depends_on``).  Same selection drives the OCI label, the L1
             tag suffix, the in-container manifest, and the help fragments.
         rebuild: Force rebuild with cache bust (refreshes agent installs).
-        full_rebuild: Force rebuild with ``--no-cache --pull=always``.
+        full_rebuild: Force rebuild with ``--no-cache`` and a forced base-image re-pull.
         build_dir: Build context directory (must be empty or absent).
         tag_as_default: When ``True``, additionally tag the L1 with the
             unsuffixed default-alias [`l1_image_tag(base_image)`][terok_executor.container.build.l1_image_tag].

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -281,6 +281,31 @@ class TestBuildProjectImage:
         assert "--no-cache" in cmd
         assert "--pull=always" in cmd
 
+    def test_pull_flag_spelling_follows_host_podman(self, tmp_path: Path) -> None:
+        """Old podman gets ``--pull-always`` — the helper's spelling is passed through."""
+        from unittest.mock import patch
+
+        from terok_executor.container.build import build_project_image
+
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.touch()
+        with (
+            patch(
+                "terok_executor.container.build.podman_pull_always_args",
+                return_value=["--pull-always"],
+            ),
+            patch("subprocess.run") as run_mock,
+        ):
+            build_project_image(
+                dockerfile=dockerfile,
+                context_dir=tmp_path,
+                target_tag="proj:tag",
+                pull_always=True,
+            )
+        cmd = run_mock.call_args[0][0]
+        assert "--pull-always" in cmd
+        assert "--pull=always" not in cmd
+
     def test_missing_podman_becomes_build_error(self, tmp_path: Path) -> None:
         from unittest.mock import patch
 

--- a/uv.lock
+++ b/uv.lock
@@ -2205,13 +2205,24 @@ wheels = [
 
 [[package]]
 name = "terok-clearance"
-version = "0.8.0a6.dev198+gd087c02d5"
-source = { git = "https://github.com/sliwowitz/terok-clearance?rev=feat%2Fpull-always-podman3#d087c02d5abb0737b26aaaf30a2863ed5d2894db" }
+version = "0.8.0a6"
+source = { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" }
 dependencies = [
     { name = "asyncvarlink" },
     { name = "dbus-fast" },
     { name = "pyyaml" },
     { name = "terok-util" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl", hash = "sha256:8c23580825510e1b46bd799838178c6245898b9794e1701dc952d812d9e147f5" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "asyncvarlink", specifier = "==0.3.2" },
+    { name = "dbus-fast", specifier = "~=5.0" },
+    { name = "pyyaml", specifier = "~=6.0" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -2265,8 +2276,8 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fpull-always-podman3" },
-    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util?rev=feat%2Fpull-always-podman3" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a8/terok_sandbox-0.5.0a8-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
 
@@ -2300,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a8.dev409+ga2a7bfe2d"
-source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fpull-always-podman3#a2a7bfe2dc74103ae57ba037e53e5a8b42b815b0" }
+version = "0.5.0a8"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a8/terok_sandbox-0.5.0a8-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2317,25 +2328,65 @@ dependencies = [
     { name = "terok-shield" },
     { name = "terok-util" },
 ]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a8/terok_sandbox-0.5.0a8-py3-none-any.whl", hash = "sha256:34c2cdf462b00bfc5095b9e9b484f0950bdb63bacf10d5e211f4c26ac1c15db5" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = "~=3.14.1" },
+    { name = "cryptography", specifier = "~=49.0" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "keyring", specifier = "~=25.7" },
+    { name = "packaging", specifier = "~=26.2" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "prompt-toolkit", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "sqlcipher3", specifier = "==0.6.2" },
+    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
+]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a6.dev330+g56aefe4ae"
-source = { git = "https://github.com/sliwowitz/terok-shield?rev=feat%2Fpull-always-podman3#56aefe4aed8d71ca57f318a7390662951701cc4e" }
+version = "0.8.0a6"
+source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl", hash = "sha256:b9ea5a1bf79380b931a80088eb92469116a072b09456745716e71ec8c1306dc5" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "pyyaml", specifier = "~=6.0" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
+]
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a3.dev69+ge29c9c537"
-source = { git = "https://github.com/sliwowitz/terok-util?rev=feat%2Fpull-always-podman3#e29c9c5372e523da154378beb92631e33bfe9bf1" }
+version = "0.3.1a3"
+source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl", hash = "sha256:dc579905a4c9d815ccadb8370834002a9f2f0c0f2fd35d42e58140e7563799c1" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2205,24 +2205,13 @@ wheels = [
 
 [[package]]
 name = "terok-clearance"
-version = "0.8.0a5"
-source = { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a5/terok_clearance-0.8.0a5-py3-none-any.whl" }
+version = "0.8.0a6.dev198+gd087c02d5"
+source = { git = "https://github.com/sliwowitz/terok-clearance?rev=feat%2Fpull-always-podman3#d087c02d5abb0737b26aaaf30a2863ed5d2894db" }
 dependencies = [
     { name = "asyncvarlink" },
     { name = "dbus-fast" },
     { name = "pyyaml" },
     { name = "terok-util" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a5/terok_clearance-0.8.0a5-py3-none-any.whl", hash = "sha256:8c78a411dbbd71ebb631eb9c1023df3b808ec544e940e2cd41d11481206ad0c1" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "asyncvarlink", specifier = "==0.3.2" },
-    { name = "dbus-fast", specifier = "~=5.0" },
-    { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -2276,8 +2265,8 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a7/terok_sandbox-0.5.0a7-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl" },
+    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fpull-always-podman3" },
+    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util?rev=feat%2Fpull-always-podman3" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
 
@@ -2311,8 +2300,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a7"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a7/terok_sandbox-0.5.0a7-py3-none-any.whl" }
+version = "0.5.0a8.dev409+ga2a7bfe2d"
+source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fpull-always-podman3#a2a7bfe2dc74103ae57ba037e53e5a8b42b815b0" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2328,65 +2317,25 @@ dependencies = [
     { name = "terok-shield" },
     { name = "terok-util" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a7/terok_sandbox-0.5.0a7-py3-none-any.whl", hash = "sha256:9c289d416f42caf012dcea6fcb66addb640890575fcf31814be50f6798e4ec92" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = "~=3.14.1" },
-    { name = "cryptography", specifier = "~=49.0" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "keyring", specifier = "~=25.7" },
-    { name = "packaging", specifier = "~=26.2" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "sqlcipher3", specifier = "==0.6.2" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a5/terok_clearance-0.8.0a5-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a5/terok_shield-0.8.0a5-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl" },
-]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a5"
-source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a5/terok_shield-0.8.0a5-py3-none-any.whl" }
+version = "0.8.0a6.dev330+g56aefe4ae"
+source = { git = "https://github.com/sliwowitz/terok-shield?rev=feat%2Fpull-always-podman3#56aefe4aed8d71ca57f318a7390662951701cc4e" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a5/terok_shield-0.8.0a5-py3-none-any.whl", hash = "sha256:c688d9feed9c3bb5a0acb9304d7d7454d24c30e7a9b0b0cf87e3673fa7b86b97" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl" },
-]
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a2"
-source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl" }
+version = "0.3.1a3.dev69+ge29c9c537"
+source = { git = "https://github.com/sliwowitz/terok-util?rev=feat%2Fpull-always-podman3#e29c9c5372e523da154378beb92631e33bfe9bf1" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a2/terok_util-0.3.1a2-py3-none-any.whl", hash = "sha256:f0172db426bb5a0dd18e45d044453c231bd02e5cea82355ca370813aa6edee1f" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

On podman 3.x hosts, `--full-rebuild` (and terok's full image rebuild) fails before building anything:

```
Error: invalid argument "always" for "--pull" flag: strconv.ParseBool: parsing "always": invalid syntax
```

Podman 4.0 turned `build --pull` into a policy option; 3.x takes it as a boolean and spells the force-pull request `--pull-always`. `build_project_image` now emits the flag via terok-util's new `podman_pull_always_args()` (terok-ai/terok-util#75), which probes the podman version once (cached) and picks the spelling the host accepts — modern hosts keep `--pull=always`, nothing is downgraded.

Doc/help mentions of the literal flag are reworded to be spelling-neutral.

## Chain

Bottom-up: terok-ai/terok-util#75 → terok-ai/terok-shield#399 + terok-ai/terok-clearance#207 (repins only) → terok-ai/terok-sandbox#462 (repins only) → this PR. Branch pins to be replaced by release wheels via the release chain.

## Test plan
- New unit test pins the helper to the old spelling and asserts pass-through; existing `--pull=always` assertions still pass (probe fallback is the modern baseline).
- Full `make check` green (1147 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)