### PR TITLE
refactor: follow shield vocab — health 'bypass' is now 'disabled'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
 # pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a22/terok_sandbox-0.5.0a22-py3-none-any.whl",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/posture-vocabulary",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl",
     "ruamel.yaml==0.19.1",
     "Jinja2~=3.1",

--- a/src/terok_executor/container/env.py
+++ b/src/terok_executor/container/env.py
@@ -226,7 +226,7 @@ class ContainerEnvResult:
     """Assembled container environment ready for RunSpec construction.
 
     Not a ``RunSpec`` — omits launch-time concerns (container name, image,
-    command, GPU, shield bypass).  Callers add those and construct ``RunSpec``.
+    command, GPU, shield kill-switch).  Callers add those and construct ``RunSpec``.
     """
 
     env: dict[str, str]

--- a/src/terok_executor/krun.py
+++ b/src/terok_executor/krun.py
@@ -167,7 +167,7 @@ class KrunHost:
           right default under crun (AI agents that refuse uid 0); under
           krun the session uid comes from which ``ssh user@…`` the
           operator picks.
-        - ``--dns 169.254.1.1`` — kept for shield-bypass; under
+        - ``--dns 169.254.1.1`` — kept for unshielded runs; under
           shield-up the bind-mounted resolv.conf overrides this anyway.
 
         Doesn't include ``--runtime krun`` itself or krun's microVM-sizing

--- a/src/terok_executor/preflight.py
+++ b/src/terok_executor/preflight.py
@@ -102,7 +102,7 @@ class Preflight:
 
         self._offer_ssh_key()
         self._offer_credentials()
-        self._note_shield_bypass()
+        self._note_shield_disabled()
 
         if all_ready and self.interactive:
             self._provider_hints()
@@ -198,12 +198,12 @@ class Preflight:
                 f"      Without credentials, {self.provider} will prompt for login on first turn."
             )
 
-    def _note_shield_bypass(self) -> None:
-        """Surface the bypass override when set — regular shield state is in sandbox-services."""
+    def _note_shield_disabled(self) -> None:
+        """Surface the kill-switch override when set — regular shield state is in sandbox-services."""
         from terok_executor.integrations.sandbox import check_environment
 
-        if check_environment().health == "bypass":
-            print("\n  Note: shield is in bypass mode — containers have unrestricted network")
+        if check_environment().health == "disabled":
+            print("\n  Note: shield is disabled — containers have unrestricted network")
 
     # ── Prerequisite probes ────────────────────────────────────────
 
@@ -269,11 +269,11 @@ class Preflight:
         # One SandboxConfig read keeps the probe from rebuilding it from
         # layered YAML on every call.
         cfg = SandboxConfig()
-        # "bypass" means the hooks are installed but the operator opted
-        # out — that's a ready environment (the bypass itself is surfaced
-        # as a warning by ``_note_shield_bypass``), so only a genuinely
-        # missing/broken environment fails the check.
-        if check_environment(cfg).health not in ("ok", "bypass"):
+        # "disabled" means the hooks are installed but the operator opted
+        # out — that's a ready environment (the kill-switch itself is
+        # surfaced as a warning by ``_note_shield_disabled``), so only a
+        # genuinely missing/broken environment fails the check.
+        if check_environment(cfg).health not in ("ok", "disabled"):
             return CheckResult("sandbox services", False, "missing: shield hooks")
         return CheckResult("sandbox services", True, "shield ready")
 

--- a/tests/unit/test_preflight.py
+++ b/tests/unit/test_preflight.py
@@ -115,12 +115,12 @@ def test_sandbox_services_lists_missing(mock_env: MagicMock) -> None:
 
 
 @patch("terok_executor.integrations.sandbox.check_environment")
-def test_sandbox_services_bypass_is_ready(mock_env: MagicMock) -> None:
-    """``bypass`` health is a *ready* environment — the hooks are installed,
-    the operator merely opted out of egress filtering.  The bypass itself is
-    surfaced elsewhere as a warning, so the readiness verdict must pass rather
-    than report a missing service."""
-    mock_env.return_value = MagicMock(health="bypass")
+def test_sandbox_services_disabled_is_ready(mock_env: MagicMock) -> None:
+    """``disabled`` health is a *ready* environment — the hooks are installed,
+    the operator merely opted out of egress filtering.  The kill-switch itself
+    is surfaced elsewhere as a warning, so the readiness verdict must pass
+    rather than report a missing service."""
+    mock_env.return_value = MagicMock(health="disabled")
     r = _pf().check_sandbox_services()
     assert r.ok is True
     assert "shield" in r.message

--- a/uv.lock
+++ b/uv.lock
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a23.dev462+ge87fdb9a1"
-source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Fposture-vocabulary#e87fdb9a141e7474f8b8f8721fc9dc057f01fc9a" }
+version = "0.5.0a23.dev463+g52f28b45f"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Fposture-vocabulary#52f28b45f346ecd0f6e745fa80a28674486b2c6e" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },

--- a/uv.lock
+++ b/uv.lock
@@ -2276,7 +2276,7 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a22/terok_sandbox-0.5.0a22-py3-none-any.whl" },
+    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Fposture-vocabulary" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
@@ -2311,8 +2311,8 @@ test = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a22"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a22/terok_sandbox-0.5.0a22-py3-none-any.whl" }
+version = "0.5.0a23.dev462+ge87fdb9a1"
+source = { git = "https://github.com/sliwowitz/terok-sandbox.git?rev=feat%2Fposture-vocabulary#e87fdb9a141e7474f8b8f8721fc9dc057f01fc9a" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2328,45 +2328,15 @@ dependencies = [
     { name = "terok-shield" },
     { name = "terok-util" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a22/terok_sandbox-0.5.0a22-py3-none-any.whl", hash = "sha256:d51c13e2671de9a0b32b480edc3149e76047486bc3bfa59fe85236119d496018" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = "~=3.14.1" },
-    { name = "cryptography", specifier = ">=49,<51" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "keyring", specifier = "~=25.7" },
-    { name = "packaging", specifier = "~=26.2" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "sqlcipher3", specifier = "==0.6.2" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a8/terok_clearance-0.8.0a8-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
-]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a9"
-source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl" }
+version = "0.8.0a10.dev361+g941098acd"
+source = { git = "https://github.com/sliwowitz/terok-shield.git?rev=feat%2Fposture-vocabulary#941098acd193e701c01e05a83d60a29e6dba7319" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl", hash = "sha256:f3425bdb9e9f01c65f10543bdc9a12306757ea98c1bd50dbbf01cb88340fb503" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
 ]
 
 [[package]]


### PR DESCRIPTION
Companion to terok-ai/terok-shield#430 and terok-ai/terok-sandbox#521 (posture-first shield vocabulary). Third link of the PR chain: shield → sandbox → **executor** → terok.

The sandbox `EnvironmentCheck` health string for the firewall kill-switch changed from `"bypass"` to `"disabled"`:

- preflight: `_note_shield_bypass()` → `_note_shield_disabled()`, health comparisons updated, operator note reworded
- prose: "shield-bypass" / "shield bypass" → unshielded runs / shield kill-switch (vault-related "bypass" wording untouched — that knob is out of scope)

**Dependency note:** `terok-sandbox` is pinned to the tip of its PR branch for the duration of the chain (terok-shield follows transitively); pins return to release wheels when the chain starts merging bottom-up.

## Testing

- `make check` green: lint, 1208 unit tests passed, plus the repo's static checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated shield status handling so disabled shields are correctly recognized as ready during preflight checks.
  * Improved messaging for disabled shields while continuing to report missing or malfunctioning hooks as failures.

* **Documentation**
  * Clarified descriptions of shield states and DNS behavior for unshielded runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->