### PR TITLE
feat: thread allow_debugger through the task-launch path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -215,6 +215,7 @@ def _handle_run(
     branch: str | None = None,
     name: str | None = None,
     restricted: bool = False,
+    debug: bool = False,
     gpus: str | None = None,
     gpu: bool = False,
     memory: str | None = None,
@@ -269,6 +270,7 @@ def _handle_run(
         "name": name,
         "branch": branch,
         "unrestricted": not restricted,
+        "allow_debugger": debug,
         "gpus": gpus if gpus is not None else ("all" if gpu else None),
         "memory": memory,
         "cpus": cpus,
@@ -774,6 +776,12 @@ RUN_COMMAND = CommandDef(
             name="--restricted",
             action="store_true",
             help="Restrict agent permissions (no auto-approve, no-new-privileges)",
+        ),
+        ArgDef(
+            name="--debug",
+            action="store_true",
+            help="Debug mode: leave supervisor children ptrace-able so a debugger "
+            "can attach (skips PR_SET_DUMPABLE only; core-limit + mlockall still apply)",
         ),
         ArgDef(
             name="--gpus",

--- a/src/terok_executor/commands.py
+++ b/src/terok_executor/commands.py
@@ -325,6 +325,7 @@ def _handle_run_tool(
     timezone: str | None = None,
     yes: bool = False,
     no_preflight: bool = False,
+    debug: bool = False,
     cfg: SandboxConfig | None = None,
 ) -> None:
     """Run a tool in a sidecar container."""
@@ -354,6 +355,7 @@ def _handle_run_tool(
         workspace=Path(workspace) if workspace else None,
         ephemeral=ephemeral,
         timezone=timezone,
+        allow_debugger=debug,
     )
     print(f"Container: {cname}")
 
@@ -906,6 +908,12 @@ RUN_TOOL_COMMAND = CommandDef(
             action="store_true",
             dest="no_preflight",
             help="Skip prerequisite checks entirely (caller manages setup)",
+        ),
+        ArgDef(
+            name="--debug",
+            action="store_true",
+            help="Debug mode: leave supervisor children ptrace-able so a debugger "
+            "can attach (skips PR_SET_DUMPABLE only; core-limit + mlockall still apply)",
         ),
     ),
 )

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -403,6 +403,7 @@ class AgentRunner:
         project_id: str = "",
         task_id: str = "",
         dossier_path: Path | str | None = None,
+        allow_debugger: bool = False,
     ) -> str:
         """Launch a sidecar tool container. Returns container name.
 
@@ -411,7 +412,8 @@ class AgentRunner:
         store — not a phantom token.
 
         See [`run_headless`][terok_executor.container.runner.AgentRunner.run_headless]
-        for the *project_id* / *task_id* / *dossier_path* semantics.
+        for the *project_id* / *task_id* / *dossier_path* / *allow_debugger*
+        semantics.
         """
         return self._run(
             agent=tool,
@@ -429,6 +431,7 @@ class AgentRunner:
             project_id=project_id,
             supervisor_task_id=task_id,
             dossier_path=dossier_path,
+            allow_debugger=allow_debugger,
         )
 
     def launch_prepared(

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -201,6 +201,7 @@ class AgentRunner:
         project_id: str = "",
         task_id: str = "",
         dossier_path: Path | str | None = None,
+        allow_debugger: bool = False,
     ) -> str:
         """Launch a headless agent run. Returns container name.
 
@@ -217,6 +218,11 @@ class AgentRunner:
         *project_id*, *task_id*, *dossier_path* propagate the terok
         orchestrator's identity into the per-container supervisor sidecar.
         Defaults preserve the standalone-executor case (no terok above).
+
+        *allow_debugger* relaxes the supervisor children's self-hardening
+        (skips only the ``PR_SET_DUMPABLE`` clear, so a debugger can
+        attach) — see
+        [`launch_prepared`][terok_executor.container.runner.AgentRunner.launch_prepared].
         """
         return self._run(
             agent=agent,
@@ -247,6 +253,7 @@ class AgentRunner:
             project_id=project_id,
             supervisor_task_id=task_id,
             dossier_path=dossier_path,
+            allow_debugger=allow_debugger,
         )
 
     def run_interactive(
@@ -275,6 +282,7 @@ class AgentRunner:
         project_id: str = "",
         task_id: str = "",
         dossier_path: Path | str | None = None,
+        allow_debugger: bool = False,
     ) -> str:
         """Launch an interactive container. Returns container name.
 
@@ -307,6 +315,7 @@ class AgentRunner:
             project_id=project_id,
             supervisor_task_id=task_id,
             dossier_path=dossier_path,
+            allow_debugger=allow_debugger,
         )
 
     def run_web(
@@ -336,6 +345,7 @@ class AgentRunner:
         project_id: str = "",
         task_id: str = "",
         dossier_path: Path | str | None = None,
+        allow_debugger: bool = False,
     ) -> str:
         """Launch a toad web container. Returns container name.
 
@@ -373,6 +383,7 @@ class AgentRunner:
             project_id=project_id,
             supervisor_task_id=task_id,
             dossier_path=dossier_path,
+            allow_debugger=allow_debugger,
         )
 
     def run_tool(
@@ -445,6 +456,7 @@ class AgentRunner:
         project_id: str = "",
         task_id: str = "",
         dossier_path: Path | str | None = None,
+        allow_debugger: bool = False,
         per_container: PerContainerResources | None = None,
     ) -> str:
         """Launch a container from a caller-prepared env, volumes, image, and command.
@@ -516,6 +528,15 @@ class AgentRunner:
                 shield reads at container start.  Default ``None``
                 omits the field from the sidecar — only orchestrated
                 runs carry a dossier.
+            allow_debugger: Relax the supervisor children's
+                self-hardening so a debugger can attach — written into
+                the sidecar as ``allow_debugger`` and honoured by
+                [`write_sidecar`][terok_sandbox.launch.write_sidecar].
+                Only the ``PR_SET_DUMPABLE`` clear is skipped;
+                ``RLIMIT_CORE`` and ``mlockall`` still apply.  Default
+                ``False`` keeps the full production hardening.  The
+                explicit flag is the sole authority (fail-closed): it
+                is never derived from ``-O`` / ``__debug__``.
             per_container: Pre-allocated per-container socket dir / TCP
                 ports.  When provided, the launch uses these instead of
                 allocating its own — so a caller that already threaded
@@ -611,6 +632,7 @@ class AgentRunner:
             gate_base_path=str(cfg.gate_base_path) if gate_active else None,
             gate_token=env["TEROK_GATE_TOKEN"] if gate_active else None,
             gate_port=per_container.gate_port if gate_active else None,
+            allow_debugger=allow_debugger,
         )
         # Fail closed: a missing sidecar means the supervisor OCI hook
         # never fires, so the container would launch with no vault,
@@ -875,6 +897,7 @@ class AgentRunner:
         project_id: str = "",
         supervisor_task_id: str = "",
         dossier_path: Path | str | None = None,
+        allow_debugger: bool = False,
     ) -> str:
         """Unified launch flow for all modes (headless, interactive, web, tool)."""
         from terok_executor.integrations.sandbox import allocate_per_container_resources
@@ -1037,6 +1060,7 @@ class AgentRunner:
             project_id=project_id,
             task_id=supervisor_task_id,
             dossier_path=dossier_path,
+            allow_debugger=allow_debugger,
             per_container=per_container,
         )
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -180,6 +180,30 @@ class TestSharedDirArgs:
         assert call_kwargs.kwargs["shared_dir"] == Path("/tmp/terok-testing/shared")
         assert call_kwargs.kwargs["shared_mount"] == "/data"
 
+    def test_handle_run_forwards_debug_as_allow_debugger(self) -> None:
+        """``--debug`` reaches the runner as ``allow_debugger``; default is False."""
+        from terok_executor.commands import _handle_run
+
+        with (
+            patch("terok_executor.commands._setup_verdict_or_exit"),
+            patch("terok_executor.commands._preflight_or_exit", return_value=True),
+            patch("terok_executor.container.runner.AgentRunner") as mock_cls,
+        ):
+            mock_runner = mock_cls.return_value
+            mock_runner.run_headless.return_value = "terok-executor-test"
+            _handle_run(agent="claude", repo=".", prompt="test", debug=True)
+        assert mock_runner.run_headless.call_args.kwargs["allow_debugger"] is True
+
+        with (
+            patch("terok_executor.commands._setup_verdict_or_exit"),
+            patch("terok_executor.commands._preflight_or_exit", return_value=True),
+            patch("terok_executor.container.runner.AgentRunner") as mock_cls,
+        ):
+            mock_runner = mock_cls.return_value
+            mock_runner.run_headless.return_value = "terok-executor-test"
+            _handle_run(agent="claude", repo=".", prompt="test")
+        assert mock_runner.run_headless.call_args.kwargs["allow_debugger"] is False
+
     def test_handle_run_omits_shared_mount_when_no_dir(self) -> None:
         """_handle_run omits shared_mount from common dict when shared_dir is None."""
         from terok_executor.commands import _handle_run

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -204,6 +204,40 @@ class TestSharedDirArgs:
             _handle_run(agent="claude", repo=".", prompt="test")
         assert mock_runner.run_headless.call_args.kwargs["allow_debugger"] is False
 
+    @pytest.mark.parametrize("verb", ["run", "run-tool"])
+    def test_debug_flag_parses_on_run_verbs(self, verb: str) -> None:
+        """The actual CLI parser maps ``--debug`` to ``args.debug`` and defaults False.
+
+        Complements the ``_handle_run`` tests above, which bypass the parser:
+        this exercises the real ``RUN_COMMAND`` / ``RUN_TOOL_COMMAND`` token
+        mapping so a missing/mis-``dest``ed ``--debug`` ArgDef would fail here.
+        """
+        import argparse
+
+        from terok_executor._tree import COMMANDS
+
+        def parse(argv: list[str]) -> argparse.Namespace:
+            parser = argparse.ArgumentParser(prog="terok-executor")
+            COMMANDS.wire(parser, argv=argv)
+            return parser.parse_args(argv)
+
+        assert parse([verb, "claude", ".", "--debug"]).debug is True
+        assert parse([verb, "claude", "."]).debug is False
+
+    def test_handle_run_tool_forwards_debug_as_allow_debugger(self) -> None:
+        """``run-tool --debug`` reaches ``run_tool`` as ``allow_debugger``."""
+        from terok_executor.commands import _handle_run_tool
+
+        with (
+            patch("terok_executor.commands._setup_verdict_or_exit"),
+            patch("terok_executor.commands._preflight_or_exit", return_value=True),
+            patch("terok_executor.container.runner.AgentRunner") as mock_cls,
+        ):
+            mock_runner = mock_cls.return_value
+            mock_runner.run_tool.return_value = "terok-executor-tool"
+            _handle_run_tool(tool="coderabbit", repo=".", debug=True)
+        assert mock_runner.run_tool.call_args.kwargs["allow_debugger"] is True
+
     def test_handle_run_omits_shared_mount_when_no_dir(self) -> None:
         """_handle_run omits shared_mount from common dict when shared_dir is None."""
         from terok_executor.commands import _handle_run

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -767,6 +767,42 @@ class TestLaunchPrepared:
         assert kwargs["task_id"] == ""
         assert kwargs["dossier_path"] is None
 
+    def test_allow_debugger_propagates_to_sidecar(self, tmp_path: Path) -> None:
+        """``allow_debugger=True`` reaches ``write_sidecar`` so the supervisor
+        children leave themselves ptrace-able."""
+        sandbox = _mock_sandbox()
+        runner = AgentRunner(sandbox=sandbox)
+
+        with patch("terok_executor.integrations.sandbox.write_sidecar") as write_sidecar:
+            runner.launch_prepared(
+                env={},
+                volumes=[],
+                image="img",
+                command=[],
+                name="c",
+                task_dir=tmp_path,
+                allow_debugger=True,
+            )
+
+        assert write_sidecar.call_args.kwargs["allow_debugger"] is True
+
+    def test_allow_debugger_defaults_to_hardened(self, tmp_path: Path) -> None:
+        """Absent the flag, the sidecar records full hardening (fail-closed)."""
+        sandbox = _mock_sandbox()
+        runner = AgentRunner(sandbox=sandbox)
+
+        with patch("terok_executor.integrations.sandbox.write_sidecar") as write_sidecar:
+            runner.launch_prepared(
+                env={},
+                volumes=[],
+                image="img",
+                command=[],
+                name="c",
+                task_dir=tmp_path,
+            )
+
+        assert write_sidecar.call_args.kwargs["allow_debugger"] is False
+
     def test_gate_fields_written_when_token_in_env(self, tmp_path: Path) -> None:
         """A ``TEROK_GATE_TOKEN`` in the env wires the gate into the sidecar.
 

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a15"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl" }
+version = "0.5.0a16"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2329,7 +2329,7 @@ dependencies = [
     { name = "terok-util" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl", hash = "sha256:789d565d3c79197002f0f7986207b9e2a7e5a6555577f791a464feda5b9a14aa" },
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl", hash = "sha256:fb2bcec4afca6c5a8b4081170c7686d7e87b6058681b9264ecbd3cf573888dae" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
## What

Adds an `allow_debugger` opt-in that rides from the executor CLI/API all the way down to `write_sidecar(allow_debugger=...)` (landed in terok-sandbox 0.5.0a12), so an operator can launch a task with the supervisor children left ptrace-able and debug the per-service split processes.

Only the `PR_SET_DUMPABLE=0` clear is skipped; `RLIMIT_CORE=0` and `mlockall` still apply. The explicit flag is the sole hardening authority (**fail-closed**) — it is deliberately *not* derived from `-O` / `__debug__`.

## Changes

- **`container/runner.py`** — `launch_prepared` gains `allow_debugger` and forwards it to `write_sidecar`; `_run` + the three public `run_headless` / `run_interactive` / `run_web` entry points thread it through.
- **`commands.py`** — `terok-executor run --debug` maps to `allow_debugger` for the standalone-executor path.

## Scope

Bottom half of the operator-facing UX for **terok-ai/terok#1176** (the CLI-only debug-mode trigger). terok's own `_run_container` calls `launch_prepared(allow_debugger=...)`; the terok CLI flag + read-only TUI badge land in a follow-up terok PR that pins this branch.

The sandbox mechanism (sidecar field + child hardening opt-out) already shipped in the supervisor-split chain.

## Tests

- `launch_prepared` propagates `allow_debugger` to `write_sidecar`, and defaults to fully hardened (fail-closed).
- `_handle_run` maps `--debug` → `allow_debugger`, default `False`.

Full unit suite green (1166 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--debug` option to the `terok-executor run` and `terok-executor run-tool` commands.
  * When enabled, debugger attachment is allowed for supported execution modes via an `allow_debugger` setting.
  * Debugging remains disabled by default.
* **Tests**
  * Added coverage to ensure the debug setting is correctly parsed from the CLI and passed through to the launch paths.
  * Added tests validating sidecar behavior for `allow_debugger` enabled/disabled.
* **Chores**
  * Updated the `terok-sandbox` dependency to the latest available version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->