### PR TITLE
feat(tmux): show the host-written review-lag warning in the container status line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a13/terok_sandbox-0.5.0a13-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/gate-agent-hooks",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/gate-agent-hooks",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a14/terok_sandbox-0.5.0a14-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
@@ -91,7 +91,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.4.0a13"
+fallback-version = "0.4.0a14"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_executor"]

--- a/src/terok_executor/resources/tmux/container-tmux.conf
+++ b/src/terok_executor/resources/tmux/container-tmux.conf
@@ -13,8 +13,10 @@ set -g status-interval 5
 set -g status-style 'bg=colour22 fg=colour255'
 set -g status-left ' CONTAINER tmux (^a) | '
 set -g status-left-length 30
-set -g status-right ' host: ^b  ^a c:new  ^a n/p:switch '
-set -g status-right-length 45
+# Review-lag warning: the host writes ~/.terok/review-status when a gate
+# branch is ahead of an open MR/PR (terok review_lag); empty/absent = quiet.
+set -g status-right '#[fg=colour226,bold]#(head -c 120 ~/.terok/review-status 2>/dev/null | tr "\n" " ")#[default] host: ^b  ^a c:new  ^a n/p:switch '
+set -g status-right-length 180
 set -g mouse on
 set -g history-limit 10000
 set -g default-terminal "screen-256color"

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Fgate-agent-hooks" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a14/terok_sandbox-0.5.0a14-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a14.dev429+gc206db7d8"
-source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Fgate-agent-hooks#c206db7d86caf7214687da1961fc1589d3c58d34" }
+version = "0.5.0a14"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a14/terok_sandbox-0.5.0a14-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2327,6 +2327,26 @@ dependencies = [
     { name = "terok-clearance" },
     { name = "terok-shield" },
     { name = "terok-util" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a14/terok_sandbox-0.5.0a14-py3-none-any.whl", hash = "sha256:be44fba02117aaa93f0b1ce4aa757925c28bad6608a976d6f3848ae80c7169cd" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = "~=3.14.1" },
+    { name = "cryptography", specifier = "~=49.0" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "keyring", specifier = "~=25.7" },
+    { name = "packaging", specifier = "~=26.2" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "prompt-toolkit", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "sqlcipher3", specifier = "==0.6.2" },
+    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a13/terok_sandbox-0.5.0a13-py3-none-any.whl" },
+    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Fgate-agent-hooks" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a13"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a13/terok_sandbox-0.5.0a13-py3-none-any.whl" }
+version = "0.5.0a14.dev429+gc206db7d8"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Fgate-agent-hooks#c206db7d86caf7214687da1961fc1589d3c58d34" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2327,26 +2327,6 @@ dependencies = [
     { name = "terok-clearance" },
     { name = "terok-shield" },
     { name = "terok-util" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a13/terok_sandbox-0.5.0a13-py3-none-any.whl", hash = "sha256:40a2a7d903196024a7aa82793f3399d05012078e126d7888ee29d08626f906c3" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = "~=3.14.1" },
-    { name = "cryptography", specifier = "~=49.0" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "keyring", specifier = "~=25.7" },
-    { name = "packaging", specifier = "~=26.2" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "sqlcipher3", specifier = "==0.6.2" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
Companion to terok-ai/terok#1203 (gatekeeping review-lag warning) and the gate facts in terok-ai/terok-sandbox#483.

The host-side review-lag check writes `~/.terok/review-status` (via the existing agent-config mount) when a gate branch is ahead of an open MR/PR; this renders it in the container tmux status-right, yellow/bold, truncated to 120 chars with newlines joined. Absent or empty file renders nothing — zero cost for online projects and quiet gates.

Level-triggered by design: the mark stays visible until the operator pushes the gate, unlike a notification that fires once. The same file is readable by the agent for deterministic knowledge of review lag.

Verified: config parses (session starts clean), pipeline renders `⚠ !42 border-wave-1 +3 ⚠ !45 fix/mirror +1` from a two-line file and empty for a missing file. Image rebuilds pick the change up through the existing tmux-config hash in terok's ImageBuilder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)