### PR TITLE
chore(deps): advance landlock chain pins to the util-rooted tips

### DIFF
--- a/docs/vault.md
+++ b/docs/vault.md
@@ -101,8 +101,8 @@ The config-patch mechanism writes the vault socket path into
 `~/.config/gh/config.yml` after `terok-executor auth gh` — the
 `{vault_socket}` template token, resolved per transport mode:
 
-- **socket mode**: `/run/terok/vault.sock` — the supervisor's vault
-  socket, bind-mounted into the container.
+- **socket mode**: `/run/terok/vault/vault.sock` — the supervisor's vault
+  socket, exposed through the read-only runtime-tree mount.
 - **TCP mode**: `/tmp/terok-vault.sock` — a socat bridge started by
   terok-sandbox's `ensure-bridges.sh`, forwarding to
   `host.containers.internal:${TEROK_TOKEN_BROKER_PORT}`.
@@ -197,8 +197,9 @@ block and have no agent YAML at all).
   for this because it's a routing concern, not a credential concern.
 
 - **socat bridges**: terok-sandbox's `ensure-bridges.sh` runs in-container.
-  In socket mode the broker socket is bind-mounted at
-  `/run/terok/vault.sock` and the bridge fronts it as TCP on
+  In socket mode the broker socket is exposed at
+  `/run/terok/vault/vault.sock` through the read-only runtime-tree mount,
+  and the bridge fronts it as TCP on
   `localhost:9419` for HTTP-only clients.  In TCP mode the bridge is
   reversed: it presents `/tmp/terok-vault.sock` for socket-only clients
   and forwards `localhost:9419` to the per-container host port.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/landlock-write-confinement",
-    "terok-util @ git+https://github.com/sliwowitz/terok-util.git@feat/landlock-fs-confinement",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a21/terok_sandbox-0.5.0a21-py3-none-any.whl",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
     "tomli-w~=1.2",
@@ -91,7 +91,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.4.0a19"
+fallback-version = "0.4.0a20"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_executor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a20/terok_sandbox-0.5.0a20-py3-none-any.whl",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/landlock-write-confinement",
+    "terok-util @ git+https://github.com/sliwowitz/terok-util.git@feat/landlock-fs-confinement",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
     "tomli-w~=1.2",

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -30,13 +30,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from terok_executor._util import detect_host_timezone
-from terok_executor.integrations.sandbox import Sharing, VolumeSpec
+from terok_executor.integrations.sandbox import (
+    CONTAINER_SSH_SIGNER_SOCKET,
+    CONTAINER_VAULT_SOCKET,
+    Sharing,
+    VolumeSpec,
+)
 from terok_executor.roster.types import EgressProjection
 
-_CONTAINER_RUNTIME_DIR = "/run/terok"
-"""Container-side mount point — must match [`terok_sandbox.CONTAINER_RUNTIME_DIR`][terok_sandbox.CONTAINER_RUNTIME_DIR]."""
-
-CONTAINER_PROTOCOL = 1
+CONTAINER_PROTOCOL = 2
 """Version of the host↔container env/script contract.
 
 Emitted to every container as ``TEROK_CONTAINER_PROTOCOL``.  In-container
@@ -646,7 +648,7 @@ def _inject_vault_tokens(
         # + ad-hoc callers that don't pass one.  In production the runner
         # always provides ``per_container`` so concurrent containers get
         # distinct ports.
-        port = (
+        allocated_port = (
             per_container.token_broker_port if per_container is not None else cfg.token_broker_port
         )
     except Exception:
@@ -658,6 +660,7 @@ def _inject_vault_tokens(
         db.close()
 
     use_socket = vault_transport == "socket"
+    port = None if use_socket else allocated_port
     # Resolve the single container-side vault address used by every
     # socket/URL injection below.  Socket mode points at the mounted host
     # socket + a loopback HTTP bridge; TCP mode points at the broker's TCP
@@ -707,7 +710,9 @@ def _inject_vault_tokens(
             env["GITLAB_API_HOST"] = host_tcp if host_tcp else f"localhost:{LOOPBACK_VAULT_PORT}"
 
     if routed:
-        if port:
+        if use_socket:
+            env["TEROK_VAULT_SOCKET"] = CONTAINER_VAULT_SOCKET
+        elif port:
             env["TEROK_TOKEN_BROKER_PORT"] = str(port)
         # The in-container loopback bridge runs in both transports
         # (socat unix→vault.sock or socat tcp→host:broker), so the URL
@@ -718,7 +723,7 @@ def _inject_vault_tokens(
     if ssh_token:
         env["TEROK_SSH_SIGNER_TOKEN"] = ssh_token
         if use_socket:
-            env["TEROK_SSH_SIGNER_SOCKET"] = f"{_CONTAINER_RUNTIME_DIR}/ssh-agent.sock"
+            env["TEROK_SSH_SIGNER_SOCKET"] = CONTAINER_SSH_SIGNER_SOCKET
         else:
             # Per-container port (production); fallback to cfg (tests).
             # See ``port`` resolution above for the same shape.

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -576,6 +576,8 @@ class AgentRunner:
                 NVIDIA CDI.
         """
         from terok_executor.integrations.sandbox import (
+            CONTAINER_GATE_SOCKET,
+            CONTAINER_RUNTIME_DIR,
             GpuConfigError,
             RunSpec,
             Sharing,
@@ -605,36 +607,55 @@ class AgentRunner:
         if per_container is None:
             per_container = allocate_per_container_resources(cfg, name)
 
-        # Bind-mount the per-container socket dir at /run/terok/.  The
-        # supervisor's later-bound vault.sock + ssh-agent.sock surface
-        # inside the container via this single mount (instead of two
-        # singleton file-mounts that two containers would collide on).
         env = dict(env)
         volumes = list(volumes)
-        volumes.append(
-            VolumeSpec(
-                per_container.container_runtime_dir,
-                "/run/terok",
-                sharing=Sharing.SHARED,
-                live=True,
+        gate_active = "TEROK_GATE_TOKEN" in env
+        if cfg.services_mode == "socket":
+            # The read-only runtime-tree mount exposes later-bound service
+            # sockets while preventing the agent from replacing socket inodes
+            # or gate runtime files.  TCP mode needs no runtime-tree access.
+            volumes.append(
+                VolumeSpec(
+                    per_container.container_runtime_dir,
+                    CONTAINER_RUNTIME_DIR,
+                    sharing=Sharing.SHARED,
+                    read_only=True,
+                    live=True,
+                )
             )
-        )
+
         # TCP-mode env vars carry the per-container port, not the
         # host-singleton ``cfg.token_broker_port`` — the launch flow
         # routes through the per-container ports only.
         if cfg.services_mode == "tcp":
+            env.pop("TEROK_VAULT_SOCKET", None)
+            env.pop("TEROK_SSH_SIGNER_SOCKET", None)
+            env.pop("TEROK_GATE_SOCKET", None)
             if per_container.token_broker_port is not None:
                 env["TEROK_TOKEN_BROKER_PORT"] = str(per_container.token_broker_port)
+            else:
+                env.pop("TEROK_TOKEN_BROKER_PORT", None)
             if per_container.ssh_signer_port is not None:
                 env["TEROK_SSH_SIGNER_PORT"] = str(per_container.ssh_signer_port)
-            if per_container.gate_port is not None:
+            else:
+                env.pop("TEROK_SSH_SIGNER_PORT", None)
+            if gate_active and per_container.gate_port is not None:
                 env["TEROK_GATE_PORT"] = str(per_container.gate_port)
+            else:
+                env.pop("TEROK_GATE_PORT", None)
+        else:
+            env.pop("TEROK_TOKEN_BROKER_PORT", None)
+            env.pop("TEROK_SSH_SIGNER_PORT", None)
+            env.pop("TEROK_GATE_PORT", None)
+            if gate_active:
+                env["TEROK_GATE_SOCKET"] = CONTAINER_GATE_SOCKET
+            else:
+                env.pop("TEROK_GATE_SOCKET", None)
 
-        # The gate is wired when the prepared env carries a gate token
-        # (set by ``_setup_gate`` / the orchestrator).  When active, the
-        # supervisor needs the mirror base path, the token, and — in TCP
-        # mode — the port to serve the gate in-process.
-        gate_active = "TEROK_GATE_TOKEN" in env
+        # The gate is wired only when the prepared env carries a token
+        # (set by ``_setup_gate`` / the orchestrator).  Its sidecar fields
+        # below follow the same predicate as the mutually exclusive
+        # socket/port bridge variables above.
 
         # Write the per-container supervisor sidecar before podman run.
         # The terok-sandbox OCI hook installed by ``terok-sandbox setup``
@@ -674,7 +695,7 @@ class AgentRunner:
         loopback_ports = tuple(
             p
             for p in (
-                per_container.gate_port,
+                per_container.gate_port if gate_active else None,
                 per_container.token_broker_port,
                 per_container.ssh_signer_port,
             )
@@ -1011,6 +1032,9 @@ class AgentRunner:
                 "agent_config_dir": agent_config_dir,
                 "envs_dir": mounts_base,
                 "timezone": timezone,
+                "vault_transport": (
+                    "socket" if self.sandbox.config.services_mode == "socket" else "direct"
+                ),
             }
             if human_name:
                 spec_kwargs["human_name"] = human_name

--- a/src/terok_executor/credentials/vault_config.py
+++ b/src/terok_executor/credentials/vault_config.py
@@ -267,9 +267,9 @@ def resolve_vault_location(token_broker_port: int | None = None) -> VaultLocatio
     — the bridge runs in both transports and forwards to the
     transport-specific target (host unix socket or per-container host
     TCP port).  *token_broker_port* picks the socket-facade shape for
-    socket-only clients: ``/run/terok/vault.sock`` in socket mode (the
-    bind-mounted host socket), ``/tmp/terok-vault.sock`` in TCP mode
-    (in-container socat unix→host-TCP).
+    socket-only clients: ``/run/terok/vault/vault.sock`` in socket mode
+    (exposed through the read-only runtime-tree mount),
+    ``/tmp/terok-vault.sock`` in TCP mode (in-container socat unix→host-TCP).
     """
     from terok_executor.vault_addr import (
         CONTAINER_VAULT_SOCKET,

--- a/src/terok_executor/doctor.py
+++ b/src/terok_executor/doctor.py
@@ -123,7 +123,7 @@ def _make_vault_bridge_check(*, socket_mode: bool) -> DoctorCheck:
     (for socket-only clients).
     """
     if socket_mode:
-        label = "Vault loopback bridge (TCP → /run/terok/vault.sock)"
+        label = f"Vault loopback bridge (TCP → {CONTAINER_VAULT_SOCKET})"
         probe = (
             f"test -S {CONTAINER_VAULT_SOCKET}"
             f" && kill -0 $(cat {_VAULT_LOOPBACK_PIDFILE} 2>/dev/null) 2>/dev/null"

--- a/src/terok_executor/integrations/sandbox.py
+++ b/src/terok_executor/integrations/sandbox.py
@@ -37,7 +37,10 @@ lives at ``terok.lib.integrations.*``).
 
 from terok_sandbox import (  # noqa: F401 — re-exported public API
     CODEX_SHARED_OAUTH_MARKER,
+    CONTAINER_GATE_SOCKET,
     CONTAINER_RUNTIME_DIR,
+    CONTAINER_SSH_SIGNER_SOCKET,
+    CONTAINER_VAULT_SOCKET,
     PHANTOM_CREDENTIALS_MARKER,
     READY_MARKER,
     ConfigScope,
@@ -92,7 +95,10 @@ from terok_sandbox.doctor import CheckVerdict, DoctorCheck  # noqa: F401 — re-
 __all__ = [
     "CODEX_SHARED_OAUTH_MARKER",
     "COMMANDS",
+    "CONTAINER_GATE_SOCKET",
     "CONTAINER_RUNTIME_DIR",
+    "CONTAINER_SSH_SIGNER_SOCKET",
+    "CONTAINER_VAULT_SOCKET",
     "PHANTOM_CREDENTIALS_MARKER",
     "READY_MARKER",
     "CheckVerdict",

--- a/src/terok_executor/vault_addr.py
+++ b/src/terok_executor/vault_addr.py
@@ -23,9 +23,9 @@ every layer imports the same value.
 
 from __future__ import annotations
 
-from terok_executor.integrations.sandbox import CONTAINER_RUNTIME_DIR
+from terok_executor.integrations.sandbox import CONTAINER_VAULT_SOCKET as _CONTAINER_VAULT_SOCKET
 
-CONTAINER_VAULT_SOCKET = f"{CONTAINER_RUNTIME_DIR}/vault.sock"
+CONTAINER_VAULT_SOCKET = _CONTAINER_VAULT_SOCKET
 """Host vault socket as seen inside the container (socket mode only)."""
 
 LOOPBACK_BRIDGE_SOCKET = "/tmp/terok-vault.sock"  # nosec B108 — container-only path

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,9 +38,8 @@ TEST_VAULT_PASSPHRASE = "unit-test-passphrase"  # nosec: B105 — fixture, not a
 
 
 # Terok-specific env vars that override path resolution.  The autouse
-# isolation fixture unsets each so resolution falls back through the
-# tmp-rooted ``HOME`` / ``XDG_*`` chain — never to the operator's real
-# state.
+# isolation fixture clears them before applying its own isolated values;
+# most paths then fall through the tmp-rooted ``HOME`` / ``XDG_*`` chain.
 _TEROK_PATH_OVERRIDE_ENV_VARS = (
     "TEROK_CONFIG_DIR",
     "TEROK_STATE_DIR",
@@ -84,6 +83,11 @@ def _isolate_user_paths(
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(fake_home / "run"))
     for var in _TEROK_PATH_OVERRIDE_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
+    # pytest's nested tmp path plus the normal XDG namespace can exceed
+    # Linux's AF_UNIX pathname limit once the per-service lanes are added.
+    # Keep the runtime root short but still isolated beneath this test's
+    # fake home.
+    monkeypatch.setenv("TEROK_SANDBOX_RUNTIME_DIR", str(fake_home / "r"))
     # ``terok_executor.cli`` mutates ``os.environ["TEROK_CONFIG_FILE"]``
     # for ``--config`` / ``--raw`` directly (not via monkeypatch), so an
     # earlier in-process ``_run_cli`` would leak across tests.

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -15,6 +15,7 @@ from terok_executor.doctor import (
     _make_ssh_bridge_check,
     _make_vault_bridge_check,
 )
+from terok_executor.integrations.sandbox import CONTAINER_VAULT_SOCKET
 from terok_executor.roster import AgentRoster
 
 TOKEN_BROKER_PORT = 18731
@@ -72,7 +73,7 @@ class TestVaultBridgeCheck:
     def test_socket_mode_probes_mounted_vault_socket(self) -> None:
         check = _make_vault_bridge_check(socket_mode=True)
         probe = " ".join(check.probe_cmd)
-        assert "/run/terok/vault.sock" in probe
+        assert CONTAINER_VAULT_SOCKET in probe
         assert "vault-loopback.pid" in probe
 
     def test_tcp_mode_probes_local_bridge_socket(self) -> None:

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -20,6 +20,10 @@ from terok_executor.container.env import (
     _shared_config_mounts,
     assemble_container_env,
 )
+from terok_executor.integrations.sandbox import (
+    CONTAINER_SSH_SIGNER_SOCKET,
+    CONTAINER_VAULT_SOCKET,
+)
 from terok_executor.roster import AgentRoster
 from tests.unit.conftest import TEST_VAULT_PASSPHRASE
 
@@ -157,6 +161,7 @@ class TestBaseEnv:
         from terok_executor.container.env import CONTAINER_PROTOCOL
 
         result = assemble_container_env(base_spec, roster, caller_manages_vault=True)
+        assert CONTAINER_PROTOCOL == 2
         assert result.env["TEROK_CONTAINER_PROTOCOL"] == str(CONTAINER_PROTOCOL)
 
 
@@ -551,13 +556,15 @@ class TestVaultTokenInjection:
         assert "ANTHROPIC_API_KEY" not in result.env
 
     def test_vault_socket_transport_injects_socket_env(self, workspace, envs_dir, roster, tmp_path):
-        """Socket transport points socket_env at the mounted host vault socket."""
-        cfg = dataclasses.replace(_make_vault_db(tmp_path), token_broker_port=None)
+        """Socket transport ignores a stale configured TCP broker port."""
+        cfg = dataclasses.replace(_make_vault_db(tmp_path), token_broker_port=18731)
         spec = _spec(workspace, envs_dir, credential_scope="proj", vault_transport="socket")
         with patch("terok_executor.integrations.sandbox.SandboxConfig", return_value=cfg):
             result = assemble_container_env(spec, roster, caller_manages_vault=False)
 
-        assert result.env["ANTHROPIC_UNIX_SOCKET"] == "/run/terok/vault.sock"
+        assert result.env["ANTHROPIC_UNIX_SOCKET"] == CONTAINER_VAULT_SOCKET
+        assert result.env["TEROK_VAULT_SOCKET"] == CONTAINER_VAULT_SOCKET
+        assert "TEROK_TOKEN_BROKER_PORT" not in result.env
 
     def test_vault_direct_transport_points_socket_at_local_bridge(
         self, workspace, envs_dir, roster, tmp_path
@@ -569,6 +576,7 @@ class TestVaultTokenInjection:
             result = assemble_container_env(spec, roster, caller_manages_vault=False)
 
         assert result.env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-vault.sock"
+        assert "TEROK_VAULT_SOCKET" not in result.env
 
     def test_vault_socket_transport_omits_tcp_broker_env_when_port_none(
         self, workspace, envs_dir, roster, tmp_path
@@ -590,7 +598,8 @@ class TestVaultTokenInjection:
         # GITLAB_API_HOST is now always set for glab — but never with "None".
         assert not any("None" in v for v in result.env.values())
         # Socket transport uses the mounted host socket directly.
-        assert result.env.get("ANTHROPIC_UNIX_SOCKET") == "/run/terok/vault.sock"
+        assert result.env.get("ANTHROPIC_UNIX_SOCKET") == CONTAINER_VAULT_SOCKET
+        assert result.env.get("TEROK_VAULT_SOCKET") == CONTAINER_VAULT_SOCKET
         # The in-container loopback port is advertised so ensure-bridges.sh
         # stands up its TCP→UNIX bridge.
         assert result.env.get("TEROK_VAULT_LOOPBACK_PORT") == "9419"
@@ -665,7 +674,7 @@ class TestVaultTokenInjection:
             result = assemble_container_env(spec, roster, caller_manages_vault=False)
 
         assert "TEROK_SSH_SIGNER_TOKEN" in result.env
-        assert result.env["TEROK_SSH_SIGNER_SOCKET"] == "/run/terok/ssh-agent.sock"
+        assert result.env["TEROK_SSH_SIGNER_SOCKET"] == CONTAINER_SSH_SIGNER_SOCKET
         assert "TEROK_SSH_SIGNER_PORT" not in result.env
 
     def test_vault_no_ssh_keys_omits_token(self, workspace, envs_dir, roster, tmp_path):

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -12,6 +12,10 @@ from unittest.mock import Mock, patch
 import pytest
 
 from terok_executor.container.runner import AgentRunner, _generate_task_id, _resolve_repo
+from terok_executor.integrations.sandbox import (
+    CONTAINER_GATE_SOCKET,
+    CONTAINER_RUNTIME_DIR,
+)
 
 
 class TestResolveRepo:
@@ -863,6 +867,7 @@ class TestLaunchPrepared:
         assert kwargs["gate_base_path"] == str(cfg.gate_base_path)
         # gate_port mirrors the per-container allocation (None in socket mode).
         assert "gate_port" in kwargs
+        assert sandbox.run.call_args[0][0].env["TEROK_GATE_SOCKET"] == CONTAINER_GATE_SOCKET
 
     def test_gate_fields_absent_without_token(self, tmp_path: Path) -> None:
         """No gate token in the env → no gate config in the sidecar."""
@@ -883,6 +888,7 @@ class TestLaunchPrepared:
         assert kwargs["gate_token"] is None
         assert kwargs["gate_base_path"] is None
         assert kwargs["gate_port"] is None
+        assert "TEROK_GATE_SOCKET" not in sandbox.run.call_args[0][0].env
 
 
 class TestLaunchPreparedSupervisorWiring:
@@ -929,7 +935,11 @@ class TestLaunchPreparedSupervisorWiring:
         runner = AgentRunner(sandbox=sandbox)
 
         runner.launch_prepared(
-            env={},
+            env={
+                "TEROK_TOKEN_BROKER_PORT": "1",
+                "TEROK_SSH_SIGNER_PORT": "2",
+                "TEROK_GATE_PORT": "3",
+            },
             volumes=[],
             image="img",
             command=[],
@@ -973,7 +983,10 @@ class TestLaunchPreparedSupervisorWiring:
             return_value=fixed,
         ):
             runner.launch_prepared(
-                env={},
+                env={
+                    "TEROK_GATE_TOKEN": "terok-g-fixed",
+                    "TEROK_GATE_SOCKET": CONTAINER_GATE_SOCKET,
+                },
                 volumes=[],
                 image="img",
                 command=[],
@@ -985,9 +998,51 @@ class TestLaunchPreparedSupervisorWiring:
         assert spec.env["TEROK_TOKEN_BROKER_PORT"] == "51001"
         assert spec.env["TEROK_SSH_SIGNER_PORT"] == "51002"
         assert spec.env["TEROK_GATE_PORT"] == "51003"
+        assert "TEROK_GATE_SOCKET" not in spec.env
+        assert all(v.container_path != CONTAINER_RUNTIME_DIR for v in spec.volumes)
         # loopback_ports is the (gate, broker, ssh) listeners, all present in TCP mode.
         assert set(spec.loopback_ports) == {51001, 51002, 51003}
         assert len(spec.loopback_ports) == 3
+
+    def test_tcp_mode_omits_inactive_gate_transport(self, tmp_path: Path) -> None:
+        """TCP mode exposes neither gate transport without a gate token."""
+        from terok_sandbox import PerContainerResources, SandboxConfig
+
+        sandbox = _mock_sandbox()
+        sandbox.config = SandboxConfig(
+            state_dir=tmp_path / "state",
+            vault_dir=tmp_path / "credentials",
+            services_mode="tcp",
+        )
+        runner = AgentRunner(sandbox=sandbox)
+        fixed = PerContainerResources(
+            container_runtime_dir=Path("/run/terok/sandbox/run/c"),
+            token_broker_port=51101,
+            ssh_signer_port=51102,
+            gate_port=51103,
+        )
+
+        with patch(
+            "terok_executor.integrations.sandbox.allocate_per_container_resources",
+            return_value=fixed,
+        ):
+            runner.launch_prepared(
+                env={
+                    "TEROK_GATE_PORT": "3",
+                    "TEROK_GATE_SOCKET": CONTAINER_GATE_SOCKET,
+                },
+                volumes=[],
+                image="img",
+                command=[],
+                name="c",
+                task_dir=tmp_path,
+            )
+
+        spec = sandbox.run.call_args[0][0]
+        assert "TEROK_GATE_PORT" not in spec.env
+        assert "TEROK_GATE_SOCKET" not in spec.env
+        assert set(spec.loopback_ports) == {51101, 51102}
+        assert all(v.container_path != CONTAINER_RUNTIME_DIR for v in spec.volumes)
 
     def test_run_threads_one_per_container_through_env_and_launch(self, tmp_path: Path) -> None:
         """``_run`` allocates per-container resources ONCE and threads the same
@@ -1025,6 +1080,7 @@ class TestLaunchPreparedSupervisorWiring:
 
         def _spy_assemble(spec, roster, **kwargs):  # type: ignore[no-untyped-def]
             seen["per_container"] = kwargs.get("per_container")
+            seen["vault_transport"] = spec.vault_transport
             return real_assemble(spec, roster, **kwargs)
 
         with (
@@ -1042,12 +1098,35 @@ class TestLaunchPreparedSupervisorWiring:
         alloc.assert_called_once()
         # Env assembly saw the SAME instance the supervisor binds.
         assert seen["per_container"] is fixed
+        assert seen["vault_transport"] == "direct"
         spec = sandbox.run.call_args[0][0]
-        assert set(spec.loopback_ports) == {52001, 52002, 52003}
+        # No repository means no gate mirror, so only the broker and signer
+        # listeners belong in the allow-list.
+        assert set(spec.loopback_ports) == {52001, 52002}
 
-    def test_runtime_dir_mount_added(self, tmp_path: Path) -> None:
-        """A ``/run/terok`` bind-mount is always appended so the supervisor's
-        later-bound sockets surface inside the container via one mount."""
+    def test_run_derives_socket_vault_transport_from_sandbox(self, tmp_path: Path) -> None:
+        """Standalone socket mode selects socket transport for env assembly."""
+        import terok_executor.container.env as env_mod
+
+        sandbox = _mock_sandbox()
+        runner = AgentRunner(sandbox=sandbox)
+        seen: dict[str, str] = {}
+        real_assemble = env_mod.assemble_container_env
+
+        def _spy_assemble(spec, roster, **kwargs):  # type: ignore[no-untyped-def]
+            seen["vault_transport"] = spec.vault_transport
+            return real_assemble(spec, roster, **kwargs)
+
+        with (
+            patch.object(env_mod, "assemble_container_env", _spy_assemble),
+            patch.object(runner, "_ensure_images", return_value="terok-l1-cli:test"),
+        ):
+            runner.run_headless("claude", None, workspace=tmp_path, prompt="x", follow=False)
+
+        assert seen["vault_transport"] == "socket"
+
+    def test_socket_mode_adds_read_only_runtime_dir_mount(self, tmp_path: Path) -> None:
+        """Socket mode exposes the supervisor runtime tree read-only."""
         sandbox = _mock_sandbox()
         runner = AgentRunner(sandbox=sandbox)
 
@@ -1061,8 +1140,9 @@ class TestLaunchPreparedSupervisorWiring:
         )
 
         spec = sandbox.run.call_args[0][0]
-        mount = next(v for v in spec.volumes if v.container_path == "/run/terok")
+        mount = next(v for v in spec.volumes if v.container_path == CONTAINER_RUNTIME_DIR)
         assert mount is not None
+        assert mount.read_only is True
 
 
 class TestWaitForExit:

--- a/uv.lock
+++ b/uv.lock
@@ -2205,24 +2205,13 @@ wheels = [
 
 [[package]]
 name = "terok-clearance"
-version = "0.8.0a7"
-source = { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a7/terok_clearance-0.8.0a7-py3-none-any.whl" }
+version = "0.8.0a8.dev216+g55c9f6702"
+source = { git = "https://github.com/sliwowitz/terok-clearance.git?rev=chore%2Futil-landlock-pin#55c9f67026f30b9df580b38f257c2473231f12ef" }
 dependencies = [
     { name = "asyncvarlink" },
     { name = "dbus-fast" },
     { name = "pyyaml" },
     { name = "terok-util" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a7/terok_clearance-0.8.0a7-py3-none-any.whl", hash = "sha256:12e357db2049850312571ab15615b61cac74a3e33d0746bcda8addaf4ca308b8" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "asyncvarlink", specifier = "==0.3.2" },
-    { name = "dbus-fast", specifier = "~=5.0" },
-    { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -2276,8 +2265,8 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a20/terok_sandbox-0.5.0a20-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
+    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement" },
+    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Flandlock-fs-confinement" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
 
@@ -2311,8 +2300,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a20"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a20/terok_sandbox-0.5.0a20-py3-none-any.whl" }
+version = "0.5.0a21.dev453+gc3da50a54"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#c3da50a54e020410dbc357edaa678cfaaeca53b7" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2328,65 +2317,25 @@ dependencies = [
     { name = "terok-shield" },
     { name = "terok-util" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a20/terok_sandbox-0.5.0a20-py3-none-any.whl", hash = "sha256:d73b0ea4056a1cb0dca3605e2bcf24be3891692fe2628e5e19bd9e894af08f5c" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = "~=3.14.1" },
-    { name = "cryptography", specifier = "~=49.0" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "keyring", specifier = "~=25.7" },
-    { name = "packaging", specifier = "~=26.2" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "sqlcipher3", specifier = "==0.6.2" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a7/terok_clearance-0.8.0a7-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a8/terok_shield-0.8.0a8-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
-]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a8"
-source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a8/terok_shield-0.8.0a8-py3-none-any.whl" }
+version = "0.8.0a9.dev352+g384510845"
+source = { git = "https://github.com/sliwowitz/terok-shield.git?rev=feat%2Flandlock-confinement#38451084513470a3300c6a95b64bd416ae90d49f" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a8/terok_shield-0.8.0a8-py3-none-any.whl", hash = "sha256:e966d2de3cd15c2649ceaa68e45a96debe54de6eae980d54df058bf8489d6d3e" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
-]
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a4"
-source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" }
+version = "0.3.1a5.dev87+g784797962"
+source = { git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Flandlock-fs-confinement#78479796236fc9f02ab5257b283ff65df22ca270" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl", hash = "sha256:8878f21e8101c5d70e17c7c44737ea5ea1390226738c0e9221f91d7dedfb38b3" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2205,13 +2205,24 @@ wheels = [
 
 [[package]]
 name = "terok-clearance"
-version = "0.8.0a8.dev223+g1d34b069a"
-source = { git = "https://github.com/sliwowitz/terok-clearance.git?rev=chore%2Futil-landlock-pin#1d34b069ac44fc4d7f056a19598981f6091e457a" }
+version = "0.8.0a8"
+source = { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a8/terok_clearance-0.8.0a8-py3-none-any.whl" }
 dependencies = [
     { name = "asyncvarlink" },
     { name = "dbus-fast" },
     { name = "pyyaml" },
     { name = "terok-util" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a8/terok_clearance-0.8.0a8-py3-none-any.whl", hash = "sha256:ee2d98a0011dde0197c7e14c61db38f6cd6235ccb8626f045dcbeef974301648" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "asyncvarlink", specifier = "==0.3.2" },
+    { name = "dbus-fast", specifier = "~=5.0" },
+    { name = "pyyaml", specifier = "~=6.0" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -2265,8 +2276,8 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement" },
-    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Flandlock-fs-confinement" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a21/terok_sandbox-0.5.0a21-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
 
@@ -2300,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a21.dev470+g9207231c4"
-source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#9207231c4d1904b1ed6cd8620d30ea3af5fbfa09" }
+version = "0.5.0a21"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a21/terok_sandbox-0.5.0a21-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2317,25 +2328,65 @@ dependencies = [
     { name = "terok-shield" },
     { name = "terok-util" },
 ]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a21/terok_sandbox-0.5.0a21-py3-none-any.whl", hash = "sha256:da766ddb7979680c6c92f36d1ff7b86cba72543859ffae5ffea8c6ddf1c852c1" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = "~=3.14.1" },
+    { name = "cryptography", specifier = ">=49,<51" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "keyring", specifier = "~=25.7" },
+    { name = "packaging", specifier = "~=26.2" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "prompt-toolkit", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "sqlcipher3", specifier = "==0.6.2" },
+    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a8/terok_clearance-0.8.0a8-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
+]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a9.dev363+gbf57bcef7"
-source = { git = "https://github.com/sliwowitz/terok-shield.git?rev=feat%2Flandlock-confinement#bf57bcef7953ba6edbe2fc13ff74488d4a330f7d" }
+version = "0.8.0a9"
+source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl", hash = "sha256:f3425bdb9e9f01c65f10543bdc9a12306757ea98c1bd50dbbf01cb88340fb503" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "pyyaml", specifier = "~=6.0" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
+]
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a5.dev97+g9e08865a2"
-source = { git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Flandlock-fs-confinement#9e08865a2132d4b1b9b3f859ca05bd18e48fd503" }
+version = "0.3.1a5"
+source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl", hash = "sha256:7be655245a7cf5589909cf2e02b9d85a8a2241db59658808b4043b74de8ec699" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2300,8 +2300,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a21.dev459+g513b81de7"
-source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#513b81de7c53e73d86241d9a48a8a467cbc0952b" }
+version = "0.5.0a21.dev460+g58d287f36"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#58d287f36afd0829169508244bda19207085deb7" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -2300,8 +2300,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a21.dev455+g0053f098c"
-source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#0053f098c89c25b010ff8c15a55314a32133b9ba" }
+version = "0.5.0a21.dev456+g5d8ac5a05"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#5d8ac5a056983cc7cbb0b379f7436ae0b1666713" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -2300,8 +2300,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a21.dev458+g3ca0025aa"
-source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#3ca0025aa3c3814a9d071f6547970e63ed07aea2" }
+version = "0.5.0a21.dev459+g513b81de7"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#513b81de7c53e73d86241d9a48a8a467cbc0952b" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -2205,8 +2205,8 @@ wheels = [
 
 [[package]]
 name = "terok-clearance"
-version = "0.8.0a8.dev218+gd11720679"
-source = { git = "https://github.com/sliwowitz/terok-clearance.git?rev=chore%2Futil-landlock-pin#d11720679951bd474649334933b3c3eb76c594c8" }
+version = "0.8.0a8.dev223+g1d34b069a"
+source = { git = "https://github.com/sliwowitz/terok-clearance.git?rev=chore%2Futil-landlock-pin#1d34b069ac44fc4d7f056a19598981f6091e457a" }
 dependencies = [
     { name = "asyncvarlink" },
     { name = "dbus-fast" },
@@ -2300,8 +2300,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a21.dev460+g58d287f36"
-source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#58d287f36afd0829169508244bda19207085deb7" }
+version = "0.5.0a21.dev470+g9207231c4"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#9207231c4d1904b1ed6cd8620d30ea3af5fbfa09" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2320,8 +2320,8 @@ dependencies = [
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a9.dev357+gc85a3b0fc"
-source = { git = "https://github.com/sliwowitz/terok-shield.git?rev=feat%2Flandlock-confinement#c85a3b0fc43bb3aaa32dcc30e8055cfe2cdf276f" }
+version = "0.8.0a9.dev363+gbf57bcef7"
+source = { git = "https://github.com/sliwowitz/terok-shield.git?rev=feat%2Flandlock-confinement#bf57bcef7953ba6edbe2fc13ff74488d4a330f7d" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -2330,8 +2330,8 @@ dependencies = [
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a5.dev88+g1e095db2b"
-source = { git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Flandlock-fs-confinement#1e095db2bfba84a96116e325c0be77d5494e3991" }
+version = "0.3.1a5.dev97+g9e08865a2"
+source = { git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Flandlock-fs-confinement#9e08865a2132d4b1b9b3f859ca05bd18e48fd503" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },

--- a/uv.lock
+++ b/uv.lock
@@ -2205,8 +2205,8 @@ wheels = [
 
 [[package]]
 name = "terok-clearance"
-version = "0.8.0a8.dev216+g55c9f6702"
-source = { git = "https://github.com/sliwowitz/terok-clearance.git?rev=chore%2Futil-landlock-pin#55c9f67026f30b9df580b38f257c2473231f12ef" }
+version = "0.8.0a8.dev218+gd11720679"
+source = { git = "https://github.com/sliwowitz/terok-clearance.git?rev=chore%2Futil-landlock-pin#d11720679951bd474649334933b3c3eb76c594c8" }
 dependencies = [
     { name = "asyncvarlink" },
     { name = "dbus-fast" },
@@ -2300,8 +2300,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a21.dev453+gc3da50a54"
-source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#c3da50a54e020410dbc357edaa678cfaaeca53b7" }
+version = "0.5.0a21.dev455+g0053f098c"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#0053f098c89c25b010ff8c15a55314a32133b9ba" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2320,8 +2320,8 @@ dependencies = [
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a9.dev352+g384510845"
-source = { git = "https://github.com/sliwowitz/terok-shield.git?rev=feat%2Flandlock-confinement#38451084513470a3300c6a95b64bd416ae90d49f" }
+version = "0.8.0a9.dev356+gc213a3c88"
+source = { git = "https://github.com/sliwowitz/terok-shield.git?rev=feat%2Flandlock-confinement#c213a3c88a896d5c18bd2703f7af7f469a8fa1cf" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -2330,8 +2330,8 @@ dependencies = [
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a5.dev87+g784797962"
-source = { git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Flandlock-fs-confinement#78479796236fc9f02ab5257b283ff65df22ca270" }
+version = "0.3.1a5.dev88+g1e095db2b"
+source = { git = "https://github.com/sliwowitz/terok-util.git?rev=feat%2Flandlock-fs-confinement#1e095db2bfba84a96116e325c0be77d5494e3991" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },

--- a/uv.lock
+++ b/uv.lock
@@ -2300,8 +2300,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a21.dev456+g5d8ac5a05"
-source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#5d8ac5a056983cc7cbb0b379f7436ae0b1666713" }
+version = "0.5.0a21.dev458+g3ca0025aa"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Flandlock-write-confinement#3ca0025aa3c3814a9d071f6547970e63ed07aea2" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2320,8 +2320,8 @@ dependencies = [
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a9.dev356+gc213a3c88"
-source = { git = "https://github.com/sliwowitz/terok-shield.git?rev=feat%2Flandlock-confinement#c213a3c88a896d5c18bd2703f7af7f469a8fa1cf" }
+version = "0.8.0a9.dev357+gc85a3b0fc"
+source = { git = "https://github.com/sliwowitz/terok-shield.git?rev=feat%2Flandlock-confinement#c85a3b0fc43bb3aaa32dcc30e8055cfe2cdf276f" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },


### PR DESCRIPTION
Advances terok-util and terok-sandbox to the finalized Landlock chain and consumes sandbox's isolated service-socket contract.

- Uses sandbox's canonical nested paths: `/run/terok/vault/vault.sock`, `/run/terok/signer/ssh-agent.sock`, and `/run/terok/gate/gate-server.sock`.
- Mounts the per-container runtime tree read-only and only in socket mode; TCP mode receives no runtime-tree mount.
- Keeps socket and TCP transport variables mutually exclusive for vault, signer, and gate.
- Wires the gate only when a gate token is active, including its sidecar fields and loopback allow-list.
- Derives standalone vault transport from `SandboxConfig.services_mode`.
- Bumps `TEROK_CONTAINER_PROTOCOL` to 2 for the breaking socket-path contract.

### Dependency-chain note

The lower sibling branch pins are deliberate while the chained PRs are unreleased; `uv.lock` resolves sandbox to `58d287f3` and its reviewed transitive chain to util `1e095db2`, clearance `d1172067`, and shield `c85a3b0f`. The release workflow will replace the branch references after the lower-layer PRs are released.

Tests cover both transports, stale opposite-mode variables, inactive gates, read-only/socket-only mounts, canonical doctor probes, and the finalized lower-layer branch heads.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved container connectivity for Vault, SSH signing, and gate services in socket and TCP modes.
  - Socket-mode containers now receive the required read-only runtime access automatically.
  - Gate networking is exposed only when an active gate token is present.
  - Improved handling of per-container TCP port assignments and stale connection settings.

- **Documentation**
  - Updated Vault socket path guidance to reflect the current runtime layout.

- **Bug Fixes**
  - Corrected socket-based Vault bridge and credential configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->