### PR TITLE
feat(egress): roster egress projection into shield tiers (ROSTER v3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/terok-ai/terok-sandbox.git@refs/pull/493/head",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ git+https://github.com/terok-ai/terok-sandbox.git@refs/pull/493/head",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a18/terok_sandbox-0.5.0a18-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",
@@ -91,7 +91,7 @@ allow-direct-references = true
 
 [tool.hatch.version]
 source = "vcs"
-fallback-version = "0.4.0a16"
+fallback-version = "0.4.0a17"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/terok_executor"]

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -110,7 +110,10 @@ if TYPE_CHECKING:
         get_agent as get_agent,
         resolve_agent_value as resolve_agent_value,
     )
-    from .roster import AgentRoster as AgentRoster
+    from .roster import (
+        AgentRoster as AgentRoster,
+        EgressProjection as EgressProjection,
+    )
     from .sandbox import ensure_sandbox_ready as ensure_sandbox_ready
     from .storage import (
         SharedMountStorageInfo as SharedMountStorageInfo,
@@ -169,6 +172,7 @@ _LAZY: dict[str, str] = {
     "AgentRunner": ".container.runner",
     # Roster (agent catalog + config resolution)
     "AgentRoster": ".roster",
+    "EgressProjection": ".roster",
     # Command registries
     "COMMANDS": "._tree",
     "AGENT_COMMANDS": ".commands:COMMANDS",

--- a/src/terok_executor/__init__.py
+++ b/src/terok_executor/__init__.py
@@ -69,6 +69,7 @@ if TYPE_CHECKING:
         ImageSet as ImageSet,
         build_project_image as build_project_image,
         known_family as known_family,
+        package_repo_hosts as package_repo_hosts,
     )
     from .container.cache import seed_workspace_from_clone_cache as seed_workspace_from_clone_cache
     from .container.env import (
@@ -162,6 +163,7 @@ _LAZY: dict[str, str] = {
     "ImageSet": ".container.build",
     "build_project_image": ".container.build",
     "known_family": ".container.build",
+    "package_repo_hosts": ".container.build",
     # Container environment assembly
     "ContainerEnvSpec": ".container.env",
     "assemble_container_env": ".container.env",

--- a/src/terok_executor/container/build.py
+++ b/src/terok_executor/container/build.py
@@ -412,6 +412,51 @@ def known_family(base_image: str, override: str | None = None) -> str | None:
     return None
 
 
+#: Package-repository hosts per package family — the egress a task needs so
+#: in-container ``dnf``/``apt`` installs keep working under a shield-up
+#: posture.  Anchored on the officially tested bases (fedora, ubuntu,
+#: quay.io/podman, NVIDIA HPC) plus the common ``family:``-override distros
+#: (Rocky/Alma).  Hostname allowlists cannot cover community mirror pools;
+#: the fedoraproject/rockylinux/almalinux entries include the metalink and
+#: primary-download hosts, and on the dnsmasq DNS tier any *.fedoraproject.org
+#: subdomain is admitted by suffix match.
+_PACKAGE_REPO_HOSTS: dict[str, tuple[str, ...]] = {
+    "rpm": (
+        "mirrors.fedoraproject.org",
+        "dl.fedoraproject.org",
+        "download.fedoraproject.org",
+        "registry.fedoraproject.org",
+        "mirrors.rockylinux.org",
+        "dl.rockylinux.org",
+        "mirrors.almalinux.org",
+        "repo.almalinux.org",
+        "cdn-ubi.redhat.com",
+        "developer.download.nvidia.com",
+    ),
+    "deb": (
+        "archive.ubuntu.com",
+        "security.ubuntu.com",
+        "ports.ubuntu.com",
+        "deb.debian.org",
+        "security.debian.org",
+        "developer.download.nvidia.com",
+    ),
+}
+
+
+def package_repo_hosts(family: str | None) -> tuple[str, ...]:
+    """OS package-repository hosts for a package *family* (``deb``/``rpm``).
+
+    The image layer's contribution to a task's egress allowlist: the distro
+    repo endpoints in-container ``dnf``/``apt`` need at runtime.  ``None``
+    (unrecognized base image) returns the union of every family — generous
+    by design, since the caller cannot know which repos the image uses.
+    """
+    if family is None:
+        return tuple(dict.fromkeys(h for hosts in _PACKAGE_REPO_HOSTS.values() for h in hosts))
+    return _PACKAGE_REPO_HOSTS.get(family, ())
+
+
 def detect_family(base_image: str, override: str | None = None) -> str:
     """Resolve the package family for *base_image*, raising for unknown images.
 

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -25,12 +25,13 @@ from __future__ import annotations
 import logging
 import os
 import stat
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from terok_executor._util import detect_host_timezone
 from terok_executor.integrations.sandbox import Sharing, VolumeSpec
+from terok_executor.roster.types import EgressProjection
 
 _CONTAINER_RUNTIME_DIR = "/run/terok"
 """Container-side mount point — must match [`terok_sandbox.CONTAINER_RUNTIME_DIR`][terok_sandbox.CONTAINER_RUNTIME_DIR]."""
@@ -232,6 +233,13 @@ class ContainerEnvResult:
     volumes: tuple[VolumeSpec, ...]
     """Typed volume specs — the sandbox decides whether to mount or inject."""
 
+    egress: EgressProjection = field(default_factory=EgressProjection)
+    """Roster-derived egress projection — shield's generated t20 / t30 tiers.
+
+    The firewall half of credential containment: relayed provider endpoints
+    denied direct (the vault relays them), exposed-credential providers left
+    reachable.  Empty by construction when no provider is vault-routed."""
+
 
 # ── Public API ──
 
@@ -260,7 +268,8 @@ def assemble_container_env(
             delegated.
 
     Returns:
-        Assembled env dict and volume tuple.
+        Assembled env dict, volume tuple, and the roster egress projection
+        (shield's generated t20 / t30 tiers).
     """
     from terok_executor.paths import mounts_dir as _mounts_dir
 
@@ -384,7 +393,15 @@ def assemble_container_env(
     # 13. Extra volumes
     volumes.extend(spec.extra_volumes)
 
-    return ContainerEnvResult(env=env, volumes=tuple(volumes))
+    # 14. Egress projection — the firewall half of credential containment.
+    #     The vault contains the credential; shield's generated deny tier keeps
+    #     the agent from bypassing it by reaching the provider host directly.
+    #     Derived from the same (roster, exposed-providers) inputs as the vault
+    #     work above; exposed providers hold the real credential in-container, so
+    #     they are skipped (they need the direct route).
+    egress = roster.compose_egress(exposed_credential_providers=spec.expose_credential_providers)
+
+    return ContainerEnvResult(env=env, volumes=tuple(volumes), egress=egress)
 
 
 # ── Private helpers ──

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -463,6 +463,8 @@ class AgentRunner:
         allow_debugger: bool = False,
         per_container: PerContainerResources | None = None,
         egress: EgressProjection | None = None,
+        project_allow: tuple[str, ...] = (),
+        override: tuple[str, ...] = (),
     ) -> str:
         """Launch a container from a caller-prepared env, volumes, image, and command.
 
@@ -556,6 +558,12 @@ class AgentRunner:
                 [`ContainerEnvResult.egress`][terok_executor.container.env.ContainerEnvResult.egress].
                 ``None`` (default) writes empty tiers — shield still
                 enforces its own profile-based allowlists.
+            project_allow: Orchestrator-authored hosts for shield's t40
+                project-allow tier (git remote + custom domains), passed
+                straight through to the run spec.  Empty by default.
+            override: Orchestrator-authored hosts for shield's t10 break-glass
+                override tier (single host/IP each), above the security-deny.
+                Empty by default.
 
         Returns:
             The container name (same as *name*).
@@ -692,6 +700,8 @@ class AgentRunner:
             loopback_ports=loopback_ports,
             security_deny=egress.deny_to_vault,
             provider_allow=egress.provider_allow,
+            project_allow=project_allow,
+            override=override,
         )
 
         try:

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -28,6 +28,7 @@ from typing import IO, TYPE_CHECKING, cast
 from terok_executor._util import detect_host_timezone
 from terok_executor.integrations.sandbox import SandboxConfig, Sharing, VolumeSpec
 from terok_executor.paths import container_state_dir
+from terok_executor.roster.types import EgressProjection
 
 from .build import BuildError, ImageBuilder
 
@@ -461,6 +462,7 @@ class AgentRunner:
         dossier_path: Path | str | None = None,
         allow_debugger: bool = False,
         per_container: PerContainerResources | None = None,
+        egress: EgressProjection | None = None,
     ) -> str:
         """Launch a container from a caller-prepared env, volumes, image, and command.
 
@@ -549,6 +551,11 @@ class AgentRunner:
                 binding on identical ports.  Default ``None`` allocates
                 internally (the standalone path, and external callers
                 that assemble env without per-container routing).
+            egress: Roster egress projection for shield's generated t20 /
+                t30 tiers, from
+                [`ContainerEnvResult.egress`][terok_executor.container.env.ContainerEnvResult.egress].
+                ``None`` (default) writes empty tiers — shield still
+                enforces its own profile-based allowlists.
 
         Returns:
             The container name (same as *name*).
@@ -663,6 +670,7 @@ class AgentRunner:
             if p is not None
         )
 
+        egress = egress or EgressProjection()
         spec = RunSpec(
             container_name=name,
             image=image,
@@ -682,6 +690,8 @@ class AgentRunner:
             annotations=spec_annotations,
             runtime=runtime,
             loopback_ports=loopback_ports,
+            security_deny=egress.deny_to_vault,
+            provider_allow=egress.provider_allow,
         )
 
         try:
@@ -965,6 +975,9 @@ class AgentRunner:
                 volumes.append(
                     VolumeSpec(provision.host_dir, "/workspace", sharing=Sharing.PRIVATE)
                 )
+            # Sidecar tools carry the real API key directly (no vault relay), so
+            # their provider host must stay reachable — no generated deny tier.
+            egress = EgressProjection()
         else:
             # Agent modes: full env assembly via canonical builder
             agent_config_dir = self._prepare_agent_config(
@@ -1009,6 +1022,7 @@ class AgentRunner:
                 per_container=per_container,
             )
             env = dict(result.env)
+            egress = result.egress
             if provision.gate_token is not None:
                 # The launch path wires this into the supervisor sidecar.
                 env["TEROK_GATE_TOKEN"] = provision.gate_token
@@ -1065,6 +1079,7 @@ class AgentRunner:
             dossier_path=dossier_path,
             allow_debugger=allow_debugger,
             per_container=per_container,
+            egress=egress,
         )
 
         # Follow output if requested

--- a/src/terok_executor/container/runner.py
+++ b/src/terok_executor/container/runner.py
@@ -66,6 +66,9 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+_NO_EGRESS = EgressProjection()
+"""The empty projection: a launch with no roster-derived egress policy."""
+
 
 @dataclass(frozen=True)
 class WorkspaceProvision:
@@ -462,7 +465,7 @@ class AgentRunner:
         dossier_path: Path | str | None = None,
         allow_debugger: bool = False,
         per_container: PerContainerResources | None = None,
-        egress: EgressProjection | None = None,
+        egress: EgressProjection = _NO_EGRESS,
         project_allow: tuple[str, ...] = (),
         override: tuple[str, ...] = (),
     ) -> str:
@@ -678,7 +681,6 @@ class AgentRunner:
             if p is not None
         )
 
-        egress = egress or EgressProjection()
         spec = RunSpec(
             container_name=name,
             image=image,

--- a/src/terok_executor/resources/agents/caddy.yaml
+++ b/src/terok_executor/resources/agents/caddy.yaml
@@ -4,7 +4,7 @@
 # Caddy reverse proxy — runtime ingress that gates web-UI roster entries
 # (toad today, Vibes and others in future) with a per-container token.
 # Not an agent or tool: pulled in via ``install.depends_on: [caddy]``.
-roster_version: 2
+roster_version: 3
 
 kind: infra
 label: Caddy

--- a/src/terok_executor/resources/agents/claude.yaml
+++ b/src/terok_executor/resources/agents/claude.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-roster_version: 2
+roster_version: 3
 
 kind: native
 label: Claude

--- a/src/terok_executor/resources/agents/coderabbit.yaml
+++ b/src/terok_executor/resources/agents/coderabbit.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-roster_version: 2
+roster_version: 3
 
 kind: tool
 label: CodeRabbit

--- a/src/terok_executor/resources/agents/codex.yaml
+++ b/src/terok_executor/resources/agents/codex.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-roster_version: 2
+roster_version: 3
 
 kind: native
 label: Codex

--- a/src/terok_executor/resources/agents/copilot.yaml
+++ b/src/terok_executor/resources/agents/copilot.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-roster_version: 2
+roster_version: 3
 
 kind: native
 label: GitHub Copilot

--- a/src/terok_executor/resources/agents/gh.yaml
+++ b/src/terok_executor/resources/agents/gh.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-roster_version: 2
+roster_version: 3
 
 kind: tool
 label: GitHub CLI

--- a/src/terok_executor/resources/agents/glab.yaml
+++ b/src/terok_executor/resources/agents/glab.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-roster_version: 2
+roster_version: 3
 
 kind: tool
 label: GitLab CLI

--- a/src/terok_executor/resources/agents/opencode.yaml
+++ b/src/terok_executor/resources/agents/opencode.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-roster_version: 2
+roster_version: 3
 
 kind: harness
 label: OpenCode

--- a/src/terok_executor/resources/agents/pi.yaml
+++ b/src/terok_executor/resources/agents/pi.yaml
@@ -9,7 +9,7 @@
 # the symlink in ``pi-env.sh`` — Pi only discovers ``*.ts``, not ``.mjs``)
 # points each materialized provider's ``baseUrl`` at the vault so Pi talks to
 # it instead of going to ``api.anthropic.com`` / ``api.openai.com`` direct.
-roster_version: 2
+roster_version: 3
 
 kind: harness
 label: Pi

--- a/src/terok_executor/resources/agents/sonar.yaml
+++ b/src/terok_executor/resources/agents/sonar.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-roster_version: 2
+roster_version: 3
 
 kind: tool
 label: SonarCloud

--- a/src/terok_executor/resources/agents/toad.yaml
+++ b/src/terok_executor/resources/agents/toad.yaml
@@ -3,7 +3,7 @@
 
 # Toad multi-agent TUI — shared config dir for theme and launcher state.
 # Not an agent or tool — a runtime component installed in L1.
-roster_version: 2
+roster_version: 3
 
 kind: frontend
 label: Toad

--- a/src/terok_executor/resources/agents/vibe.yaml
+++ b/src/terok_executor/resources/agents/vibe.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-roster_version: 2
+roster_version: 3
 
 kind: native
 label: Mistral Vibe

--- a/src/terok_executor/roster/__init__.py
+++ b/src/terok_executor/roster/__init__.py
@@ -15,26 +15,28 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .loader import (
         AgentRoster as AgentRoster,
+        EgressProjection as EgressProjection,
         MountDef as MountDef,
         SidecarSpec as SidecarSpec,
         VaultRoute as VaultRoute,
         load_roster as load_roster,
     )
 
-#: Names resolvable through this package.  Only ``AgentRoster`` is part
-#: of the stable public surface (re-exported as
-#: ``terok_executor.AgentRoster``); the rest stay importable here for
+#: Names resolvable through this package.  ``AgentRoster`` and its egress
+#: projection result ``EgressProjection`` are the stable public surface
+#: (re-exported as ``terok_executor.*``); the rest stay importable here for
 #: internal callers but are absent from ``__all__`` — reach for them via
 #: [`.loader`][terok_executor.roster.loader] when you need them.
 _LAZY: dict[str, str] = {
     "AgentRoster": ".loader",
+    "EgressProjection": ".loader",
     "MountDef": ".loader",
     "SidecarSpec": ".loader",
     "VaultRoute": ".loader",
     "load_roster": ".loader",
 }
 
-__all__ = ["AgentRoster"]
+__all__ = ["AgentRoster", "EgressProjection"]
 
 
 def __getattr__(name: str) -> object:

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -283,7 +283,7 @@ class AgentRoster:
         )
 
     def deny_to_vault_hosts(
-        self, *, exposed_providers: frozenset[str] = frozenset()
+        self, *, exposed_credential_providers: frozenset[str] = frozenset()
     ) -> frozenset[str]:
         """Hosts to deny directly at the egress firewall (shield ``security_deny``, t20).
 
@@ -296,23 +296,42 @@ class AgentRoster:
           the API rides an apex that also serves ``git push`` / docs, so a
           host-level deny would kill legitimate traffic; credential containment
           carries the weight instead.
-        - **``exposed_providers``**: terok's experimental ``expose_oauth_token``
-          mode hands the agent its *real* credential in-container (vault
-          bypassed), so it must reach the endpoint directly.
+        - the providers bound by **``exposed_credential_providers``** — roster-entry
+          (agent/tool) names in terok's experimental ``expose_oauth_token`` mode,
+          where the agent holds its *real* credential in-container (vault bypassed)
+          and so must reach the endpoint directly.  Each entry is mapped to the
+          provider it binds (``provider_binding.default``).
 
-        A pure function of the roster and *exposed_providers*, mirroring
+        A pure function of the roster and *exposed_credential_providers*, mirroring
         [`generate_routes_json`][terok_executor.roster.loader.AgentRoster.generate_routes_json]:
         the vault routes every provider, so every relayed host is denied.
         """
+        exposed = self._exposed_provider_names(exposed_credential_providers)
         hosts: set[str] = set()
         for name, provider in self._providers.items():
-            if provider.shared_domain or name in exposed_providers:
+            if provider.shared_domain or name in exposed:
                 continue
             hosts |= provider.relayed_hosts()
         return frozenset(hosts)
 
+    def _exposed_provider_names(self, exposed_entries: frozenset[str]) -> frozenset[str]:
+        """Map exposed roster-entry (agent/tool) names to the providers they bind.
+
+        The exposed set is keyed by roster entry (``claude``, ``codex``), but a
+        deny targets a *provider* (``anthropic``, ``openai``).  Resolve each entry
+        through its ``provider_binding.default``; entries with no binding (harnesses)
+        contribute nothing.
+        """
+        names: set[str] = set()
+        for entry in exposed_entries:
+            agent = self._agents.get(entry)
+            binding = agent.provider_binding if agent else None
+            if binding and binding.default:
+                names.add(binding.default)
+        return frozenset(names)
+
     def compose_egress(
-        self, *, exposed_providers: frozenset[str] = frozenset()
+        self, *, exposed_credential_providers: frozenset[str] = frozenset()
     ) -> EgressProjection:
         """Project the roster into the shield's egress tiers.
 
@@ -321,11 +340,20 @@ class AgentRoster:
         [`egress_allow`][terok_executor.roster.types.Provider.egress_allow]
         (t30) into one [`EgressProjection`][terok_executor.roster.types.EgressProjection];
         both tuples are sorted and de-duplicated for a deterministic bundle.
+
+        *exposed_credential_providers* — roster-entry (agent/tool) names whose real
+        credential is exposed in-container; the providers they bind are left
+        reachable (see
+        [`deny_to_vault_hosts`][terok_executor.roster.loader.AgentRoster.deny_to_vault_hosts]).
         """
         provider_allow = {host for p in self._providers.values() for host in p.egress_allow}
         return EgressProjection(
             deny_to_vault=tuple(
-                sorted(self.deny_to_vault_hosts(exposed_providers=exposed_providers))
+                sorted(
+                    self.deny_to_vault_hosts(
+                        exposed_credential_providers=exposed_credential_providers
+                    )
+                )
             ),
             provider_allow=tuple(sorted(provider_allow)),
         )

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -36,6 +36,7 @@ from terok_executor.provider.providers import Agent
 
 from .schema import RawAgentYaml, RawProvider, RawProviderBinding, VaultRouteEntry
 from .types import (
+    EgressProjection,
     HelpSpec,
     InstallSpec,
     MountDef,
@@ -53,7 +54,7 @@ _USER_AGENTS_DIR_NAME = "agents"
 _USER_PROVIDERS_DIR_NAME = "providers"
 _YAML_SUFFIX = ".yaml"
 
-ROSTER_VERSION = 2
+ROSTER_VERSION = 3
 """Schema version of the agent-roster YAML format.
 
 Bundled agent YAMLs and user override files declare a top-level
@@ -279,6 +280,54 @@ class AgentRoster:
             TypeAdapter(dict[str, VaultRouteEntry])
             .dump_json(routes, indent=2, exclude_none=True)
             .decode()
+        )
+
+    def deny_to_vault_hosts(
+        self, *, exposed_providers: frozenset[str] = frozenset()
+    ) -> frozenset[str]:
+        """Hosts to deny directly at the egress firewall (shield ``security_deny``, t20).
+
+        Every provider the vault relays contributes its
+        [`relayed_hosts`][terok_executor.roster.types.Provider.relayed_hosts]
+        (upstream + path overrides + OAuth-refresh endpoint) — the agent must
+        reach those *only* through the loopback vault.  Two classes are skipped:
+
+        - **``shared_domain`` providers** (``gitlab.com``, ``sonarcloud.io``):
+          the API rides an apex that also serves ``git push`` / docs, so a
+          host-level deny would kill legitimate traffic; credential containment
+          carries the weight instead.
+        - **``exposed_providers``**: terok's experimental ``expose_oauth_token``
+          mode hands the agent its *real* credential in-container (vault
+          bypassed), so it must reach the endpoint directly.
+
+        A pure function of the roster and *exposed_providers*, mirroring
+        [`generate_routes_json`][terok_executor.roster.loader.AgentRoster.generate_routes_json]:
+        the vault routes every provider, so every relayed host is denied.
+        """
+        hosts: set[str] = set()
+        for name, provider in self._providers.items():
+            if provider.shared_domain or name in exposed_providers:
+                continue
+            hosts |= provider.relayed_hosts()
+        return frozenset(hosts)
+
+    def compose_egress(
+        self, *, exposed_providers: frozenset[str] = frozenset()
+    ) -> EgressProjection:
+        """Project the roster into the shield's egress tiers.
+
+        Bundles the [`deny_to_vault_hosts`][terok_executor.roster.loader.AgentRoster.deny_to_vault_hosts]
+        set (t20) with the union of every provider's
+        [`egress_allow`][terok_executor.roster.types.Provider.egress_allow]
+        (t30) into one [`EgressProjection`][terok_executor.roster.types.EgressProjection];
+        both tuples are sorted and de-duplicated for a deterministic bundle.
+        """
+        provider_allow = {host for p in self._providers.values() for host in p.egress_allow}
+        return EgressProjection(
+            deny_to_vault=tuple(
+                sorted(self.deny_to_vault_hosts(exposed_providers=exposed_providers))
+            ),
+            provider_allow=tuple(sorted(provider_allow)),
         )
 
     def collect_all_auto_approve_env(self) -> dict[str, str]:

--- a/src/terok_executor/roster/loader.py
+++ b/src/terok_executor/roster/loader.py
@@ -346,15 +346,10 @@ class AgentRoster:
         reachable (see
         [`deny_to_vault_hosts`][terok_executor.roster.loader.AgentRoster.deny_to_vault_hosts]).
         """
+        deny = self.deny_to_vault_hosts(exposed_credential_providers=exposed_credential_providers)
         provider_allow = {host for p in self._providers.values() for host in p.egress_allow}
         return EgressProjection(
-            deny_to_vault=tuple(
-                sorted(
-                    self.deny_to_vault_hosts(
-                        exposed_credential_providers=exposed_credential_providers
-                    )
-                )
-            ),
+            deny_to_vault=tuple(sorted(deny)),
             provider_allow=tuple(sorted(provider_allow)),
         )
 

--- a/src/terok_executor/roster/schema.py
+++ b/src/terok_executor/roster/schema.py
@@ -371,6 +371,20 @@ class RawProviderAuth(StrictModel):
         return self
 
 
+class RawEgress(StrictModel):
+    """``egress:`` — extra runtime destinations a provider legitimately reaches.
+
+    ``allow`` hosts feed the shield's ``provider_allow`` tier (t30) — traffic
+    the agent makes *directly* at runtime, additional to the vault-relayed API
+    host (e.g. telemetry or a model-listing endpoint).  Build-time fetches do
+    **not** belong here: image build runs before the shield attaches.
+    """
+
+    allow: list[str] = Field(
+        default_factory=list, description="Hosts allowed directly at egress (t30)"
+    )
+
+
 class RawProvider(StrictModel):
     """Full schema for one ``resources/providers/*.yaml`` file.
 
@@ -384,6 +398,9 @@ class RawProvider(StrictModel):
     path_upstreams: dict[str, str] = Field(default_factory=dict)
     oauth_refresh: RawOAuthRefresh | None = None
     shared_domain: bool = False
+    egress: RawEgress | None = Field(
+        default=None, description="Extra runtime egress hosts allowed at t30"
+    )
     serves: dict[str, str] = Field(
         default_factory=dict,
         description="Wire protocol → container-facing base path (LLM providers only)",
@@ -413,6 +430,7 @@ class RawProvider(StrictModel):
             path_upstreams=dict(self.path_upstreams),
             oauth_refresh=refresh,
             shared_domain=self.shared_domain,
+            egress_allow=tuple(self.egress.allow) if self.egress else (),
             serves=dict(self.serves),
             opencode_config=self.opencode.to_dataclass() if self.opencode else None,
             install_spec=self.install.to_dataclass() if self.install else None,
@@ -576,6 +594,7 @@ __all__ = [
     "RawAuthKey",
     "RawAutoApprove",
     "RawCapabilities",
+    "RawEgress",
     "RawGitIdentity",
     "RawHeadless",
     "RawHelp",

--- a/src/terok_executor/roster/types.py
+++ b/src/terok_executor/roster/types.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Literal, get_args
+from urllib.parse import urlsplit
 
 
 @dataclass(frozen=True)
@@ -309,6 +310,16 @@ class Provider:
     contract.
     """
 
+    egress_allow: tuple[str, ...] = ()
+    """Extra hosts this provider's runtime legitimately reaches *directly*.
+
+    Projected into the shield's ``provider_allow`` tier (t30) — distinct from
+    the vault-relayed API host in ``upstream``: these are *additional* runtime
+    destinations (telemetry, a model-listing endpoint, …) the agent reaches
+    without vault mediation.  Build-time fetches do **not** belong here: image
+    build is unshielded.  Empty for most providers.
+    """
+
     opencode_config: OpenCodeProviderConfig | None = None
     """OpenCode wrapper config when a harness drives this provider (Blablador,
     KISSKI, OpenRouter).  ``None`` for native LLM providers and tool providers,
@@ -358,3 +369,38 @@ class Provider:
         if mode is None:
             raise ValueError(f"Provider {self.name!r} declares no auth mode")
         return mode.header, mode.prefix, dict(mode.extra_headers)
+
+    def relayed_hosts(self) -> frozenset[str]:
+        """Every host the vault relays to for this provider.
+
+        The union of the ``upstream`` host, every ``path_upstreams`` override
+        host, and the OAuth-refresh ``token_url`` host when present — exactly
+        the hosts the agent must reach *only* through the loopback vault, and
+        thus the raw material for the shield's ``security_deny`` tier.  Values
+        that carry no parseable host are dropped.
+        """
+        urls = [self.upstream, *self.path_upstreams.values()]
+        if self.oauth_refresh and (token_url := self.oauth_refresh.get("token_url")):
+            urls.append(token_url)
+        return frozenset(host for url in urls if (host := urlsplit(url).hostname))
+
+
+@dataclass(frozen=True)
+class EgressProjection:
+    """Roster-derived egress policy for a task's shield bundle.
+
+    Produced by [`AgentRoster.compose_egress`][terok_executor.roster.loader.AgentRoster.compose_egress]
+    and handed (via the sandbox) to the shield's tier writer: ``deny_to_vault``
+    seeds the ``security_deny`` tier (t20), ``provider_allow`` the
+    ``provider_allow`` tier (t30).  Both tuples are sorted and de-duplicated so
+    the projection is deterministic across runs.
+    """
+
+    deny_to_vault: tuple[str, ...] = ()
+    """Relayed provider endpoints the agent may reach *only* through the vault,
+    denied directly at the egress firewall (shared-domain and exposed-credential
+    providers excluded)."""
+
+    provider_allow: tuple[str, ...] = ()
+    """Extra runtime-egress hosts the providers legitimately need
+    (``egress.allow`` in the roster), allowed at the egress firewall."""

--- a/tach.toml
+++ b/tach.toml
@@ -161,6 +161,7 @@ depends_on = [
     "terok_executor.credentials.vault_config",
     "terok_executor.integrations.sandbox",
     "terok_executor.paths",
+    "terok_executor.roster.types",
     "terok_executor.vault_addr",
 ]
 
@@ -179,6 +180,7 @@ depends_on = [
     "terok_executor.paths",
     "terok_executor.provider.agents",
     "terok_executor.provider.instructions", "terok_executor.roster",
+    "terok_executor.roster.types",
 ]
 
 # ── credentials/ — authentication + vault ────────────────

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -173,7 +173,10 @@ def executor_env(tmp_path: Path) -> Iterator[ExecutorEnv]:
 
     The vault DB is a real SQLCipher file opened with a throwaway passphrase
     (the operator's own passphrase chain is never consulted, and their vault
-    is never opened).  ``SandboxConfig`` is patched only where the env
+    is never opened).  The passphrase rides the ``passphrase_command`` tier —
+    sandbox removed the plaintext config tier in terok-sandbox#461 — with the
+    keyring tier switched off so nothing above it can reach the operator's
+    Secret Service.  ``SandboxConfig`` is patched only where the env
     assembler constructs one implicitly — see the module docstring.
     """
     env = ExecutorEnv(
@@ -181,7 +184,8 @@ def executor_env(tmp_path: Path) -> Iterator[ExecutorEnv]:
             state_dir=tmp_path / "state",
             vault_dir=tmp_path / "vault",
             config_dir=tmp_path / "config",
-            credentials_passphrase=INTEGRATION_VAULT_PASSPHRASE,
+            credentials_use_keyring=False,
+            credentials_passphrase_command=f"printf %s {INTEGRATION_VAULT_PASSPHRASE}",
         ),
         mounts_dir=tmp_path / "mounts",
         task_dir=tmp_path / "task",

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -24,6 +24,7 @@ from terok_executor.container.build import (
     l0_image_tag,
     l1_image_tag,
     l1_sidecar_image_tag,
+    package_repo_hosts,
     prepare_build_context,
     render_l0,
     render_l1,
@@ -1470,6 +1471,24 @@ class TestKnownFamily:
         # A bad explicit ``family:`` is a config error, not an unknown image.
         with pytest.raises(BuildError, match="must be 'deb' or 'rpm'"):
             known_family("ubuntu:24.04", override="alpine")
+
+
+class TestPackageRepoHosts:
+    """The image layer's egress contribution: distro repo hosts by family."""
+
+    def test_families_map_to_their_repo_hosts(self) -> None:
+        assert "mirrors.fedoraproject.org" in package_repo_hosts("rpm")
+        assert "archive.ubuntu.com" in package_repo_hosts("deb")
+        assert "archive.ubuntu.com" not in package_repo_hosts("rpm")
+
+    def test_unknown_family_gets_generous_union(self) -> None:
+        """None (unrecognized base image) yields every family's hosts, deduplicated."""
+        union = package_repo_hosts(None)
+        assert set(package_repo_hosts("rpm")) | set(package_repo_hosts("deb")) == set(union)
+        assert len(union) == len(set(union))
+
+    def test_unlisted_family_string_yields_empty(self) -> None:
+        assert package_repo_hosts("apk") == ()
 
 
 class TestRenderFamilyAware:

--- a/tests/unit/test_egress_projection.py
+++ b/tests/unit/test_egress_projection.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Roster → shield egress projection (``deny_to_vault_hosts`` / ``compose_egress``).
+
+The projection is generic: no provider is special-cased in code.  Behaviour is
+driven entirely by declarative roster fields — ``shared_domain`` and the
+per-task ``exposed_providers`` set decide what is *not* denied; ``egress.allow``
+decides what is additionally allowed.  These tests pin each rule branch on
+synthetic providers and then confirm the real bundled roster projects the way
+the design intends.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from terok_executor.roster.loader import AgentRoster, load_roster
+from terok_executor.roster.schema import RawProvider
+from terok_executor.roster.types import EgressProjection, Provider
+
+# Real-roster hosts asserted below — the expected output of the projection over
+# the bundled provider YAMLs (dedicated API endpoints, refresh/backend hosts,
+# and the two shared-domain apexes).
+ANTHROPIC_API = "api.anthropic.com"
+ANTHROPIC_REFRESH = "platform.claude.com"  # anthropic oauth_refresh.token_url
+OPENAI_API = "api.openai.com"
+OPENAI_REFRESH = "auth.openai.com"  # openai oauth_refresh.token_url
+OPENAI_BACKEND = "chatgpt.com"  # openai path_upstreams
+GITHUB_API = "api.github.com"
+GITLAB_APEX = "gitlab.com"  # shared_domain: true
+SONARCLOUD_APEX = "sonarcloud.io"  # shared_domain: true
+
+
+class TestRelayedHosts:
+    """``Provider.relayed_hosts`` — every host the vault relays to for a provider."""
+
+    def test_upstream_host(self) -> None:
+        """The ``upstream`` host is always included."""
+        p = Provider(name="x", upstream="https://api.example.com")
+        assert p.relayed_hosts() == frozenset({"api.example.com"})
+
+    def test_includes_path_upstreams(self) -> None:
+        """Every ``path_upstreams`` override host is a relayed host too."""
+        p = Provider(
+            name="x",
+            upstream="https://api.example.com",
+            path_upstreams={"/backend/": "https://backend.example.net"},
+        )
+        assert p.relayed_hosts() == frozenset({"api.example.com", "backend.example.net"})
+
+    def test_includes_oauth_refresh_token_url(self) -> None:
+        """The OAuth-refresh ``token_url`` host is relayed (the vault refreshes, not the agent)."""
+        p = Provider(
+            name="x",
+            upstream="https://api.example.com",
+            oauth_refresh={"token_url": "https://auth.example.org/oauth/token"},
+        )
+        assert p.relayed_hosts() == frozenset({"api.example.com", "auth.example.org"})
+
+    def test_unparseable_url_dropped(self) -> None:
+        """A value with no parseable host contributes nothing (never a bogus deny)."""
+        p = Provider(name="x", upstream="not-a-url")
+        assert p.relayed_hosts() == frozenset()
+
+
+class TestDenyToVaultHosts:
+    """``AgentRoster.deny_to_vault_hosts`` — the t20 security-deny projection."""
+
+    def test_dedicated_relayed_host_denied(self) -> None:
+        """A plain relayed provider contributes its host to the deny set."""
+        roster = AgentRoster(_providers={"x": Provider(name="x", upstream="https://api.x.com")})
+        assert roster.deny_to_vault_hosts() == frozenset({"api.x.com"})
+
+    def test_shared_domain_skipped(self) -> None:
+        """``shared_domain`` providers are never host-denied (apex serves git/docs too)."""
+        roster = AgentRoster(
+            _providers={
+                "g": Provider(name="g", upstream="https://gitlab.example", shared_domain=True)
+            }
+        )
+        assert roster.deny_to_vault_hosts() == frozenset()
+
+    def test_exposed_provider_skipped(self) -> None:
+        """An exposed provider (real cred in-container) must reach its host directly."""
+        roster = AgentRoster(_providers={"a": Provider(name="a", upstream="https://api.a.com")})
+        assert roster.deny_to_vault_hosts(exposed_providers=frozenset({"a"})) == frozenset()
+
+    def test_multiple_providers_union_all_relayed_hosts(self) -> None:
+        """The deny set is the union of every non-skipped provider's relayed hosts."""
+        roster = AgentRoster(
+            _providers={
+                "a": Provider(name="a", upstream="https://api.a.com"),
+                "b": Provider(
+                    name="b",
+                    upstream="https://api.b.com",
+                    oauth_refresh={"token_url": "https://auth.b.com/t"},
+                ),
+            }
+        )
+        assert roster.deny_to_vault_hosts() == frozenset({"api.a.com", "api.b.com", "auth.b.com"})
+
+
+class TestComposeEgress:
+    """``AgentRoster.compose_egress`` — the bundled, deterministic projection."""
+
+    def test_returns_sorted_deduped_projection(self) -> None:
+        """``deny_to_vault`` is a sorted tuple (deterministic bundle)."""
+        roster = AgentRoster(
+            _providers={
+                "b": Provider(name="b", upstream="https://api.b.com"),
+                "a": Provider(name="a", upstream="https://api.a.com"),
+            }
+        )
+        proj = roster.compose_egress()
+        assert isinstance(proj, EgressProjection)
+        assert proj.deny_to_vault == ("api.a.com", "api.b.com")
+
+    def test_provider_allow_gathers_egress_allow_sorted_deduped(self) -> None:
+        """``provider_allow`` is the sorted, de-duplicated union of every ``egress_allow``."""
+        roster = AgentRoster(
+            _providers={
+                "a": Provider(
+                    name="a", upstream="https://api.a.com", egress_allow=("z.example", "a.example")
+                ),
+                "b": Provider(name="b", upstream="https://api.b.com", egress_allow=("a.example",)),
+            }
+        )
+        assert roster.compose_egress().provider_allow == ("a.example", "z.example")
+
+    def test_empty_roster_empty_projection(self) -> None:
+        """An empty roster yields an empty projection, not an error."""
+        assert AgentRoster().compose_egress() == EgressProjection(
+            deny_to_vault=(), provider_allow=()
+        )
+
+
+class TestRealRosterProjection:
+    """The projection over the real bundled provider YAMLs matches the design."""
+
+    def test_dedicated_api_hosts_denied(self) -> None:
+        """Dedicated provider API endpoints are denied directly (defense-in-depth)."""
+        deny = load_roster().deny_to_vault_hosts()
+        assert {ANTHROPIC_API, OPENAI_API, GITHUB_API} <= deny
+
+    def test_refresh_and_backend_hosts_denied(self) -> None:
+        """OAuth-refresh + path-backend hosts are relayed too, so they are denied."""
+        deny = load_roster().deny_to_vault_hosts()
+        assert {ANTHROPIC_REFRESH, OPENAI_REFRESH, OPENAI_BACKEND} <= deny
+
+    def test_shared_domain_apexes_not_denied(self) -> None:
+        """gitlab.com / sonarcloud.io ride mixed apexes — never host-denied."""
+        deny = load_roster().deny_to_vault_hosts()
+        assert GITLAB_APEX not in deny
+        assert SONARCLOUD_APEX not in deny
+
+    def test_exposing_anthropic_frees_only_its_hosts(self) -> None:
+        """Exposing anthropic frees its hosts (subscription mode) but not others'."""
+        deny = load_roster().deny_to_vault_hosts(exposed_providers=frozenset({"anthropic"}))
+        assert ANTHROPIC_API not in deny
+        assert ANTHROPIC_REFRESH not in deny
+        assert OPENAI_API in deny
+
+
+class TestRawProviderEgress:
+    """``egress.allow`` in a provider YAML projects onto ``Provider.egress_allow``."""
+
+    def _raw(self, extra: dict) -> dict:
+        """A minimal valid provider dict merged with *extra*."""
+        return {
+            "upstream": "https://api.x.com",
+            "auth": {"api_key": {"header": "x-api-key"}},
+            **extra,
+        }
+
+    def test_egress_allow_projects_to_provider(self) -> None:
+        """A declared ``egress.allow`` list becomes the provider's ``egress_allow`` tuple."""
+        raw = RawProvider.model_validate(self._raw({"egress": {"allow": ["telemetry.x.com"]}}))
+        assert raw.to_dataclass(name="x").egress_allow == ("telemetry.x.com",)
+
+    def test_egress_absent_defaults_empty(self) -> None:
+        """A provider with no ``egress`` block projects to an empty tuple."""
+        raw = RawProvider.model_validate(self._raw({}))
+        assert raw.to_dataclass(name="x").egress_allow == ()
+
+    def test_egress_strict_keys_reject_typo(self) -> None:
+        """A typo inside ``egress`` fails fast (strict keys), not silently ignored."""
+        with pytest.raises(ValidationError):
+            RawProvider.model_validate(self._raw({"egress": {"allwo": ["telemetry.x.com"]}}))

--- a/tests/unit/test_egress_projection.py
+++ b/tests/unit/test_egress_projection.py
@@ -82,10 +82,16 @@ class TestDenyToVaultHosts:
         )
         assert roster.deny_to_vault_hosts() == frozenset()
 
-    def test_exposed_provider_skipped(self) -> None:
-        """An exposed provider (real cred in-container) must reach its host directly."""
+    def test_bare_provider_name_does_not_skip(self) -> None:
+        """The exposed set is keyed by roster-entry (agent) name, not provider name.
+
+        A provider name with no matching agent maps to nothing, so its host stays
+        denied — only an exposed *agent* frees the provider it binds.
+        """
         roster = AgentRoster(_providers={"a": Provider(name="a", upstream="https://api.a.com")})
-        assert roster.deny_to_vault_hosts(exposed_providers=frozenset({"a"})) == frozenset()
+        assert roster.deny_to_vault_hosts(
+            exposed_credential_providers=frozenset({"a"})
+        ) == frozenset({"api.a.com"})
 
     def test_multiple_providers_union_all_relayed_hosts(self) -> None:
         """The deny set is the union of every non-skipped provider's relayed hosts."""
@@ -155,12 +161,20 @@ class TestRealRosterProjection:
         assert GITLAB_APEX not in deny
         assert SONARCLOUD_APEX not in deny
 
-    def test_exposing_anthropic_frees_only_its_hosts(self) -> None:
-        """Exposing anthropic frees its hosts (subscription mode) but not others'."""
-        deny = load_roster().deny_to_vault_hosts(exposed_providers=frozenset({"anthropic"}))
+    def test_exposing_claude_frees_anthropic_hosts(self) -> None:
+        """Exposing the ``claude`` agent (subscription mode) frees the provider it
+        binds (anthropic), mapped via provider_binding — not other providers."""
+        deny = load_roster().deny_to_vault_hosts(exposed_credential_providers=frozenset({"claude"}))
         assert ANTHROPIC_API not in deny
         assert ANTHROPIC_REFRESH not in deny
         assert OPENAI_API in deny
+
+    def test_exposing_codex_frees_openai_hosts(self) -> None:
+        """The mapping works for codex → openai too (a second real binding)."""
+        deny = load_roster().deny_to_vault_hosts(exposed_credential_providers=frozenset({"codex"}))
+        assert OPENAI_API not in deny
+        assert OPENAI_REFRESH not in deny
+        assert ANTHROPIC_API in deny
 
 
 class TestRawProviderEgress:

--- a/tests/unit/test_egress_projection.py
+++ b/tests/unit/test_egress_projection.py
@@ -200,5 +200,6 @@ class TestRawProviderEgress:
 
     def test_egress_strict_keys_reject_typo(self) -> None:
         """A typo inside ``egress`` fails fast (strict keys), not silently ignored."""
+        raw = self._raw({"egress": {"allwo": ["telemetry.x.com"]}})
         with pytest.raises(ValidationError):
-            RawProvider.model_validate(self._raw({"egress": {"allwo": ["telemetry.x.com"]}}))
+            RawProvider.model_validate(raw)

--- a/tests/unit/test_env_builder.py
+++ b/tests/unit/test_env_builder.py
@@ -1327,3 +1327,27 @@ class TestExposedProviderMaterialization:
         from terok_executor.container.env import _materialize_exposed_providers
 
         assert _materialize_exposed_providers(roster, tmp_path, frozenset({"claude"})) == {}
+
+
+class TestEgressProjection:
+    """assemble_container_env computes the roster egress projection into result.egress."""
+
+    def test_result_carries_projection(self, base_spec, roster):
+        """Dedicated provider hosts are denied; shared-domain apexes are not."""
+        result = assemble_container_env(base_spec, roster, caller_manages_vault=True)
+        assert "api.anthropic.com" in result.egress.deny_to_vault
+        assert "gitlab.com" not in result.egress.deny_to_vault
+
+    def test_exposed_agent_frees_its_provider(self, workspace, envs_dir, roster):
+        """A spec exposing 'claude' frees anthropic's host (real cred in-container)."""
+        spec = _spec(workspace, envs_dir, expose_credential_providers=frozenset({"claude"}))
+        result = assemble_container_env(spec, roster, caller_manages_vault=True)
+        assert "api.anthropic.com" not in result.egress.deny_to_vault
+        assert "api.openai.com" in result.egress.deny_to_vault
+
+    def test_default_result_has_empty_projection(self):
+        """A bare ContainerEnvResult defaults to an empty projection."""
+        from terok_executor.container.env import ContainerEnvResult
+        from terok_executor.roster.types import EgressProjection
+
+        assert ContainerEnvResult(env={}, volumes=()).egress == EgressProjection()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -192,6 +192,20 @@ class TestAgentRunner:
         spec = sandbox.run.call_args[0][0]
         assert spec.gpus == "all"
 
+    def test_egress_projection_reaches_runspec(self, tmp_path: Path) -> None:
+        """The roster egress projection flows through assembly into RunSpec tiers."""
+        sandbox = _mock_sandbox()
+        runner = AgentRunner(sandbox=sandbox)
+
+        with patch.object(runner, "_ensure_images", return_value="terok-l1-cli:test"):
+            runner.run_headless("claude", None, workspace=tmp_path, prompt="test", follow=False)
+
+        spec = sandbox.run.call_args[0][0]
+        # Dedicated provider API hosts are denied direct (the vault relays them);
+        # shared-domain apexes are not.
+        assert "api.anthropic.com" in spec.security_deny
+        assert "gitlab.com" not in spec.security_deny
+
     def test_gpu_vendor_string_reaches_runspec(self, tmp_path: Path) -> None:
         """A comma-separated vendor string normalizes to a vendor tuple."""
         sandbox = _mock_sandbox()

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -585,6 +585,26 @@ class TestLaunchPrepared:
         assert spec.sealed is True
         assert spec.extra_args == ("-p", "127.0.0.1:8080:8080")
 
+    def test_authored_tiers_reach_runspec(self, tmp_path: Path) -> None:
+        """project_allow / override map to the RunSpec t40 / t10 fields."""
+        sandbox = _mock_sandbox()
+        runner = AgentRunner(sandbox=sandbox)
+
+        runner.launch_prepared(
+            env={},
+            volumes=[],
+            image="terok-l1-cli:test",
+            command=["bash"],
+            name="terok-x",
+            task_dir=tmp_path,
+            project_allow=("github.com",),
+            override=("api.foo.com",),
+        )
+
+        spec = sandbox.run.call_args[0][0]
+        assert spec.project_allow == ("github.com",)
+        assert spec.override == ("api.foo.com",)
+
     def test_annotations_propagate_to_runspec(self, tmp_path: Path) -> None:
         """``annotations`` kwarg lands on RunSpec.annotations (typed channel
         the sandbox validates) — distinct from the freeform *extra_args*."""

--- a/uv.lock
+++ b/uv.lock
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a17.dev2+gf6f9581de"
-source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#f6f9581de9e84814664bd5da28fc3982fc4a4303" }
+version = "0.5.0a17.dev3+gf0a2e3906"
+source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#f0a2e3906622095bba51c5fc7000330c6c82f1e9" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl" },
+    { name = "terok-sandbox", git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a16"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl" }
+version = "0.5.0a17.dev2+gf6f9581de"
+source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#f6f9581de9e84814664bd5da28fc3982fc4a4303" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2328,45 +2328,15 @@ dependencies = [
     { name = "terok-shield" },
     { name = "terok-util" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl", hash = "sha256:fb2bcec4afca6c5a8b4081170c7686d7e87b6058681b9264ecbd3cf573888dae" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = "~=3.14.1" },
-    { name = "cryptography", specifier = "~=49.0" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "keyring", specifier = "~=25.7" },
-    { name = "packaging", specifier = "~=26.2" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "sqlcipher3", specifier = "==0.6.2" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
-]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a6"
-source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" }
+version = "0.8.0a7.dev9+gbae31c266"
+source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#bae31c266255085f6fc9edb266bee41c1cf60f39" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl", hash = "sha256:b9ea5a1bf79380b931a80088eb92469116a072b09456745716e71ec8c1306dc5" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a17.dev6+g9f8c6ba11"
-source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#9f8c6ba110f647d578ea48c35e119814c91f0574" }
+version = "0.5.0a17.dev7+g7ec82992f"
+source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#7ec82992f258491e9850a89704e774f7f3d72dba" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2331,8 +2331,8 @@ dependencies = [
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a7.dev12+g414892e53"
-source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#414892e53e36813775b6601ee60be81de80f1560" }
+version = "0.8.0a7.dev13+g53fc22682"
+source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#53fc2268222b28ceb49cb4b8c74dbec87bb3fb7c" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a17.dev3+gf0a2e3906"
-source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#f0a2e3906622095bba51c5fc7000330c6c82f1e9" }
+version = "0.5.0a17.dev5+gd904e3824"
+source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#d904e3824c012d24acc112146304f8d0b72e9e06" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2331,8 +2331,8 @@ dependencies = [
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a7.dev9+gbae31c266"
-source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#bae31c266255085f6fc9edb266bee41c1cf60f39" }
+version = "0.8.0a7.dev12+g414892e53"
+source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#414892e53e36813775b6601ee60be81de80f1560" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a17.dev5+gd904e3824"
-source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#d904e3824c012d24acc112146304f8d0b72e9e06" }
+version = "0.5.0a17.dev6+g9f8c6ba11"
+source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#9f8c6ba110f647d578ea48c35e119814c91f0574" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a18/terok_sandbox-0.5.0a18-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a17.dev22+ga19422d0e"
-source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#a19422d0ef9a9fbba93470bf1256de35aa1057b6" }
+version = "0.5.0a18"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a18/terok_sandbox-0.5.0a18-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2328,15 +2328,45 @@ dependencies = [
     { name = "terok-shield" },
     { name = "terok-util" },
 ]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a18/terok_sandbox-0.5.0a18-py3-none-any.whl", hash = "sha256:801e1adedd9094392d9a54fd205750c928f44ac7781c5bd19b3cb6c63c48a0ca" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = "~=3.14.1" },
+    { name = "cryptography", specifier = "~=49.0" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "keyring", specifier = "~=25.7" },
+    { name = "packaging", specifier = "~=26.2" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "prompt-toolkit", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "sqlcipher3", specifier = "==0.6.2" },
+    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a7/terok_shield-0.8.0a7-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
+]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a7.dev28+ga89d0034d"
-source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#a89d0034d969d4a30b8d5eba596277c080ea242d" }
+version = "0.8.0a7"
+source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a7/terok_shield-0.8.0a7-py3-none-any.whl" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a7/terok_shield-0.8.0a7-py3-none-any.whl", hash = "sha256:6b9f508caba11c443cab1f2c95bc1475347d342436574bef45bb4b6c3e852329" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "pyyaml", specifier = "~=6.0" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a17.dev7+g7ec82992f"
-source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#7ec82992f258491e9850a89704e774f7f3d72dba" }
+version = "0.5.0a17.dev9+gb2d2ae0d6"
+source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#b2d2ae0d6f3ab154616be897d53f3d91f9d6d829" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2331,8 +2331,8 @@ dependencies = [
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a7.dev13+g53fc22682"
-source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#53fc2268222b28ceb49cb4b8c74dbec87bb3fb7c" }
+version = "0.8.0a7.dev16+ga42e103f5"
+source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#a42e103f5631504a79660b1d6323056ba9d31cd9" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a17.dev9+gb2d2ae0d6"
-source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#b2d2ae0d6f3ab154616be897d53f3d91f9d6d829" }
+version = "0.5.0a17.dev20+gc71de3250"
+source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#c71de32504b78bb0e8eda7b94f1c0a7f855a1834" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2331,8 +2331,8 @@ dependencies = [
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a7.dev16+ga42e103f5"
-source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#a42e103f5631504a79660b1d6323056ba9d31cd9" }
+version = "0.8.0a7.dev27+g8edc93758"
+source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#8edc93758fd5b78f53eaecb8751bb80e3138069f" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },

--- a/uv.lock
+++ b/uv.lock
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a17.dev20+gc71de3250"
-source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#c71de32504b78bb0e8eda7b94f1c0a7f855a1834" }
+version = "0.5.0a17.dev22+ga19422d0e"
+source = { git = "https://github.com/terok-ai/terok-sandbox.git?rev=refs%2Fpull%2F493%2Fhead#a19422d0ef9a9fbba93470bf1256de35aa1057b6" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2331,8 +2331,8 @@ dependencies = [
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a7.dev27+g8edc93758"
-source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#8edc93758fd5b78f53eaecb8751bb80e3138069f" }
+version = "0.8.0a7.dev28+ga89d0034d"
+source = { git = "https://github.com/terok-ai/terok-shield.git?rev=refs%2Fpull%2F406%2Fhead#a89d0034d969d4a30b8d5eba596277c080ea242d" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },


### PR DESCRIPTION
## What

Executor computes the **egress projection** — the generated `security_deny`
(t20) and `provider_allow` (t30) tiers — from the agent roster, and threads it
into the container's `RunSpec` so the sandbox can hand it to shield.

The projection is the **firewall half of credential containment**: the vault
contains the credential; the deny tier keeps the agent from bypassing the vault
by reaching a provider's API host directly. It is generic and declarative — no
provider is special-cased in code.

## The rule (driven by roster YAML + selection)

- **Deny** every relayed provider host: `upstream` + `path_upstreams` +
  `oauth_refresh.token_url` (so `chatgpt.com`, `platform.claude.com`,
  `auth.openai.com` are covered, not just the apex API hosts).
- **Skip `shared_domain`** apexes (`gitlab.com`, `sonarcloud.io`) — they also
  serve `git push` / docs, so a host-deny would bite; credential containment
  carries the weight.
- **Skip exposed agents**: `expose_credential_providers` is keyed by roster-entry
  (agent) name; each is mapped to the provider it binds
  (`provider_binding.default`) and that provider's hosts stay reachable. This is
  Claude subscription mode (real cred in-container).
- github needs no special code — `api.github.com` is a dedicated host denied like
  any other; `github.com` general git is terok's t40 concern.

## Where it lives

- `AgentRoster.compose_egress()` / `deny_to_vault_hosts()` — the projection
  (roster knowledge, executor's layer). `Provider.relayed_hosts()`,
  `EgressProjection`, `egress.allow` provider field. `ROSTER_VERSION` 2 → 3.
- `assemble_container_env` computes it into `ContainerEnvResult.egress` —
  cohesive with the credential-containment machinery it already owns.
  `launch_prepared` threads it into `RunSpec`. Sidecar tools (real key in
  container) get an empty projection.

## Chain

Part of the terok-shield "default up" Phase 2 chain:
shield#406 ← terok-sandbox#493 ← **this** ← terok. Pins the sandbox transport PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-run egress security controls, including deny rules for relayed hosts and provider-specific allow destinations.
  * Introduced provider-level `egress.allow` and an aggregated egress projection used during sandbox run configuration.
  * Added package-repository host allowlists for supported package families.
  * Bumped agent roster schema/version to **3**.
* **Public API**
  * Exposed `EgressProjection` and `package_repo_hosts`.
* **Tests**
  * Expanded unit and integration coverage for egress projection, environment assembly, repository host resolution, and security propagation.
* **Chores**
  * Updated the sandbox dependency reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->