### PR TITLE
feat(wrappers): pre-flight provider readiness for codex/vibe

### DIFF
--- a/src/terok_executor/provider/wrappers.py
+++ b/src/terok_executor/provider/wrappers.py
@@ -119,6 +119,7 @@ def _wrapper_context(agent: Agent) -> dict[str, object]:
         "is_opencode": agent.name == "opencode",
         "provider_launcher": provider_launcher,
         **_claude_provider_context(agent),
+        **_readiness_guard_context(agent, provider_launcher),
         "author_name": shlex.quote(agent.git_author_name),
         "author_email": shlex.quote(agent.git_author_email),
         "refuse_pattern": "|".join(agent.refuse_subcommands),
@@ -154,6 +155,29 @@ def _claude_provider_context(agent: Agent) -> dict[str, str]:
         "provider_base_url_env": base_url_env,
         "provider_bearer_env": bearer_env,
     }
+
+
+def _readiness_guard_context(agent: Agent, provider_launcher: str) -> dict[str, object]:
+    """Resolve whether this wrapper pre-flights provider readiness, and against whom.
+
+    A native, protocol-routed agent (codex, vibe) launches its bare binary on
+    the default path, trusting a vault-materialized credential to be there. When
+    no provider serving its wire protocol was authenticated at container-creation
+    time, that credential is absent and the agent dies with an opaque parse error
+    (codex: ``EOF while parsing a value at line 1 column 0``). The guard checks
+    the effective provider's ``TEROK_PROVIDER_<NAME>_BASE_<PROTOCOL>`` handle —
+    the same startup snapshot ``hilfe`` and ``providers`` read — and refuses with
+    an actionable message instead.
+
+    Truthy only for agents that both route through a launcher and carry a fixed
+    protocol + default provider to check; harnesses (opencode, pi, no default)
+    and bindingless CLIs (copilot) opt out and render no guard.
+    """
+    binding = agent.provider_binding
+    default = binding.default if binding else None
+    if not (provider_launcher and default and agent.protocol):
+        return {"readiness_guard": False, "default_provider": ""}
+    return {"readiness_guard": True, "default_provider": default}
 
 
 def _extra_args_expansion(agent: Agent, session_path: str) -> str:

--- a/src/terok_executor/resources/templates/agent-wrappers.sh.j2
+++ b/src/terok_executor/resources/templates/agent-wrappers.sh.j2
@@ -40,6 +40,23 @@
     local _runner=({{ c.binary }})
     [ -n "$_provider" ] && _runner=({{ c.provider_launcher }} --provider "$_provider")
 {%- endif %}
+{%- if c.readiness_guard %}
+    # Pre-flight: refuse when the effective provider (the selected one, else the
+    # baked default) has no authenticated, protocol-serving vault handle in this
+    # container's startup snapshot.  Without it {{ c.binary }} would launch
+    # against an empty credential and die with an opaque parse error; the same
+    # snapshot backs the `hilfe` / `providers` readiness views, so this never
+    # refuses an invocation those would call ready.
+    local _eff="${_provider:-{{ c.default_provider }}}"
+    local _handle="TEROK_PROVIDER_${_eff^^}_BASE_{{ c.provider_protocol_var }}"
+    if [ -z "${!_handle:-}" ]; then
+        echo "terok: {{ c.name }} has no authenticated {{ c.provider_protocol }} provider ('${_eff}')." >&2
+        echo "  Authenticate one on the host:  terok auth {{ c.name }}" >&2
+        echo "  Ready pairs in this container: providers" >&2
+        echo "  (Authenticating on the host after this task started needs a fresh task to take effect.)" >&2
+        return 1
+    fi
+{%- endif %}
     [ -r /usr/local/share/terok/terok-env-git-identity.sh ] && \
         . /usr/local/share/terok/terok-env-git-identity.sh
 {%- if c.is_vibe %}

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -122,6 +122,33 @@ class TestRuntimeProviderWrappers:
         assert AGENTS["opencode"].protocol == "openai-chat"
         assert AGENTS["pi"].protocol == "openai-chat"
 
+    def test_codex_preflight_refuses_without_a_ready_provider(self) -> None:
+        """Codex checks its effective provider's vault handle before launch, so an
+        unauthenticated task fails with an actionable message instead of codex's
+        opaque ``EOF while parsing a value`` on an empty credential file."""
+        wrapper = generate_agent_wrapper(AGENTS["codex"])
+        assert 'local _eff="${_provider:-openai}"' in wrapper
+        assert 'local _handle="TEROK_PROVIDER_${_eff^^}_BASE_OPENAI_RESPONSES"' in wrapper
+        assert 'if [ -z "${!_handle:-}" ]; then' in wrapper
+        assert "codex has no authenticated openai-responses provider" in wrapper
+        assert "terok auth codex" in wrapper
+
+    def test_vibe_preflight_checks_its_own_default_and_protocol(self) -> None:
+        """Vibe's guard resolves against its baked default (mistral) and wire
+        protocol (openai-chat), independent of codex's."""
+        wrapper = generate_agent_wrapper(AGENTS["vibe"])
+        assert 'local _eff="${_provider:-mistral}"' in wrapper
+        assert 'local _handle="TEROK_PROVIDER_${_eff^^}_BASE_OPENAI_CHAT"' in wrapper
+        assert "vibe has no authenticated openai-chat provider" in wrapper
+
+    def test_preflight_guard_scoped_to_native_protocol_agents(self) -> None:
+        """The guard is emitted only for native, protocol-routed CLIs (codex, vibe).
+        Harnesses select a provider at runtime and bindingless CLIs have no default
+        to check, so they must not carry it."""
+        for name in ("opencode", "pi", "copilot", "claude"):
+            wrapper = generate_agent_wrapper(AGENTS[name])
+            assert 'local _handle="TEROK_PROVIDER_' not in wrapper, name
+
 
 class TestWriteSessionHook:
     """Tests for _write_session_hook."""


### PR DESCRIPTION
## Problem

Running an unauthenticated native agent inside a task container gives an
incomprehensible failure. Bare `codex` (no provider serving `openai-responses`
authenticated) launches straight into the binary, which reads an empty vault
credential and dies with:

```
EOF while parsing a value at line 1 column 0
```

The container already *knows* codex is unusable — the `hilfe` banner even dims
it as `codex - OpenAI Codex (needs an openai-responses provider)` — but the
wrapper never consulted that state before exec'ing into the crash.

## Fix

The generated wrapper for native, protocol-routed agents (codex, vibe) now
pre-flights the **effective provider** — the explicit `--provider`, else the
container's `TEROK_PROVIDER`, else the agent's baked default — against its
`TEROK_PROVIDER_<NAME>_BASE_<PROTOCOL>` handle. When that handle is absent it
refuses with an actionable message instead:

```
terok: codex has no authenticated openai-responses provider ('openai').
  Authenticate one on the host:  terok auth codex
  Ready pairs in this container: providers
  (Authenticating on the host after this task started needs a fresh task to take effect.)
```

Key properties:

- **Same signal as the rest of the readiness UX.** The handle set is the
  container-startup snapshot that `hilfe`, `providers`, and `terok-agents` all
  read (materialized once by `_inject_vault_tokens` → `_set_provider_handle`).
  The guard can't be staler than the banner and never refuses an invocation
  those views would call ready.
- **Also fixes `--provider X` where X doesn't serve the protocol.** That path
  previously printed a note and ran the agent on its default endpoint — i.e.
  straight into the same crash. Now it's refused cleanly, naming X.
- **Mid-task host auth is honest.** A running container keeps its startup
  snapshot, so a provider authenticated on the host after the task started
  isn't routable anyway; the message says a fresh task is needed.

## Scope

Emitted only for native CLIs that route through a launcher **and** carry a fixed
protocol + default provider — exactly codex and vibe. Harnesses (opencode, pi)
select a provider at runtime and bindingless CLIs (copilot) have no default to
check, so they render no guard. Claude's separate wrapper is untouched.

## Tests

Three cases added to `TestRuntimeProviderWrappers` (codex guard + default/proto,
vibe's own default/proto, and scope-exclusion for opencode/pi/copilot/claude).
Full suite green (1161 passed); `wrappers.py` at 100% coverage. `make check`
clean (lint, reuse, docstrings 98.1%, tach, lint-imports, bandit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-flight readiness check to supported agent wrappers.
  * Wrappers now verify that the required provider credentials are available before starting.
  * Added clear error messages with guidance for authenticating missing providers.

* **Bug Fixes**
  * Prevented agents from starting when their configured provider is unavailable or unauthenticated.
  * Ensured readiness checks use the correct default provider and protocol routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->