### PR TITLE
test(vault): executor vault + codex integration coverage; git-identity container test moved in

### DIFF
--- a/tests/integration/containers/__init__.py
+++ b/tests/integration/containers/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Container-level integration tests that build real images and exec inside them."""

--- a/tests/integration/containers/conftest.py
+++ b/tests/integration/containers/conftest.py
@@ -121,22 +121,24 @@ def shell_test_image(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     stage_scripts(build_dir / "scripts")
     stage_tmux_config(build_dir / "tmux")
 
-    # Build L0 from the real template.
-    _podman_build(build_dir / "L0.Dockerfile", ITEST_L0_IMAGE, build_dir)
+    # Build + yield inside try/finally so a failure of the *second* build still removes
+    # the first image — otherwise a partially-built L0 leaks tagged across CI attempts.
+    # ``podman rmi -f`` on a never-built tag is a harmless no-op.
+    try:
+        _podman_build(build_dir / "L0.Dockerfile", ITEST_L0_IMAGE, build_dir)
 
-    # Write and build the shell-init layer.
-    shell_df = build_dir / "Shell.Dockerfile"
-    shell_df.write_text(_SHELL_INIT_DOCKERFILE)
-    _podman_build(
-        shell_df,
-        ITEST_SHELL_IMAGE,
-        build_dir,
-        build_args={"BASE": ITEST_L0_IMAGE},
-        timeout=120,
-    )
+        # Write and build the shell-init layer.
+        shell_df = build_dir / "Shell.Dockerfile"
+        shell_df.write_text(_SHELL_INIT_DOCKERFILE)
+        _podman_build(
+            shell_df,
+            ITEST_SHELL_IMAGE,
+            build_dir,
+            build_args={"BASE": ITEST_L0_IMAGE},
+            timeout=120,
+        )
 
-    yield ITEST_SHELL_IMAGE
-
-    # Cleanup: remove both images (ignore errors if already removed).
-    for tag in (ITEST_SHELL_IMAGE, ITEST_L0_IMAGE):
-        subprocess.run(["podman", "rmi", "-f", tag], capture_output=True, timeout=30)
+        yield ITEST_SHELL_IMAGE
+    finally:
+        for tag in (ITEST_SHELL_IMAGE, ITEST_L0_IMAGE):
+            subprocess.run(["podman", "rmi", "-f", tag], capture_output=True, timeout=30)

--- a/tests/integration/containers/conftest.py
+++ b/tests/integration/containers/conftest.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Session-scoped fixtures that build L0 + shell-init test images via Podman.
+
+Two images are built once per session (~30-60s, no agent installs):
+
+1. **L0** from the real ``l0.dev.Dockerfile.template`` — validates the base layer.
+2. **Shell-init layer** on top of L0 using a small Dockerfile that replicates L1's
+   shell wiring (COPY terok-env.sh, terok-env-git-identity.sh, mkdir,
+   ``/etc/bash.bashrc`` append, ``BASH_ENV``) — validates the exact wiring that
+   broke when ``mkdir -p /usr/local/share/terok`` was below the cache bust point.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from collections.abc import Iterator
+from importlib import resources
+from pathlib import Path
+
+import pytest
+
+ITEST_L0_IMAGE = "terok-itest-l0:latest"
+ITEST_SHELL_IMAGE = "terok-itest-shell:latest"
+
+# Shell-init Dockerfile — mirrors the L1 wiring steps that previously broke.
+_SHELL_INIT_DOCKERFILE = textwrap.dedent("""\
+    ARG BASE
+    FROM ${BASE}
+    USER root
+    RUN mkdir -p /usr/local/share/terok
+    COPY scripts/terok-env.sh /etc/profile.d/terok-env.sh
+    COPY scripts/terok-env-git-identity.sh /usr/local/share/terok/terok-env-git-identity.sh
+    RUN chmod +x /etc/profile.d/terok-env.sh \\
+                 /usr/local/share/terok/terok-env-git-identity.sh; \\
+        if [ -f /etc/bash.bashrc ]; then \\
+          printf '\\n. /etc/profile.d/terok-env.sh\\n' >> /etc/bash.bashrc; \\
+        else \\
+          printf '. /etc/profile.d/terok-env.sh\\n' > /etc/bash.bashrc; \\
+        fi
+    ENV BASH_ENV=/etc/profile.d/terok-env.sh
+    USER dev
+    WORKDIR /workspace
+""")
+
+
+def _copy_resource_tree(package: str, rel_path: str, dest: Path) -> None:
+    """Copy a package resource directory tree to a filesystem path."""
+    root = resources.files(package) / rel_path
+
+    def _recurse(src, dst: Path) -> None:
+        dst.mkdir(parents=True, exist_ok=True)
+        for child in src.iterdir():
+            out = dst / child.name
+            if child.is_dir():
+                _recurse(child, out)
+            else:
+                out.write_bytes(child.read_bytes())
+
+    _recurse(root, dest)
+
+
+def _podman_build(
+    dockerfile: Path,
+    tag: str,
+    context: Path,
+    *,
+    build_args: dict[str, str] | None = None,
+    timeout: int = 300,
+) -> None:
+    """Run ``podman build`` with clear error reporting."""
+    ba_flags: list[str] = []
+    for k, v in (build_args or {}).items():
+        ba_flags.extend(["--build-arg", f"{k}={v}"])
+    result = subprocess.run(
+        ["podman", "build", "-f", str(dockerfile), *ba_flags, "-t", tag, str(context)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"podman build failed for {tag} (exit {result.returncode}):\n"
+            f"  stderr: {result.stderr.strip()}\n"
+            f"  stdout: {result.stdout.strip()}"
+        )
+
+
+@pytest.fixture(scope="session")
+def shell_test_image(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """Build L0 + shell-init test images and yield the shell image tag.
+
+    Skips if podman is not installed. Both images are removed in the finalizer.
+    """
+    if not shutil.which("podman"):
+        pytest.skip("podman not installed")
+
+    build_dir = tmp_path_factory.mktemp("container-build")
+
+    # Render the L0 template through terok_executor's Jinja pipeline.
+    # Reading the raw template and writing it verbatim leaves `{{ BASE_IMAGE }}`
+    # and `{% if family ... %}` placeholders un-substituted, so podman build
+    # dies at `FROM {{` with "invalid reference format".
+    from terok_executor.container.build import render_l0, stage_scripts, stage_tmux_config
+
+    # Fully-qualified base image: nested rootless podman in the matrix images
+    # has no unqualified-search-registries, so a short name like ``fedora:44``
+    # (executor's default) fails to resolve.
+    (build_dir / "L0.Dockerfile").write_text(render_l0("registry.fedoraproject.org/fedora:44"))
+
+    # Stage scripts (executor's own + sandbox bridge overlays) and tmux
+    # config into the build context.  Using executor's `stage_scripts()`
+    # rather than a bare resources-tree copy is what gets the
+    # ssh-agent-bridge.sh / ensure-bridges.sh scripts in — those live in
+    # terok_sandbox, and the L0 Dockerfile's COPY lines expect them under
+    # scripts/.  Without the overlay, STEP 8 (COPY ssh-agent-bridge.sh)
+    # fails with "no such file or directory".
+    stage_scripts(build_dir / "scripts")
+    stage_tmux_config(build_dir / "tmux")
+
+    # Build L0 from the real template.
+    _podman_build(build_dir / "L0.Dockerfile", ITEST_L0_IMAGE, build_dir)
+
+    # Write and build the shell-init layer.
+    shell_df = build_dir / "Shell.Dockerfile"
+    shell_df.write_text(_SHELL_INIT_DOCKERFILE)
+    _podman_build(
+        shell_df,
+        ITEST_SHELL_IMAGE,
+        build_dir,
+        build_args={"BASE": ITEST_L0_IMAGE},
+        timeout=120,
+    )
+
+    yield ITEST_SHELL_IMAGE
+
+    # Cleanup: remove both images (ignore errors if already removed).
+    for tag in (ITEST_SHELL_IMAGE, ITEST_L0_IMAGE):
+        subprocess.run(["podman", "rmi", "-f", tag], capture_output=True, timeout=30)

--- a/tests/integration/containers/test_git_identity_container.py
+++ b/tests/integration/containers/test_git_identity_container.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for git identity inside real terok containers.
+
+Builds real images (L0 + shell-init wiring), starts one shared container,
+then verifies that ``BASH_ENV``, ``_terok_apply_git_identity``, and all four
+authorship modes work correctly — including actual ``git commit`` metadata.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import uuid
+from collections.abc import Iterator
+
+import pytest
+
+pytestmark = pytest.mark.needs_podman
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+CONTAINER_PREFIX = "terok-itest-git"
+
+HUMAN_NAME = "Alice Human"
+HUMAN_EMAIL = "alice@example.com"
+AGENT_NAME = "Claude"
+AGENT_EMAIL = "noreply@anthropic.com"
+
+# Expected (author_name, author_email, committer_name, committer_email) per mode.
+EXPECTED_IDENTITY: dict[str, tuple[str, str, str, str]] = {
+    "agent-human": (AGENT_NAME, AGENT_EMAIL, HUMAN_NAME, HUMAN_EMAIL),
+    "human-agent": (HUMAN_NAME, HUMAN_EMAIL, AGENT_NAME, AGENT_EMAIL),
+    "agent": (AGENT_NAME, AGENT_EMAIL, AGENT_NAME, AGENT_EMAIL),
+    "human": (HUMAN_NAME, HUMAN_EMAIL, HUMAN_NAME, HUMAN_EMAIL),
+}
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _exec(
+    container: str,
+    *cmd: str,
+    env: dict[str, str] | None = None,
+    timeout: int = 10,
+) -> subprocess.CompletedProcess[str]:
+    """Run a command inside *container*, optionally injecting env overrides."""
+    env_args: list[str] = []
+    for k, v in (env or {}).items():
+        env_args.extend(["-e", f"{k}={v}"])
+    return subprocess.run(
+        ["podman", "exec", *env_args, container, *cmd],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _bash(
+    container: str,
+    script: str,
+    *,
+    env: dict[str, str] | None = None,
+    timeout: int = 10,
+) -> subprocess.CompletedProcess[str]:
+    """Run a bash script inside *container* (sources ``BASH_ENV`` automatically)."""
+    return _exec(container, "bash", "-c", script, env=env, timeout=timeout)
+
+
+def _git_commit_and_log(container: str, mode: str) -> str:
+    """Create an empty git commit inside *container* and return the identity log line.
+
+    Returns ``author_name|author_email|committer_name|committer_email``.
+    """
+    script = (
+        f'_terok_apply_git_identity "{AGENT_NAME}" "{AGENT_EMAIL}"\n'
+        "dir=$(mktemp -d)\n"
+        'cd "$dir"\n'
+        "git init -q\n"
+        "git commit --allow-empty -q -m test\n"
+        "git log -1 --format='%an|%ae|%cn|%ce'\n"
+    )
+    result = _bash(container, script, env={"TEROK_GIT_AUTHORSHIP": mode})
+    assert result.returncode == 0, (
+        f"git commit failed for mode={mode}:\n  stdout: {result.stdout}\n  stderr: {result.stderr}"
+    )
+    return result.stdout.strip()
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="class")
+def container(shell_test_image: str) -> Iterator[str]:
+    """Start a long-lived container from the shell-init test image.
+
+    Shared across all tests in the class; removed in the finalizer.
+    """
+    name = f"{CONTAINER_PREFIX}-{uuid.uuid4().hex[:8]}"
+    # Clean up any leftover from a previous interrupted run.
+    subprocess.run(["podman", "rm", "-f", name], capture_output=True, timeout=30)
+    subprocess.run(
+        [
+            "podman",
+            "run",
+            "-d",
+            "--name",
+            name,
+            "-e",
+            f"HUMAN_GIT_NAME={HUMAN_NAME}",
+            "-e",
+            f"HUMAN_GIT_EMAIL={HUMAN_EMAIL}",
+            "-e",
+            "TEROK_GIT_AUTHORSHIP=agent-human",
+            shell_test_image,
+            "sleep",
+            "300",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    yield name
+    subprocess.run(["podman", "rm", "-f", name], capture_output=True, timeout=30)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestGitIdentityContainer:
+    """Verify git identity shell wiring works end-to-end inside a real container."""
+
+    # -- Shell environment wiring --
+
+    def test_bash_env_sources_terok_env(self, container: str) -> None:
+        """Non-interactive ``bash -c`` loads terok-env.sh via BASH_ENV."""
+        result = _bash(container, "type _terok_apply_git_identity && type _terok_env_ready")
+        assert result.returncode == 0
+        assert "function" in result.stdout.lower()
+
+    def test_identity_function_available_noninteractive(self, container: str) -> None:
+        """``_terok_apply_git_identity`` is available in non-interactive bash."""
+        result = _bash(container, "type _terok_apply_git_identity")
+        assert result.returncode == 0
+        assert "function" in result.stdout.lower()
+
+    def test_human_env_vars_present(self, container: str) -> None:
+        """``HUMAN_GIT_NAME`` and ``HUMAN_GIT_EMAIL`` are visible inside the container."""
+        result = _bash(container, "echo $HUMAN_GIT_NAME/$HUMAN_GIT_EMAIL")
+        assert result.returncode == 0
+        assert result.stdout.strip() == f"{HUMAN_NAME}/{HUMAN_EMAIL}"
+
+    # -- Authorship env var modes --
+
+    @pytest.mark.parametrize("mode", ["agent-human", "human-agent", "agent", "human"])
+    def test_authorship_modes(self, container: str, mode: str) -> None:
+        """``_terok_apply_git_identity`` sets correct GIT_* vars for each mode."""
+        script = (
+            f'_terok_apply_git_identity "{AGENT_NAME}" "{AGENT_EMAIL}"\n'
+            'echo "$GIT_AUTHOR_NAME|$GIT_AUTHOR_EMAIL|$GIT_COMMITTER_NAME|$GIT_COMMITTER_EMAIL"'
+        )
+        result = _bash(container, script, env={"TEROK_GIT_AUTHORSHIP": mode})
+        assert result.returncode == 0
+
+        an, ae, cn, ce = result.stdout.strip().split("|")
+        expected = EXPECTED_IDENTITY[mode]
+        assert (an, ae, cn, ce) == expected, f"mode={mode}: got {(an, ae, cn, ce)}"
+
+    # -- Actual git commit identity --
+
+    @pytest.mark.parametrize("mode", ["agent-human", "human-agent", "agent", "human"])
+    def test_git_commit_identity(self, container: str, mode: str) -> None:
+        """``git log`` shows the correct author/committer for each authorship mode."""
+        log_line = _git_commit_and_log(container, mode)
+        an, ae, cn, ce = log_line.split("|")
+        expected = EXPECTED_IDENTITY[mode]
+        assert (an, ae, cn, ce) == expected, f"mode={mode}: got {(an, ae, cn, ce)}"

--- a/tests/integration/test_codex_vault_handshake.py
+++ b/tests/integration/test_codex_vault_handshake.py
@@ -252,7 +252,10 @@ def test_real_codex_phantom_swaps_and_reaches_the_vault(
     monkeypatch.setattr(
         SandboxConfig,
         "resolve_passphrase_with_source",
-        lambda _self: (INTEGRATION_VAULT_PASSPHRASE, "integration"),
+        lambda _self, **_kw: (
+            INTEGRATION_VAULT_PASSPHRASE,
+            "integration",
+        ),  # **_kw tolerates credentials_db/prompt_on_tty
     )
     host_socket = tmp_path / "vault.sock"
     name = unique_container_name("codex-handshake")

--- a/tests/integration/test_codex_vault_handshake.py
+++ b/tests/integration/test_codex_vault_handshake.py
@@ -14,12 +14,18 @@ What this gates on (at the trap):
 - **codex reached the vault at all** — a sudden client-side refusal of the phantom, or a
   base-url/config regression, shows up as *no capture*;
 - **the phantom swapped to the real key** — proves phantom-health + the auth *mechanism*
-  (codex sends `Authorization: Bearer <token>` in api_key mode) + end-to-end connectivity.
+  (codex sends `Authorization: Bearer <token>` in api_key mode) + end-to-end connectivity;
+- **the transport** — codex v0.146 is WS-first, so a `ws` upgrade to `/v1/responses`
+  must reach the trap (the leg terok's vault WS fix targets); a fallback to plain HTTP
+  would mean the WS path regressed;
+- **the client identity** — codex tags itself `originator: codex_exec`; a change flags a
+  codex protocol/identity drift worth knowing about.
 
-Reported (not yet gated): the transport (codex v0.146 is WS-first — `wss://{base}/responses`
-via a background prewarm — the leg terok's vault WS fix targets) and the `originator`
-identity header are emitted as a warning so v2 can harden them from real captures. The
-first matrix run confirmed the two gates pass; the originator canary was mis-calibrated.
+The transport + identity gates are calibrated from the first matrix run (codex v0.146
+`exec`): every capture was `ws /v1/responses` with `originator='codex_exec'` across all
+ten distro slots. (Note: the codex-rs *static* default is `codex_cli_rs`; the `exec`
+path overrides it to `codex_exec` — which is why an early guess against `codex_cli_rs`
+failed.) v2 will additionally capture a WS *frame* to assert the sentinel prompt survives.
 
 Scope (v1, per design): **api_key mode only** — that's what a current-shape phantom
 (`terok-p-<hex>`) supports (oauth mode JWT-decodes the token and hits a hardcoded
@@ -52,7 +58,6 @@ import os
 import threading
 import time
 import uuid
-import warnings
 from pathlib import Path
 
 import pytest
@@ -295,16 +300,14 @@ def test_real_codex_phantom_swaps_and_reaches_the_vault(
     assert any(c["auth"] == f"Bearer {REAL_SECRET}" for c in vault.captures), (
         f"phantom did not swap to the real key at the trap; captures={vault.captures}"
     )
-    # Transport + identity are reported, not yet gated: the first matrix run showed the
-    # core passes but the originator canary needs calibrating against what codex actually
-    # sends. Surface it as a warning (visible in the matrix warnings summary) so v2 can
-    # harden the WebSocket + originator canaries from real data rather than a guess.
-    warnings.warn(
-        "codex vault canary — "
-        + "; ".join(
-            f"{c['kind']} {c['path']} originator={c['originator']!r} "
-            f"ua={c['user_agent']!r} version={c['version']!r}"
-            for c in vault.captures
-        ),
-        stacklevel=2,
+    # Transport + identity gates, calibrated from the first matrix run (codex v0.146
+    # exec, all ten slots): codex goes WS-first to /v1/responses and tags itself
+    # `codex_exec`. A regression here means codex changed its transport or client
+    # identity — exactly what this canary exists to catch.
+    assert any(c["kind"] == "ws" and c["path"] == "/v1/responses" for c in vault.captures), (
+        "expected a WebSocket upgrade to /v1/responses (codex v0.146 is WS-first); a plain "
+        f"HTTP fallback would mean the WS path regressed. captures={vault.captures}"
+    )
+    assert any(c["originator"] == "codex_exec" for c in vault.captures), (
+        f"codex originator is no longer 'codex_exec' — client identity drift; captures={vault.captures}"
     )

--- a/tests/integration/test_codex_vault_handshake.py
+++ b/tests/integration/test_codex_vault_handshake.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""v1: run the *real* Codex CLI with a phantom token and trap its first authed request.
+
+The whole chain, "as if a user ran it": real `codex` in a container, given only a
+phantom API key (api_key mode) + the vault base URL via `config.toml` exactly as
+terok provisions it, reaches the host-side vault, which swaps the phantom for the real
+credential and forwards to a **request trap**.  The trap records what it saw and
+answers with nothing useful — codex then errors, which is fine; we only need the first
+authenticated request(s).
+
+What this asserts (at the trap):
+- **the phantom swapped to the real key** — proves phantom-health + the auth *mechanism*
+  (codex sends `Authorization: Bearer <token>` in api_key mode) + end-to-end connectivity;
+- **codex reached the vault at all** — a sudden client-side refusal of the phantom, or a
+  base-url/config regression, shows up as *no capture*;
+- **the WebSocket transport** — codex v0.146 on the default `openai` provider is
+  WS-first (`wss://{base}/responses`, background prewarm at session spawn), so a WS
+  upgrade should reach the trap; this is the leg terok's vault WS fix targets.
+
+Scope (v1, per design): **api_key mode only** — that's what a current-shape phantom
+(`terok-p-<hex>`) supports (oauth mode JWT-decodes the token and hits a hardcoded
+auth.openai.com refresh). v2 will capture a WS *frame* to assert the sentinel prompt
+survives the hop; the oauth/zstd path and the full `terok task` driver are later.
+
+────────────────────────────────────────────────────────────────────────────────
+MATRIX VALIDATION NOTES — this has only been collection+lint-checked off the test
+machine.  Run it under the matrix and expect to tune:
+  * Image: fedora + `npm i -g @openai/codex` + socat/curl/git + a uid-1000 `dev` user.
+    Codex ships a glibc binary via npm → fedora base (not the alpine PODMAN_BASE_IMAGE).
+    Verify the dev user / HOME=/home/dev / WORKDIR match what Sandbox.run expects.
+  * Codex provisioning: `~/.codex/auth.json = {"OPENAI_API_KEY": <phantom>}` +
+    `~/.codex/config.toml` with `openai_base_url`.  Confirm the exact auth.json shape
+    codex v0.146 expects for api_key mode (spec says that field name; verify nesting).
+  * Reachability: codex reads `openai_base_url=http://localhost:9419/v1`; the socat
+    loopback bridge (same command ensure-bridges.sh uses) fronts the bind-mounted
+    vault socket.  WS + HTTP both traverse socat.
+  * Timing: the WS prewarm is a background task racing the /models GET — poll the trap
+    for a few seconds.  If no WS upgrade appears, the swap assertion still holds.
+  * OTEL: disabled via `-c otel.metrics_exporter=none` so the shield stays quiet
+    (default-on egress to a hardcoded ab.chatgpt.com otherwise — see follow-up).
+────────────────────────────────────────────────────────────────────────────────
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+
+from terok_executor.integrations.sandbox import RunSpec, VolumeSpec
+from terok_executor.vault_addr import CONTAINER_VAULT_SOCKET, LOOPBACK_VAULT_PORT
+from tests.constants import CONTAINER_WORKSPACE_DIR, INTEGRATION_VAULT_PASSPHRASE
+
+from .conftest import ExecutorEnv, hooks_missing, podman_missing
+from .helpers import exec_in, podman, podman_rm, unique_container_name
+
+pytestmark = [pytest.mark.needs_podman, podman_missing, hooks_missing]
+
+PROVIDER = "openai"  # codex's vault route key (codex.yaml provider.default: openai)
+REAL_SECRET = "sk-integration-codex-not-for-the-container"  # nosec B105 — fixture value
+CREDENTIAL_SET = "default"
+CREDENTIAL_SCOPE = "integration-scope"
+_CODEX_IMAGE = "terok-executor-itest-codex:latest"
+_FEDORA_BASE = "registry.fedoraproject.org/fedora:44"  # glibc base for codex's npm binary
+_CAPTURE_TIMEOUT_S = 30
+
+
+class _TrappingVault:
+    """Vault broker + a request trap on a background event loop.
+
+    The trap accepts anything: WS upgrades are prepared+recorded+closed; plain HTTP is
+    recorded and answered with a minimal ``{"data": []}`` (enough for codex's cold
+    ``GET /models``).  Every capture records the ``Authorization`` header the *vault
+    forwarded* (i.e. the real key, post-swap) plus the path and transport kind, so a
+    synchronous test can assert on them while codex runs.
+    """
+
+    def __init__(self, db_path: Path, routes_path: Path, socket_path: Path) -> None:
+        self._db_path = db_path
+        self._routes_path = routes_path
+        self._socket_path = socket_path
+        self.captures: list[dict[str, object]] = []
+        self._loop = None
+        self._thread: threading.Thread | None = None
+        self._runners: list[web.AppRunner] = []
+
+    def __enter__(self) -> _TrappingVault:
+        ready = threading.Event()
+        self._thread = threading.Thread(target=self._run, args=(ready,), daemon=True)
+        self._thread.start()
+        if not ready.wait(15):
+            raise RuntimeError("vault/trap did not come up on the background loop")
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread is not None:
+            self._thread.join(15)
+
+    def _run(self, ready: threading.Event) -> None:
+        import asyncio
+
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._start())
+        ready.set()
+        try:
+            self._loop.run_forever()
+        finally:
+            self._loop.run_until_complete(self._cleanup())
+            self._loop.close()
+
+    async def _start(self) -> None:
+        from terok_sandbox.vault.daemon.token_broker import _build_app
+
+        async def _trap(request: web.Request) -> web.StreamResponse:
+            rec: dict[str, object] = {
+                "path": request.path,
+                "auth": request.headers.get("Authorization", ""),
+                "originator": request.headers.get("originator", ""),
+                "user_agent": request.headers.get("User-Agent", ""),
+                "version": request.headers.get("version", ""),
+            }
+            if request.headers.get("Upgrade", "").lower() == "websocket":
+                rec["kind"] = "ws"
+                self.captures.append(rec)
+                ws = web.WebSocketResponse()
+                await ws.prepare(request)
+                await ws.close()
+                return ws
+            rec["kind"] = "http"
+            self.captures.append(rec)
+            return web.json_response({"data": []})
+
+        trap_app = web.Application()
+        trap_app.router.add_route("*", "/{tail:.*}", _trap)
+        trap_runner = web.AppRunner(trap_app)
+        await trap_runner.setup()
+        trap_site = web.TCPSite(trap_runner, host="127.0.0.1", port=0)
+        await trap_site.start()
+        trap_port = trap_site._server.sockets[0].getsockname()[1]  # type: ignore[attr-defined]
+        self._routes_path.write_text(
+            json.dumps(
+                {
+                    PROVIDER: {
+                        "upstream": f"http://127.0.0.1:{trap_port}",
+                        "auth_header": "Authorization",
+                        "auth_prefix": "Bearer ",
+                    }
+                }
+            )
+        )
+
+        broker_runner = web.AppRunner(_build_app(str(self._db_path), str(self._routes_path)))
+        await broker_runner.setup()
+        broker_site = web.UnixSite(broker_runner, path=str(self._socket_path))
+        await broker_site.start()
+        os.chmod(self._socket_path, 0o666)  # noqa: S103 — per-test tmp socket, container peer UID
+        self._runners = [broker_runner, trap_runner]
+
+    async def _cleanup(self) -> None:
+        for runner in self._runners:
+            await runner.cleanup()
+
+
+@pytest.fixture(scope="session")
+def codex_image() -> str:
+    """Build (once) a fedora image with codex + socat/curl/git and a uid-1000 dev user."""
+    import shutil
+    import subprocess
+
+    if not shutil.which("podman"):
+        pytest.skip("podman not on PATH")
+    if podman("image", "exists", _CODEX_IMAGE).returncode != 0:
+        dockerfile = (
+            f"FROM {_FEDORA_BASE}\n"
+            "RUN dnf install -y --setopt=install_weak_deps=False nodejs npm socat curl git "
+            "&& dnf clean all\n"
+            "RUN npm install -g @openai/codex && npm cache clean --force\n"
+            "RUN useradd -m -u 1000 dev && mkdir -p /workspace && chown dev:dev /workspace\n"
+            "USER dev\n"
+            "WORKDIR /workspace\n"
+        )
+        subprocess.run(
+            ["podman", "build", "-t", _CODEX_IMAGE, "-f", "-", "."],
+            input=dockerfile,
+            check=True,
+            text=True,
+            timeout=600,
+        )
+    return _CODEX_IMAGE
+
+
+def test_real_codex_phantom_swaps_and_reaches_the_vault(
+    executor_env: ExecutorEnv,
+    codex_image: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real codex, phantom-only, api_key mode → vault swaps to the real key at the trap."""
+    from terok_sandbox.config import SandboxConfig
+
+    # 1. Seed the real credential + mint a phantom for the openai route.
+    db = executor_env.cfg.open_credential_db()
+    try:
+        db.store_credential(CREDENTIAL_SET, PROVIDER, {"type": "api_key", "key": REAL_SECRET})
+        phantom = db.create_token(CREDENTIAL_SCOPE, "codex-handshake", CREDENTIAL_SET, PROVIDER)
+    finally:
+        db.close()
+    assert phantom != REAL_SECRET
+
+    # 2. Provision codex exactly as terok does for api_key mode (codex.yaml): auth.json
+    #    holds the bearer, config.toml points openai_base_url at the in-container vault
+    #    loopback that the socat bridge fronts.
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(json.dumps({"OPENAI_API_KEY": phantom}))
+    (codex_home / "config.toml").write_text(
+        f'openai_base_url = "http://localhost:{LOOPBACK_VAULT_PORT}/v1"\n'
+    )
+
+    # 3. Broker (over executor's DB) + trap on a background loop; pin the passphrase the
+    #    broker's _TokenDB resolves (executor_env patches only the adapter's SandboxConfig).
+    monkeypatch.setattr(
+        SandboxConfig,
+        "resolve_passphrase_with_source",
+        lambda _self: (INTEGRATION_VAULT_PASSPHRASE, "integration"),
+    )
+    host_socket = tmp_path / "vault.sock"
+    name = unique_container_name("codex-handshake")
+
+    with _TrappingVault(executor_env.cfg.db_path, tmp_path / "routes.json", host_socket) as vault:
+        # 4. Launch real codex via the real Sandbox.run path, with .codex config + the
+        #    vault socket bind-mounted where CONTAINER_VAULT_SOCKET expects it.
+        executor_env.sandbox().run(
+            RunSpec(
+                container_name=name,
+                image=codex_image,
+                env={"TEROK_VAULT_LOOPBACK_PORT": str(LOOPBACK_VAULT_PORT)},
+                volumes=(
+                    VolumeSpec(executor_env.workspace_dir, CONTAINER_WORKSPACE_DIR),
+                    VolumeSpec(host_socket, CONTAINER_VAULT_SOCKET),
+                    VolumeSpec(codex_home, "/home/dev/.codex"),
+                ),
+                command=("sleep", "300"),
+                task_dir=executor_env.task_dir,
+            )
+        )
+        try:
+            # 5. Start the loopback bridge (same command ensure-bridges.sh uses).
+            exec_in(
+                name,
+                "sh",
+                "-c",
+                f"setsid socat TCP-LISTEN:{LOOPBACK_VAULT_PORT},bind=127.0.0.1,fork,reuseaddr "
+                f"UNIX-CONNECT:{CONTAINER_VAULT_SOCKET},retry=300,interval=0.1 "
+                ">/tmp/socat.log 2>&1 &",
+            )
+            # 6. Drive one codex turn, detached — we don't need it to succeed, only to
+            #    emit its first authed request(s). OTEL off so the shield stays quiet.
+            sentinel = f"TEROK-CANARY-{uuid.uuid4().hex[:8]}"
+            exec_in(
+                name,
+                "sh",
+                "-c",
+                "setsid codex exec --skip-git-repo-check "
+                f"-c otel.metrics_exporter=none '{sentinel}' >/tmp/codex.log 2>&1 &",
+            )
+
+            # 7. Wait for the trap to capture the first authed request(s).
+            deadline = time.monotonic() + _CAPTURE_TIMEOUT_S
+            while not vault.captures and time.monotonic() < deadline:
+                time.sleep(0.5)
+        finally:
+            podman_rm(name)
+
+    # 8. Assertions.
+    assert vault.captures, (
+        "codex never reached the vault — phantom refused client-side, or base-url/config "
+        "regressed (see /tmp/codex.log, /tmp/socat.log in the container)"
+    )
+    assert any(c["auth"] == f"Bearer {REAL_SECRET}" for c in vault.captures), (
+        f"phantom did not swap to the real key at the trap; captures={vault.captures}"
+    )
+    # codex identifies itself on every request — a cheap protocol-shape canary.
+    assert any(c["originator"] == "codex_cli_rs" for c in vault.captures)
+    # WS-first path: the prewarm should surface a WS upgrade (timing-dependent).
+    assert any(c["kind"] == "ws" for c in vault.captures), (
+        "no WebSocket upgrade reached the trap — codex may have gone straight to HTTP "
+        f"fallback, or the prewarm didn't fire in time; captures={vault.captures}"
+    )

--- a/tests/integration/test_codex_vault_handshake.py
+++ b/tests/integration/test_codex_vault_handshake.py
@@ -10,14 +10,16 @@ credential and forwards to a **request trap**.  The trap records what it saw and
 answers with nothing useful — codex then errors, which is fine; we only need the first
 authenticated request(s).
 
-What this asserts (at the trap):
-- **the phantom swapped to the real key** — proves phantom-health + the auth *mechanism*
-  (codex sends `Authorization: Bearer <token>` in api_key mode) + end-to-end connectivity;
+What this gates on (at the trap):
 - **codex reached the vault at all** — a sudden client-side refusal of the phantom, or a
   base-url/config regression, shows up as *no capture*;
-- **the WebSocket transport** — codex v0.146 on the default `openai` provider is
-  WS-first (`wss://{base}/responses`, background prewarm at session spawn), so a WS
-  upgrade should reach the trap; this is the leg terok's vault WS fix targets.
+- **the phantom swapped to the real key** — proves phantom-health + the auth *mechanism*
+  (codex sends `Authorization: Bearer <token>` in api_key mode) + end-to-end connectivity.
+
+Reported (not yet gated): the transport (codex v0.146 is WS-first — `wss://{base}/responses`
+via a background prewarm — the leg terok's vault WS fix targets) and the `originator`
+identity header are emitted as a warning so v2 can harden them from real captures. The
+first matrix run confirmed the two gates pass; the originator canary was mis-calibrated.
 
 Scope (v1, per design): **api_key mode only** — that's what a current-shape phantom
 (`terok-p-<hex>`) supports (oauth mode JWT-decodes the token and hits a hardcoded
@@ -50,6 +52,7 @@ import os
 import threading
 import time
 import uuid
+import warnings
 from pathlib import Path
 
 import pytest
@@ -283,7 +286,8 @@ def test_real_codex_phantom_swaps_and_reaches_the_vault(
         finally:
             podman_rm(name)
 
-    # 8. Assertions.
+    # 8. Core gates — the whole chain works with the real binary: codex reached the
+    #    vault (phantom accepted client-side) and the phantom swapped to the real key.
     assert vault.captures, (
         "codex never reached the vault — phantom refused client-side, or base-url/config "
         "regressed (see /tmp/codex.log, /tmp/socat.log in the container)"
@@ -291,10 +295,16 @@ def test_real_codex_phantom_swaps_and_reaches_the_vault(
     assert any(c["auth"] == f"Bearer {REAL_SECRET}" for c in vault.captures), (
         f"phantom did not swap to the real key at the trap; captures={vault.captures}"
     )
-    # codex identifies itself on every request — a cheap protocol-shape canary.
-    assert any(c["originator"] == "codex_cli_rs" for c in vault.captures)
-    # WS-first path: the prewarm should surface a WS upgrade (timing-dependent).
-    assert any(c["kind"] == "ws" for c in vault.captures), (
-        "no WebSocket upgrade reached the trap — codex may have gone straight to HTTP "
-        f"fallback, or the prewarm didn't fire in time; captures={vault.captures}"
+    # Transport + identity are reported, not yet gated: the first matrix run showed the
+    # core passes but the originator canary needs calibrating against what codex actually
+    # sends. Surface it as a warning (visible in the matrix warnings summary) so v2 can
+    # harden the WebSocket + originator canaries from real data rather than a guess.
+    warnings.warn(
+        "codex vault canary — "
+        + "; ".join(
+            f"{c['kind']} {c['path']} originator={c['originator']!r} "
+            f"ua={c['user_agent']!r} version={c['version']!r}"
+            for c in vault.captures
+        ),
+        stacklevel=2,
     )

--- a/tests/integration/test_codex_vault_handshake.py
+++ b/tests/integration/test_codex_vault_handshake.py
@@ -99,13 +99,16 @@ class _TrappingVault:
         self._loop = None
         self._thread: threading.Thread | None = None
         self._runners: list[web.AppRunner] = []
+        self._startup_error: BaseException | None = None
 
     def __enter__(self) -> _TrappingVault:
         ready = threading.Event()
         self._thread = threading.Thread(target=self._run, args=(ready,), daemon=True)
         self._thread.start()
         if not ready.wait(15):
-            raise RuntimeError("vault/trap did not come up on the background loop")
+            raise RuntimeError("vault/trap did not signal ready within 15s")
+        if self._startup_error is not None:
+            raise RuntimeError("vault/trap startup failed") from self._startup_error
         return self
 
     def __exit__(self, *_exc: object) -> None:
@@ -119,7 +122,14 @@ class _TrappingVault:
 
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
-        self._loop.run_until_complete(self._start())
+        try:
+            self._loop.run_until_complete(self._start())
+        except Exception as exc:  # noqa: BLE001 — surfaced to __enter__, not lost as a timeout
+            self._startup_error = exc
+            self._loop.run_until_complete(self._cleanup())
+            self._loop.close()
+            ready.set()
+            return
         ready.set()
         try:
             self._loop.run_forever()
@@ -153,6 +163,7 @@ class _TrappingVault:
         trap_app.router.add_route("*", "/{tail:.*}", _trap)
         trap_runner = web.AppRunner(trap_app)
         await trap_runner.setup()
+        self._runners.append(trap_runner)  # track as started so a later failure still cleans up
         trap_site = web.TCPSite(trap_runner, host="127.0.0.1", port=0)
         await trap_site.start()
         trap_port = trap_site._server.sockets[0].getsockname()[1]  # type: ignore[attr-defined]
@@ -170,10 +181,10 @@ class _TrappingVault:
 
         broker_runner = web.AppRunner(_build_app(str(self._db_path), str(self._routes_path)))
         await broker_runner.setup()
+        self._runners.append(broker_runner)
         broker_site = web.UnixSite(broker_runner, path=str(self._socket_path))
         await broker_site.start()
         os.chmod(self._socket_path, 0o666)  # noqa: S103 — per-test tmp socket, container peer UID
-        self._runners = [broker_runner, trap_runner]
 
     async def _cleanup(self) -> None:
         for runner in self._runners:

--- a/tests/integration/test_vault_bridge_roundtrip.py
+++ b/tests/integration/test_vault_bridge_roundtrip.py
@@ -83,13 +83,16 @@ class _ThreadedVault:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._runners: list[web.AppRunner] = []
+        self._startup_error: BaseException | None = None
 
     def __enter__(self) -> _ThreadedVault:
         ready = threading.Event()
         self._thread = threading.Thread(target=self._run, args=(ready,), daemon=True)
         self._thread.start()
         if not ready.wait(15):
-            raise RuntimeError("vault broker did not come up on the background loop")
+            raise RuntimeError("vault broker did not signal ready within 15s")
+        if self._startup_error is not None:
+            raise RuntimeError("vault broker startup failed") from self._startup_error
         return self
 
     def __exit__(self, *_exc: object) -> None:
@@ -101,7 +104,14 @@ class _ThreadedVault:
     def _run(self, ready: threading.Event) -> None:
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
-        self._loop.run_until_complete(self._start())
+        try:
+            self._loop.run_until_complete(self._start())
+        except Exception as exc:  # noqa: BLE001 — surfaced to __enter__, not lost as a timeout
+            self._startup_error = exc
+            self._loop.run_until_complete(self._cleanup())
+            self._loop.close()
+            ready.set()
+            return
         ready.set()
         try:
             self._loop.run_forever()
@@ -120,6 +130,7 @@ class _ThreadedVault:
         mock_app.router.add_route("*", "/{tail:.*}", _echo)
         mock_runner = web.AppRunner(mock_app)
         await mock_runner.setup()
+        self._runners.append(mock_runner)  # track as started so a later failure still cleans up
         mock_site = web.TCPSite(mock_runner, host="127.0.0.1", port=0)
         await mock_site.start()
         mock_port = mock_site._server.sockets[0].getsockname()[1]  # type: ignore[attr-defined]
@@ -137,10 +148,10 @@ class _ThreadedVault:
 
         broker_runner = web.AppRunner(_build_app(str(self._db_path), str(self._routes_path)))
         await broker_runner.setup()
+        self._runners.append(broker_runner)
         broker_site = web.UnixSite(broker_runner, path=str(self._socket_path))
         await broker_site.start()
         os.chmod(self._socket_path, 0o666)  # noqa: S103 — per-test tmp socket, container peer UID
-        self._runners = [broker_runner, mock_runner]
 
     async def _cleanup(self) -> None:
         for runner in self._runners:

--- a/tests/integration/test_vault_bridge_roundtrip.py
+++ b/tests/integration/test_vault_bridge_roundtrip.py
@@ -248,7 +248,10 @@ def test_generated_base_url_reaches_the_vault_via_the_socat_bridge(
     monkeypatch.setattr(
         SandboxConfig,
         "resolve_passphrase_with_source",
-        lambda _self: (INTEGRATION_VAULT_PASSPHRASE, "integration"),
+        lambda _self, **_kw: (
+            INTEGRATION_VAULT_PASSPHRASE,
+            "integration",
+        ),  # **_kw tolerates credentials_db/prompt_on_tty
     )
     host_socket = tmp_path / "vault.sock"
     with _ThreadedVault(

--- a/tests/integration/test_vault_bridge_roundtrip.py
+++ b/tests/integration/test_vault_bridge_roundtrip.py
@@ -1,0 +1,268 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""The full agent transport: ``$PROVIDER_BASE_URL`` → in-container socat bridge → vault.
+
+[`test_vault_route_roundtrip`][tests.integration.test_vault_route_roundtrip] proves the
+generated phantom *functions* by calling the broker host-side.  This closes the last
+gap — the exact path a real agent takes: the container reaches the vault at the
+``ANTHROPIC_BASE_URL`` executor generated (``http://localhost:9419``), served by the
+in-container socat loopback bridge that fronts the bind-mounted host vault socket
+(``ensure-bridges.sh``, socket mode).  So it exercises executor's ``vault_addr`` wiring
+and the bridge contract, not just phantom resolution.
+
+Why the shape it has:
+
+- The broker + mock upstream run on a **background event loop thread** because these
+  integration tests are synchronous and the driving ``podman exec`` blocks — the broker
+  must keep answering while it does.
+- The container is launched through the real ``Sandbox.run`` (as executor launches
+  one), but with an image carrying ``socat`` + ``curl`` and the host vault socket
+  bind-mounted at [`CONTAINER_VAULT_SOCKET`][terok_executor.vault_addr.CONTAINER_VAULT_SOCKET];
+  the keepalive command runs no init, so the test starts the socat bridge itself with
+  the same command ``ensure-bridges.sh`` uses.
+
+NOTE (validation): this is the highest-fidelity vault test but has the most moving
+parts (background-thread broker, socat bridge timing, the socket bind-mount, an image
+with socat).  It has only been checked by collection + lint off the test machine — run
+it under the matrix (or a local podman host) to shake out timing/mount details before
+relying on it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+
+from terok_executor.container.env import ContainerEnvSpec, assemble_container_env
+from terok_executor.integrations.sandbox import RunSpec, VolumeSpec
+from terok_executor.roster import AgentRoster
+from terok_executor.vault_addr import CONTAINER_VAULT_SOCKET, LOOPBACK_VAULT_PORT
+from tests.constants import (
+    CONTAINER_KEEPALIVE_COMMAND,
+    CONTAINER_WORKSPACE_DIR,
+    INTEGRATION_VAULT_PASSPHRASE,
+    PODMAN_BASE_IMAGE,
+)
+
+from .conftest import ExecutorEnv, hooks_missing, podman_missing
+from .helpers import exec_in, podman, podman_rm, unique_container_name
+
+pytestmark = [pytest.mark.needs_podman, podman_missing, hooks_missing]
+
+PROVIDER = "anthropic"
+REAL_SECRET = "sk-integration-bridge-not-for-the-container"  # nosec B105 — fixture value
+CREDENTIAL_SCOPE = "integration-scope"
+CREDENTIAL_SET = "default"
+TASK_ID = "vault-bridge"
+_SOCAT_CURL_IMAGE = "terok-executor-itest-socat:latest"
+
+
+class _ThreadedVault:
+    """A broker + mock upstream on a background event loop.
+
+    A synchronous test can then drive a blocking ``podman exec`` against the broker
+    (over the bind-mounted UNIX socket) while it keeps servicing requests.  Records the
+    ``Authorization`` header the mock upstream ultimately saw, so the test can assert
+    the phantom resolved to the real key.
+    """
+
+    def __init__(self, db_path: Path, routes_path: Path, socket_path: Path) -> None:
+        self._db_path = db_path
+        self._routes_path = routes_path
+        self._socket_path = socket_path
+        self.seen_auth: str | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._runners: list[web.AppRunner] = []
+
+    def __enter__(self) -> _ThreadedVault:
+        ready = threading.Event()
+        self._thread = threading.Thread(target=self._run, args=(ready,), daemon=True)
+        self._thread.start()
+        if not ready.wait(15):
+            raise RuntimeError("vault broker did not come up on the background loop")
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread is not None:
+            self._thread.join(15)
+
+    def _run(self, ready: threading.Event) -> None:
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_until_complete(self._start())
+        ready.set()
+        try:
+            self._loop.run_forever()
+        finally:
+            self._loop.run_until_complete(self._cleanup())
+            self._loop.close()
+
+    async def _start(self) -> None:
+        from terok_sandbox.vault.daemon.token_broker import _build_app
+
+        async def _echo(request: web.Request) -> web.Response:
+            self.seen_auth = request.headers.get("Authorization", "")
+            return web.json_response({"ok": True})
+
+        mock_app = web.Application()
+        mock_app.router.add_route("*", "/{tail:.*}", _echo)
+        mock_runner = web.AppRunner(mock_app)
+        await mock_runner.setup()
+        mock_site = web.TCPSite(mock_runner, host="127.0.0.1", port=0)
+        await mock_site.start()
+        mock_port = mock_site._server.sockets[0].getsockname()[1]  # type: ignore[attr-defined]
+        self._routes_path.write_text(
+            json.dumps(
+                {
+                    PROVIDER: {
+                        "upstream": f"http://127.0.0.1:{mock_port}",
+                        "auth_header": "Authorization",
+                        "auth_prefix": "Bearer ",
+                    }
+                }
+            )
+        )
+
+        broker_runner = web.AppRunner(_build_app(str(self._db_path), str(self._routes_path)))
+        await broker_runner.setup()
+        broker_site = web.UnixSite(broker_runner, path=str(self._socket_path))
+        await broker_site.start()
+        os.chmod(self._socket_path, 0o666)  # noqa: S103 — per-test tmp socket, container peer UID
+        self._runners = [broker_runner, mock_runner]
+
+    async def _cleanup(self) -> None:
+        for runner in self._runners:
+            await runner.cleanup()
+
+
+@pytest.fixture(scope="session")
+def socat_curl_image() -> str:
+    """Build (once) an Alpine image with ``socat`` + ``curl`` for the bridge path."""
+    import shutil
+
+    if not shutil.which("podman"):
+        pytest.skip("podman not on PATH")
+    if podman("image", "exists", _SOCAT_CURL_IMAGE).returncode != 0:
+        subprocess.run(
+            ["podman", "build", "-t", _SOCAT_CURL_IMAGE, "-f", "-", "."],
+            input=f"FROM {PODMAN_BASE_IMAGE}\nRUN apk add --no-cache socat curl\n",
+            check=True,
+            text=True,
+            timeout=120,
+        )
+    return _SOCAT_CURL_IMAGE
+
+
+@pytest.fixture
+def launch_with_vault_socket(executor_env: ExecutorEnv, socat_curl_image: str) -> Iterator[object]:
+    """Launch through the real ``Sandbox.run`` with a socat image + the vault socket mounted.
+
+    Mirrors the shared ``launch`` fixture but overrides the image (the base image has no
+    ``socat``) and bind-mounts the host broker socket at ``CONTAINER_VAULT_SOCKET`` — the
+    hop the supervisor performs in production and that this test stands in for.
+    """
+    started: list[str] = []
+
+    def _launch(host_socket: Path, env: dict[str, str], volumes: tuple[VolumeSpec, ...]) -> str:
+        name = unique_container_name("vault-bridge")
+        started.append(name)
+        executor_env.sandbox().run(
+            RunSpec(
+                container_name=name,
+                image=socat_curl_image,
+                env=dict(env),
+                volumes=(
+                    VolumeSpec(executor_env.workspace_dir, CONTAINER_WORKSPACE_DIR),
+                    VolumeSpec(host_socket, CONTAINER_VAULT_SOCKET),
+                    *volumes,
+                ),
+                command=CONTAINER_KEEPALIVE_COMMAND,
+                task_dir=executor_env.task_dir,
+            )
+        )
+        return name
+
+    try:
+        yield _launch
+    finally:
+        for name in started:
+            podman_rm(name)
+
+
+def test_generated_base_url_reaches_the_vault_via_the_socat_bridge(
+    executor_env: ExecutorEnv,
+    roster: AgentRoster,
+    launch_with_vault_socket,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A request to ``$ANTHROPIC_BASE_URL`` from inside the container reaches the real key."""
+    from terok_sandbox.config import SandboxConfig
+
+    route = roster.vault_routes[PROVIDER]
+    token_var = route.token_env["_default"]
+
+    # 1. Seed the real credential in executor's vault DB and assemble the container env
+    #    (mints the phantom + sets ANTHROPIC_BASE_URL to the loopback the bridge serves).
+    db = executor_env.cfg.open_credential_db()
+    try:
+        db.store_credential(CREDENTIAL_SET, PROVIDER, {"type": "api_key", "key": REAL_SECRET})
+    finally:
+        db.close()
+    spec = ContainerEnvSpec(
+        task_id=TASK_ID,
+        agent_name="claude",
+        envs_dir=executor_env.mounts_dir,
+        credential_scope=CREDENTIAL_SCOPE,
+        credential_set=CREDENTIAL_SET,
+        vault_required=True,
+    )
+    result = assemble_container_env(spec, roster, caller_manages_vault=False)
+    assert route.base_url_env in result.env, "executor did not point the SDK at the vault"
+
+    # 2. Broker (over executor's DB) + mock on a background loop; pin the passphrase the
+    #    broker's _TokenDB resolves (executor_env patches only the adapter's SandboxConfig).
+    monkeypatch.setattr(
+        SandboxConfig,
+        "resolve_passphrase_with_source",
+        lambda _self: (INTEGRATION_VAULT_PASSPHRASE, "integration"),
+    )
+    host_socket = tmp_path / "vault.sock"
+    with _ThreadedVault(
+        executor_env.cfg.db_path, tmp_path / "broker-routes.json", host_socket
+    ) as vault:
+        name = launch_with_vault_socket(host_socket, result.env, result.volumes)
+
+        # 3. Start the loopback bridge with the exact command ensure-bridges.sh uses, then
+        #    hit $ANTHROPIC_BASE_URL from inside the container — the true agent path.
+        bridge = (
+            f"socat TCP-LISTEN:{LOOPBACK_VAULT_PORT},bind=127.0.0.1,fork,reuseaddr "
+            f"UNIX-CONNECT:{CONTAINER_VAULT_SOCKET},retry=300,interval=0.1"
+        )
+        exec_in(name, "sh", "-c", f"setsid {bridge} >/tmp/socat.log 2>&1 &")
+        # --retry-connrefused absorbs the race between the detached socat binding 9419
+        # and curl connecting; the agent's own client would retry similarly.
+        exec_in(
+            name,
+            "sh",
+            "-c",
+            "curl -sS --fail --retry 5 --retry-connrefused "
+            '-H "Authorization: Bearer $' + token_var + '" '
+            '"$' + route.base_url_env + '/v1/messages"',
+        )
+
+    assert vault.seen_auth == f"Bearer {REAL_SECRET}", (
+        "the request to $ANTHROPIC_BASE_URL did not resolve the phantom to the real key"
+    )

--- a/tests/integration/test_vault_route_roundtrip.py
+++ b/tests/integration/test_vault_route_roundtrip.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""A provider route executor *generates* must yield a phantom that actually works.
+
+[`test_vault_route_env`][tests.integration.test_vault_route_env] proves the phantom
+executor mints for a route is *delivered* to the container and *resolves* in the vault
+DB.  This adds the missing half: that same phantom, sent through a real token broker
+wired to executor's vault DB, comes out the other side as the *real* provider key at a
+mock upstream — the config-generation → working-credential contract, end to end, with
+no real API key in the harness.
+
+The container is launched exactly as executor launches one (``Sandbox.run`` via the
+``launch`` fixture), and the token round-tripped through the broker is the one read
+back out of the container's own environment — so delivery and function are asserted on
+the *same* value.
+
+The upstream leg (``ANTHROPIC_BASE_URL`` + the in-container socat loopback bridge that
+the supervisor's init starts) is intentionally not exercised here: the keepalive
+launch runs no init, and that socket-transport hop is already covered at its owning
+layer by terok-sandbox's ``test_vault_container_transport``.  A follow-up that boots
+the real init and curls ``$ANTHROPIC_BASE_URL`` from inside the container would close
+that last gap (it needs ``socat`` in the image).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from terok_executor.container.env import ContainerEnvSpec, assemble_container_env
+from terok_executor.roster import AgentRoster
+from tests.constants import INTEGRATION_VAULT_PASSPHRASE
+
+from .conftest import ExecutorEnv, Launcher, hooks_missing, podman_missing
+from .helpers import exec_in
+
+pytestmark = [pytest.mark.needs_podman, podman_missing, hooks_missing]
+
+PROVIDER = "anthropic"
+"""claude's default route — the roster's richest, matching test_vault_route_env."""
+
+REAL_SECRET = "sk-integration-roundtrip-not-for-the-container"  # nosec B105 — fixture value
+CREDENTIAL_SCOPE = "integration-scope"
+CREDENTIAL_SET = "default"
+TASK_ID = "vault-roundtrip"
+
+
+async def _real_key_seen_by_upstream(db_path: Path, routes_path: Path, phantom: str) -> str:
+    """Run a mock upstream + a broker over *db_path*; return the auth header the mock saw.
+
+    The broker resolves the phantom against executor's real SQLCipher DB and injects the
+    real credential, so the returned value is what a provider would actually receive.
+    """
+    from terok_sandbox.vault.daemon.token_broker import _build_app
+
+    seen: dict[str, str] = {}
+
+    async def _echo(request: web.Request) -> web.Response:
+        seen["authorization"] = request.headers.get("Authorization", "")
+        return web.json_response({"ok": True})
+
+    upstream_app = web.Application()
+    upstream_app.router.add_route("*", "/{tail:.*}", _echo)
+    upstream_server = TestServer(upstream_app)
+    await upstream_server.start_server()
+
+    routes_path.write_text(
+        json.dumps(
+            {
+                PROVIDER: {
+                    "upstream": f"http://127.0.0.1:{upstream_server.port}",
+                    "auth_header": "Authorization",
+                    "auth_prefix": "Bearer ",
+                }
+            }
+        )
+    )
+
+    broker_app = _build_app(str(db_path), str(routes_path))
+    try:
+        async with TestClient(TestServer(broker_app)) as client:
+            resp = await client.get("/v1/messages", headers={"Authorization": f"Bearer {phantom}"})
+            assert resp.status == 200, f"broker rejected the generated phantom: {resp.status}"
+    finally:
+        await upstream_server.close()
+    return seen.get("authorization", "")
+
+
+def test_generated_phantom_round_trips_to_the_real_key(
+    executor_env: ExecutorEnv,
+    roster: AgentRoster,
+    launch: Launcher,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The phantom executor generates for the anthropic route works through the broker."""
+    from terok_sandbox.config import SandboxConfig
+
+    route = roster.vault_routes[PROVIDER]
+    token_var = route.token_env["_default"]
+
+    # 1. Seed the real credential in executor's own vault DB.
+    db = executor_env.cfg.open_credential_db()
+    try:
+        db.store_credential(CREDENTIAL_SET, PROVIDER, {"type": "api_key", "key": REAL_SECRET})
+    finally:
+        db.close()
+
+    # 2. Executor assembles the container env — this mints the phantom for the route.
+    spec = ContainerEnvSpec(
+        task_id=TASK_ID,
+        agent_name="claude",
+        envs_dir=executor_env.mounts_dir,
+        credential_scope=CREDENTIAL_SCOPE,
+        credential_set=CREDENTIAL_SET,
+        vault_required=True,
+    )
+    result = assemble_container_env(spec, roster, caller_manages_vault=False)
+    assert result.env[token_var] != REAL_SECRET
+
+    # 3. Launch the container exactly as executor does, and read the phantom back out
+    #    of its environment — delivery and function are asserted on the same value.
+    name = launch("vault-roundtrip", env=result.env, volumes=result.volumes)
+    container_phantom = exec_in(name, "printenv", token_var).strip()
+    assert container_phantom == result.env[token_var]
+    assert REAL_SECRET not in exec_in(name, "env"), "real credential leaked into the container"
+
+    # 4. The broker opens executor's DB through the production passphrase chain; pin it
+    #    to the config's throwaway passphrase (executor_env only patches the executor
+    #    adapter's SandboxConfig, not the one the broker's _TokenDB constructs).
+    monkeypatch.setattr(
+        SandboxConfig,
+        "resolve_passphrase_with_source",
+        lambda _self: (INTEGRATION_VAULT_PASSPHRASE, "integration"),
+    )
+
+    seen_auth = asyncio.run(
+        _real_key_seen_by_upstream(
+            executor_env.cfg.db_path, tmp_path / "broker-routes.json", container_phantom
+        )
+    )
+    assert seen_auth == f"Bearer {REAL_SECRET}", (
+        "the generated phantom did not resolve to the real provider key at the upstream"
+    )

--- a/tests/integration/test_vault_route_roundtrip.py
+++ b/tests/integration/test_vault_route_roundtrip.py
@@ -137,7 +137,10 @@ def test_generated_phantom_round_trips_to_the_real_key(
     monkeypatch.setattr(
         SandboxConfig,
         "resolve_passphrase_with_source",
-        lambda _self: (INTEGRATION_VAULT_PASSPHRASE, "integration"),
+        lambda _self, **_kw: (
+            INTEGRATION_VAULT_PASSPHRASE,
+            "integration",
+        ),  # **_kw tolerates credentials_db/prompt_on_tty
     )
 
     seen_auth = asyncio.run(


### PR DESCRIPTION
**Draft** — the podman tests are `needs_podman` (skipped in non-podman CI) and need a matrix run; the codex v1 test in particular has documented image/timing unknowns to tune on the runner.

Fills executor's matrix gap (it was launching only a bare base image). Four commits:

- **`test_vault_route_env` companion — generated phantom round-trips** (`test_vault_route_roundtrip.py`): the phantom executor mints for the anthropic route actually functions — sent through a broker over executor's vault DB, it comes out as the real key at a mock. Delivery + function asserted on the same value.
- **Full agent path via `$BASE_URL` + socat bridge** (`test_vault_bridge_roundtrip.py`): the real transport a container uses (loopback bridge → vault socket), broker + mock on a background loop.
- **git-identity container E2E test — moved in from terok** (`tests/integration/containers/`): builds executor's own L0 + shell-init wiring (`render_l0`/`stage_scripts`) and checks `BASH_ENV` + all four authorship modes with a real `git commit`. It's an executor artifact that only lived in terok by history. **Paired with terok-ai/terok removing it** — merge together to avoid a coverage gap.
- **v1 real-codex vault handshake** (`test_codex_vault_handshake.py`): runs the real `codex` CLI with a phantom-only api_key, pointed at the vault via `config.toml` as terok provisions it, and traps the first authed request — asserting the phantom→real swap, `originator: codex_cli_rs`, and a WebSocket upgrade (codex v0.146 is WS-first — the leg the recent vault WS fix targets). Validated by collection+lint only; matrix-run to tune the codex image + auth.json shape + WS-prewarm timing (documented in-module). v2 will capture a WS frame to assert the sentinel prompt survives.

Note: executor's sandbox pin (a16) currently lags its own conftest API (`credentials_passphrase`), so the vault integration tests — these and the pre-existing `test_vault_route_env` — need that pin bumped before they run green on the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added container-based end-to-end coverage for shell initialization and Git identity wiring, including authorship mode checks and commit metadata verification.
  * Added integration coverage for the vault token broker handshake and vault route round-tripping with phantom tokens, asserting correct upstream authorization behavior.
  * Added a new vault bridge roundtrip test validating requests reach the host vault through an in-container socket bridge.
  * Improved Podman-based integration setup/teardown reliability to avoid leftover partial image builds across CI runs, and strengthened canary reliability with clearer startup failure reporting and cleanup tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->