### PR TITLE
feat(gpu): device-grant selectors pass through (sandbox gpu-device-grants chain)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox@feat/gpu-device-grants",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a10/terok_sandbox-0.5.0a10-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
@@ -91,7 +91,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.4.0a9"
+fallback-version = "0.4.0a10"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_executor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a9/terok_sandbox-0.5.0a9-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox@feat/gpu-device-grants",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -777,7 +777,7 @@ RUN_COMMAND = CommandDef(
         ),
         ArgDef(
             name="--gpus",
-            help="GPU passthrough: 'all', or vendors 'nvidia'/'amd'/'intel' (comma-separated)",
+            help="GPU passthrough: 'all', vendors 'nvidia'/'amd'/'intel', or devices 'amd:1' (comma-separated)",
         ),
         ArgDef(
             name="--gpu", action="store_true", help="Deprecated, removed in 0.6.0: use --gpus all"

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -159,9 +159,10 @@ _AGENT_DIGEST_LEN = 12
 # quay.io/podman/stable, nvcr.io/nvidia/nvhpc.  Other images in the
 # same family path will match but are unsupported.
 _NVIDIA_UBI_TAG_RE: re.Pattern[str] = re.compile(r"ubi\d+", re.IGNORECASE)
+_RPM_MARKER_RE: re.Pattern[str] = re.compile(r"almalinux|centos|rhel|rocky|ubi", re.IGNORECASE)
 
 
-def _nvidia_family(tag: str) -> str:
+def _nvidia_family(name: str, tag: str) -> str:
     """Pick the family for a matched NVIDIA image from its *tag*.
 
     NVIDIA tags carry an explicit ``ubuntu`` or ``ubi[N]`` marker; absence
@@ -170,11 +171,23 @@ def _nvidia_family(tag: str) -> str:
     return "rpm" if _NVIDIA_UBI_TAG_RE.search(tag) else "deb"
 
 
-_KNOWN_FAMILIES: tuple[tuple[str, str | Callable[[str], str]], ...] = (
+def _distro_marker_family(name: str, tag: str) -> str:
+    """Family from an RPM-distro marker anywhere in the name or tag.
+
+    ROCm encodes the distro in the image *name* (``rocm/dev-ubuntu-24.04``
+    vs ``rocm/dev-almalinux-8``); Intel's oneAPI images in the *tag*.
+    Ubuntu is both vendors' default, so no marker means ``deb``.
+    """
+    return "rpm" if _RPM_MARKER_RE.search(f"{name}:{tag}") else "deb"
+
+
+_KNOWN_FAMILIES: tuple[tuple[str, str | Callable[[str, str], str]], ...] = (
     ("registry.fedoraproject.org/fedora", "rpm"),
     ("quay.io/podman", "rpm"),
     ("nvcr.io/nvidia", _nvidia_family),
     ("nvidia", _nvidia_family),
+    ("rocm", _distro_marker_family),
+    ("intel", _distro_marker_family),
     ("ubuntu", "deb"),
     ("debian", "deb"),
     ("fedora", "rpm"),
@@ -379,20 +392,23 @@ def known_family(base_image: str, override: str | None = None) -> str | None:
     detection (used to support unknown bases via project config).
 
     Detection matches a small allowlist of known image prefixes
-    (Ubuntu/Debian, Fedora, the official Podman container, NVIDIA CUDA/HPC
-    SDK).  NVIDIA images are inspected at the tag level so UBI variants
+    (Ubuntu/Debian, Fedora, the official Podman container, NVIDIA
+    CUDA/HPC SDK, AMD ROCm, Intel oneAPI); an explicit ``docker.io/``
+    (or ``docker.io/library/``) qualifier is ignored for matching.
+    NVIDIA images are inspected at the tag level so UBI variants
     (e.g. ``…:13.0.0-devel-ubi9``) resolve to ``rpm`` while Ubuntu
-    variants resolve to ``deb``.
+    variants resolve to ``deb``; ROCm and oneAPI images resolve from an
+    RPM-distro marker in the name or tag, defaulting to ``deb``.
     """
     if override is not None:
         if override not in {"deb", "rpm"}:
             raise BuildError(f"family must be 'deb' or 'rpm', got {override!r}")
         return override
     name, tag = _split_image_ref(_normalize_base_image(base_image))
-    name_lc = name.lower()
+    name_lc = name.lower().removeprefix("docker.io/library/").removeprefix("docker.io/")
     for prefix, fam in _KNOWN_FAMILIES:
         if name_lc == prefix or name_lc.startswith(prefix + "/"):
-            return fam(tag) if callable(fam) else fam
+            return fam(name_lc, tag) if callable(fam) else fam
     return None
 
 

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -1335,6 +1335,36 @@ class TestDetectFamily:
     @pytest.mark.parametrize(
         ("base_image", "expected"),
         [
+            # ROCm encodes the distro in the image name.
+            ("rocm/dev-ubuntu-24.04:latest", "deb"),
+            ("docker.io/rocm/dev-ubuntu-24.04:latest", "deb"),
+            ("rocm/dev-almalinux-8:latest", "rpm"),
+            ("rocm/rocm-terminal:latest", "deb"),
+            # Intel oneAPI encodes it in the tag; Ubuntu is the default.
+            ("intel/oneapi-basekit:latest", "deb"),
+            ("docker.io/intel/oneapi-basekit:latest", "deb"),
+            ("intel/oneapi-basekit:2025.1-rockylinux9", "rpm"),
+        ],
+    )
+    def test_rocm_and_oneapi_distro_markers(self, base_image: str, expected: str) -> None:
+        assert detect_family(base_image) == expected
+
+    @pytest.mark.parametrize(
+        ("base_image", "expected"),
+        [
+            ("docker.io/ubuntu:24.04", "deb"),
+            ("docker.io/library/ubuntu:24.04", "deb"),
+            ("docker.io/fedora:44", "rpm"),
+        ],
+    )
+    def test_docker_io_qualifier_is_ignored_for_matching(
+        self, base_image: str, expected: str
+    ) -> None:
+        assert detect_family(base_image) == expected
+
+    @pytest.mark.parametrize(
+        ("base_image", "expected"),
+        [
             # Digest-only refs — tag parsing must not consume the digest.
             (
                 "ubuntu@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -203,7 +203,7 @@ class TestAgentRunner:
             )
 
         spec = sandbox.run.call_args[0][0]
-        assert spec.gpus == ("amd", "intel")
+        assert spec.gpus == (("amd", None), ("intel", None))
 
     def test_deprecated_gpu_kwarg_still_works(self, tmp_path: Path) -> None:
         """``gpu=True`` warns but keeps enabling passthrough (as ``"all"``)."""
@@ -241,7 +241,7 @@ class TestAgentRunner:
             )
 
         spec = sandbox.run.call_args[0][0]
-        assert spec.gpus == ("amd",)
+        assert spec.gpus == (("amd", None),)
 
     def test_unknown_gpu_vendor_becomes_build_error(self, tmp_path: Path) -> None:
         """A typo'd vendor fails as BuildError before any podman call."""
@@ -548,7 +548,7 @@ class TestLaunchPrepared:
         assert spec.env == {"FOO": "bar"}
         assert spec.command == ("bash",)
         assert spec.task_dir == tmp_path
-        assert spec.gpus == ("nvidia", "amd")
+        assert spec.gpus == (("nvidia", None), ("amd", None))
         assert spec.memory == "4g"
         assert spec.cpus == "2.0"
         assert spec.unrestricted is False

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgpu-device-grants" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a10/terok_sandbox-0.5.0a10-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a10.dev412+g7d8cb9c37"
-source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgpu-device-grants#7d8cb9c376c6ea7df69a0a89fee05adf9ae7083a" }
+version = "0.5.0a10"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a10/terok_sandbox-0.5.0a10-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2327,6 +2327,26 @@ dependencies = [
     { name = "terok-clearance" },
     { name = "terok-shield" },
     { name = "terok-util" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a10/terok_sandbox-0.5.0a10-py3-none-any.whl", hash = "sha256:16f81b95afa3ef43672d87b4be9bb5a769e10d5943b47edc3b00f5a2a2886d9c" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = "~=3.14.1" },
+    { name = "cryptography", specifier = "~=49.0" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "keyring", specifier = "~=25.7" },
+    { name = "packaging", specifier = "~=26.2" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "prompt-toolkit", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "sqlcipher3", specifier = "==0.6.2" },
+    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a9/terok_sandbox-0.5.0a9-py3-none-any.whl" },
+    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgpu-device-grants" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a9"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a9/terok_sandbox-0.5.0a9-py3-none-any.whl" }
+version = "0.5.0a10.dev412+g7d8cb9c37"
+source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgpu-device-grants#7d8cb9c376c6ea7df69a0a89fee05adf9ae7083a" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2327,26 +2327,6 @@ dependencies = [
     { name = "terok-clearance" },
     { name = "terok-shield" },
     { name = "terok-util" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a9/terok_sandbox-0.5.0a9-py3-none-any.whl", hash = "sha256:0044b263021ef2cf69bbff3a74522299e3399d6fa8920c8798d0acdffe252ae9" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = "~=3.14.1" },
-    { name = "cryptography", specifier = "~=49.0" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "keyring", specifier = "~=25.7" },
-    { name = "packaging", specifier = "~=26.2" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "sqlcipher3", specifier = "==0.6.2" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
Chain link for terok-ai/terok-sandbox#463 (per-device GPU grants + vendor-scoped raw DRM mounts). Executor passes `run.gpus` selector strings through to sandbox's `normalize_gpus` unchanged, so the substance is the branch pin plus:

- `--gpus` help text now names the device form (`amd:1`).
- Test expectations updated for the normalized grant shape (`(("amd", None), …)`).
- **Family detection extended**: `rocm/*` (distro in the image name) and `intel/*` (distro in the tag) resolve with Ubuntu/deb as the vendors' default, and an explicit `docker.io/`(`library/`) qualifier no longer defeats the allowlist — unblocks the wizard's new ROCm/oneAPI bases in the terok link of this chain.

Draft until the sandbox PR's hardware pass; repin to release wheels at merge time via the release chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
