### PR TITLE
feat(runner): plumb typed caps grants through to RunSpec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a12/terok_sandbox-0.5.0a12-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox@feat/grantable-caps",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox@feat/grantable-caps",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a13/terok_sandbox-0.5.0a13-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
@@ -91,7 +91,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.4.0a12"
+fallback-version = "0.4.0a13"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_executor"]

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -477,7 +477,8 @@ class AgentRunner:
             memory: Podman ``--memory`` value (``"4g"`` etc.); ``None`` = unlimited.
             cpus: Podman ``--cpus`` value (``"2.0"`` etc.); ``None`` = unlimited.
             caps: Linux capabilities to grant (``--cap-add``); every
-                entry must be on sandbox's ``GRANTABLE_CAPS`` allowlist
+                entry must be on
+                [`GRANTABLE_CAPS`][terok_sandbox.sandbox.GRANTABLE_CAPS]
                 (sandbox rejects anything else at command-assembly
                 time).  Typed channel for capability grants — never
                 pass ``--cap-add`` via *extra_args*.

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -188,6 +188,7 @@ class AgentRunner:
         gpu: bool | None = None,
         memory: str | None = None,
         cpus: str | None = None,
+        caps: Sequence[str] | None = None,
         workspace: Path | None = None,
         ephemeral: bool = False,
         hooks: LifecycleHooks | None = None,
@@ -233,6 +234,7 @@ class AgentRunner:
             gpus=_fold_deprecated_gpu(gpu, gpus),
             memory=memory,
             cpus=cpus,
+            caps=caps,
             workspace=workspace,
             ephemeral=ephemeral,
             hooks=hooks,
@@ -260,6 +262,7 @@ class AgentRunner:
         gpu: bool | None = None,
         memory: str | None = None,
         cpus: str | None = None,
+        caps: Sequence[str] | None = None,
         workspace: Path | None = None,
         ephemeral: bool = False,
         hooks: LifecycleHooks | None = None,
@@ -291,6 +294,7 @@ class AgentRunner:
             gpus=_fold_deprecated_gpu(gpu, gpus),
             memory=memory,
             cpus=cpus,
+            caps=caps,
             workspace=workspace,
             ephemeral=ephemeral,
             hooks=hooks,
@@ -319,6 +323,7 @@ class AgentRunner:
         gpu: bool | None = None,
         memory: str | None = None,
         cpus: str | None = None,
+        caps: Sequence[str] | None = None,
         workspace: Path | None = None,
         ephemeral: bool = False,
         hooks: LifecycleHooks | None = None,
@@ -355,6 +360,7 @@ class AgentRunner:
             gpus=_fold_deprecated_gpu(gpu, gpus),
             memory=memory,
             cpus=cpus,
+            caps=caps,
             workspace=workspace,
             ephemeral=ephemeral,
             hooks=hooks,
@@ -427,6 +433,7 @@ class AgentRunner:
         gpu: bool | None = None,
         memory: str | None = None,
         cpus: str | None = None,
+        caps: Sequence[str] | None = None,
         ephemeral: bool = False,
         unrestricted: bool = True,
         sealed: bool = False,
@@ -469,6 +476,12 @@ class AgentRunner:
                 wins.  Will be removed in terok-executor 0.6.0.
             memory: Podman ``--memory`` value (``"4g"`` etc.); ``None`` = unlimited.
             cpus: Podman ``--cpus`` value (``"2.0"`` etc.); ``None`` = unlimited.
+            caps: Linux capabilities to grant (``--cap-add``); every
+                entry must be on
+                [`GRANTABLE_CAPS`][terok_sandbox.sandbox.GRANTABLE_CAPS]
+                (sandbox rejects anything else at command-assembly
+                time).  Typed channel for capability grants — never
+                pass ``--cap-add`` via *extra_args*.
             ephemeral: When True, podman removes the container as soon as
                 it exits (``--rm``); the default keeps it for
                 ``start``/``rm``, matching ``podman run``.
@@ -635,6 +648,7 @@ class AgentRunner:
             gpus=spec_gpus,
             memory=memory,
             cpus=cpus,
+            caps=tuple(caps or ()),
             extra_args=tuple(extra_args or ()),
             unrestricted=unrestricted,
             sealed=sealed,
@@ -847,6 +861,7 @@ class AgentRunner:
         gpus: bool | str | Sequence[str] | None = None,
         memory: str | None = None,
         cpus: str | None = None,
+        caps: Sequence[str] | None = None,
         workspace: Path | None = None,
         ephemeral: bool = False,
         hooks: LifecycleHooks | None = None,
@@ -1014,6 +1029,7 @@ class AgentRunner:
             gpus=gpus,
             memory=memory,
             cpus=cpus,
+            caps=caps,
             ephemeral=ephemeral,
             unrestricted=unrestricted,
             extra_args=extra_args or None,

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -477,8 +477,7 @@ class AgentRunner:
             memory: Podman ``--memory`` value (``"4g"`` etc.); ``None`` = unlimited.
             cpus: Podman ``--cpus`` value (``"2.0"`` etc.); ``None`` = unlimited.
             caps: Linux capabilities to grant (``--cap-add``); every
-                entry must be on
-                [`GRANTABLE_CAPS`][terok_sandbox.sandbox.GRANTABLE_CAPS]
+                entry must be on sandbox's ``GRANTABLE_CAPS`` allowlist
                 (sandbox rejects anything else at command-assembly
                 time).  Typed channel for capability grants — never
                 pass ``--cap-add`` via *extra_args*.

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -285,6 +285,19 @@ class TestAgentRunner:
         spec = sandbox.run.call_args[0][0]
         assert spec.cpus == "2.0"
 
+    def test_caps_propagate(self, tmp_path: Path) -> None:
+        """Capability grants flow through to RunSpec.caps as a tuple."""
+        sandbox = _mock_sandbox()
+        runner = AgentRunner(sandbox=sandbox)
+
+        with patch.object(runner, "_ensure_images", return_value="terok-l1-cli:test"):
+            runner.run_headless(
+                "claude", None, workspace=tmp_path, prompt="test", follow=False, caps=["perfmon"]
+            )
+
+        spec = sandbox.run.call_args[0][0]
+        assert spec.caps == ("perfmon",)
+
     def test_resource_limits_default_none(self, tmp_path: Path) -> None:
         """Resource limits default to None when not specified."""
         sandbox = _mock_sandbox()
@@ -296,6 +309,7 @@ class TestAgentRunner:
         spec = sandbox.run.call_args[0][0]
         assert spec.memory is None
         assert spec.cpus is None
+        assert spec.caps == ()
 
     def test_run_interactive_command(self, tmp_path: Path) -> None:
         """Interactive mode includes init-ssh-and-repo.sh in command."""
@@ -537,6 +551,7 @@ class TestLaunchPrepared:
             gpus="nvidia,amd",
             memory="4g",
             cpus="2.0",
+            caps=["perfmon"],
             unrestricted=False,
             sealed=True,
             extra_args=["-p", "127.0.0.1:8080:8080"],
@@ -551,6 +566,7 @@ class TestLaunchPrepared:
         assert spec.gpus == (("nvidia", None), ("amd", None))
         assert spec.memory == "4g"
         assert spec.cpus == "2.0"
+        assert spec.caps == ("perfmon",)
         assert spec.unrestricted is False
         assert spec.sealed is True
         assert spec.extra_args == ("-p", "127.0.0.1:8080:8080")

--- a/uv.lock
+++ b/uv.lock
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a13.dev427+g08e1f107e"
-source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgrantable-caps#08e1f107eb70eb0ed9b403bbad2b3fc0e6a18ae1" }
+version = "0.5.0a13.dev428+gd4f7ac4bc"
+source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgrantable-caps#d4f7ac4bccb6e75667b1aeca54a775e851b049df" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a12/terok_sandbox-0.5.0a12-py3-none-any.whl" },
+    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgrantable-caps" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a12"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a12/terok_sandbox-0.5.0a12-py3-none-any.whl" }
+version = "0.5.0a13.dev427+g08e1f107e"
+source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgrantable-caps#08e1f107eb70eb0ed9b403bbad2b3fc0e6a18ae1" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2327,26 +2327,6 @@ dependencies = [
     { name = "terok-clearance" },
     { name = "terok-shield" },
     { name = "terok-util" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a12/terok_sandbox-0.5.0a12-py3-none-any.whl", hash = "sha256:2bd420541427eea97949c1afc21d412a8a7b93e63549784ac653b8a4a77b95f8" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = "~=3.14.1" },
-    { name = "cryptography", specifier = "~=49.0" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "keyring", specifier = "~=25.7" },
-    { name = "packaging", specifier = "~=26.2" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "sqlcipher3", specifier = "==0.6.2" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgrantable-caps" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a13/terok_sandbox-0.5.0a13-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a13.dev428+gd4f7ac4bc"
-source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Fgrantable-caps#d4f7ac4bccb6e75667b1aeca54a775e851b049df" }
+version = "0.5.0a13"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a13/terok_sandbox-0.5.0a13-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2327,6 +2327,26 @@ dependencies = [
     { name = "terok-clearance" },
     { name = "terok-shield" },
     { name = "terok-util" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a13/terok_sandbox-0.5.0a13-py3-none-any.whl", hash = "sha256:40a2a7d903196024a7aa82793f3399d05012078e126d7888ee29d08626f906c3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = "~=3.14.1" },
+    { name = "cryptography", specifier = "~=49.0" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "keyring", specifier = "~=25.7" },
+    { name = "packaging", specifier = "~=26.2" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "prompt-toolkit", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "sqlcipher3", specifier = "==0.6.2" },
+    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
Middle of the perf/podman-args chain: terok-ai/terok-sandbox#481 (below) → this → terok-ai/terok#1213 (above).

All four launch entry points (`run_headless`, `run_interactive`, `run_web`, `launch_prepared`) accept `caps: Sequence[str]`, forwarded to sandbox's new `RunSpec.caps` field, where every entry is validated against the `GRANTABLE_CAPS` allowlist and emitted as `--cap-add`. The typed channel keeps capability policy in sandbox — callers must not smuggle `--cap-add` through `extra_args` (sandbox's managed-flag set still owns it).

Pins terok-sandbox to the `feat/grantable-caps` branch tip; **repin to the release wheel** (0.5.0a13) before cutting a release.

`make check` green (1158 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)