### PR TITLE
fix(build): apply default-alias tag on cache hit

### DIFF
--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -485,6 +485,24 @@ def build_project_image(
         raise BuildError(f"Image build failed: {exc}") from exc
 
 
+def _tag_image(source: str, alias: str) -> None:
+    """Point *alias* at the *source* image via ``podman tag``.
+
+    Idempotent: re-tagging an alias that already resolves to *source* is a
+    no-op.  Used by [`build_base_images`][terok_executor.container.build.build_base_images]
+    to apply the default-alias tag on a cache hit, where no ``podman build``
+    (and therefore no ``-t`` tagging) runs.
+    """
+    cmd = ["podman", "tag", source, alias]
+    print("$", shlex.join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+    except FileNotFoundError as exc:
+        raise BuildError("podman not found; please install podman") from exc
+    except subprocess.CalledProcessError as exc:
+        raise BuildError(f"Image tag failed ({alias!r} -> {source!r}): {exc}") from exc
+
+
 def build_base_images(
     base_image: str = DEFAULT_BASE_IMAGE,
     *,
@@ -548,6 +566,17 @@ def build_base_images(
     # with explicit family) can still be reused without supplying it again.
     if not rebuild and not full_rebuild:
         if _image_exists(l0_tag) and _image_exists(l1_tag):
+            # The default alias is applied only as an extra ``-t`` target at
+            # build time, so a cache hit would otherwise skip it entirely.
+            # A prior non-default build (a project or per-agent L1) leaves the
+            # suffixed L1 present while the alias is absent; without this the
+            # ``tag_as_default`` request is silently dropped and
+            # ``ensure_default_l1`` hands back an alias tag that was never
+            # created — ``podman run`` then fails to resolve it.  ``podman
+            # tag`` is idempotent, so re-pointing an already-correct alias is
+            # a no-op.
+            for alias in extra_tags:
+                _tag_image(l1_tag, alias)
             return ImageSet(l0=l0_tag, l1=l1_tag)
 
     fam = detect_family(base_image, override=family)

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -1072,6 +1072,52 @@ class TestDefaultAliasTagging:
         # Both the suffixed tag AND the unsuffixed default alias appear as -t targets.
         assert default_alias in l1_cmd
 
+    def test_applies_alias_on_cache_hit(self) -> None:
+        """A cache hit still applies the default alias via ``podman tag``.
+
+        Regression: a prior non-default build leaves the suffixed L1 present
+        while the alias is absent.  ``tag_as_default=True`` must not be
+        silently dropped just because no rebuild is needed — otherwise
+        ``ensure_default_l1`` returns an alias tag that never got created.
+        """
+        from unittest.mock import patch
+
+        from terok_executor.container.build import (
+            DEFAULT_BASE_IMAGE,
+            build_base_images,
+            l1_image_tag,
+        )
+
+        default_alias = l1_image_tag(DEFAULT_BASE_IMAGE)
+        with (
+            patch("terok_executor.container.build._check_podman"),
+            patch("terok_executor.container.build._image_exists", return_value=True),
+            patch("subprocess.run") as mock_run,
+        ):
+            result = build_base_images(tag_as_default=True)
+
+        # No ``podman build`` runs (cache hit), but the alias is tagged.
+        assert mock_run.call_count == 1
+        tag_cmd = mock_run.call_args_list[0][0][0]
+        assert tag_cmd[:2] == ["podman", "tag"]
+        assert tag_cmd[2] == result.l1
+        assert tag_cmd[3] == default_alias
+
+    def test_no_alias_tag_on_cache_hit_without_default(self) -> None:
+        """A cache hit for a non-default build tags nothing (no alias to apply)."""
+        from unittest.mock import patch
+
+        from terok_executor.container.build import build_base_images
+
+        with (
+            patch("terok_executor.container.build._check_podman"),
+            patch("terok_executor.container.build._image_exists", return_value=True),
+            patch("subprocess.run") as mock_run,
+        ):
+            build_base_images(tag_as_default=False)
+
+        mock_run.assert_not_called()
+
 
 class TestImageAgents:
     """Verify the ``ai.terok.agents`` OCI label reader."""


### PR DESCRIPTION
## Problem

Host-wide `terok auth <provider>` fails to launch its auth container when a suffixed L1 already exists but the default alias does not:

```
$ podman run ... terok-l1-cli:fedora-44 setup-codex-auth.sh --device-auth
Error: short-name "terok-l1-cli:fedora-44" did not resolve to an alias and no unqualified-search registries are defined
```

Observed on the codex OAuth device-auth flow after a project image had already been built.

## Root cause

`build_base_images` applies the unsuffixed default alias (`terok-l1-cli:<base>`) **only as an extra `-t` target at build time**. When the suffixed L0+L1 already exist, the function early-returns without building — silently dropping a `tag_as_default=True` request.

A prior non-default build (a project or per-agent L1 via `build_base` with `tag_as_default=False`) leaves the suffixed L1 present while the alias is absent. `ensure_default_l1` then finds the alias missing, calls `build_base_images(tag_as_default=True)`, hits the cache-skip at `_image_exists(l0_tag) and _image_exists(l1_tag)`, and returns an alias tag that was **never created**. `podman run` against it then fails short-name resolution.

## Fix

Apply the `extra_tags` (the default alias) with an idempotent `podman tag` on the cache-hit path, so the alias always tracks the current suffixed L1 even when no rebuild is needed. Re-pointing an already-correct alias is a no-op.

## Tests

- `test_applies_alias_on_cache_hit` — cache hit + `tag_as_default=True` now issues `podman tag <l1_tag> <alias>` and no `podman build`.
- `test_no_alias_tag_on_cache_hit_without_default` — cache hit without `tag_as_default` tags nothing (guards against spurious tagging).

Full `make check` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cached image builds so requested default aliases are applied correctly.
  * Avoided unnecessary image rebuilds when the required image already exists.
  * Preserved behavior without additional container commands when default aliasing is disabled.

* **Tests**
  * Added coverage for default alias creation and cached-image behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->